### PR TITLE
[#3] Ensure Attestation CA packages VERSION file correctly

### DIFF
--- a/HIRS_AttestationCA/build.gradle
+++ b/HIRS_AttestationCA/build.gradle
@@ -37,6 +37,8 @@ task generateProtoBuf(type:Exec) {
 }
 
 compileJava.dependsOn generateProtoBuf
+copyVersion.dependsOn compileJava
+war.dependsOn copyVersion
 
 ext.configDir = new File(projectDir, 'config')
 ext.checkstyleConfigDir = "$configDir/checkstyle"
@@ -49,6 +51,10 @@ checkstyle {
 }
 
 war {
+    from(buildDir) {
+        include 'VERSION'
+        into 'WEB-INF/classes'
+    }
     archiveName = 'HIRS_AttestationCA.war'
 }
 


### PR DESCRIPTION
As it turns out, there was a minor oversight when building the TPM 2.0 provisioning. We introduced the use `DeviceInfoReport` to the ACA, which, upon construction, attempts to pull the version, but the VERSION file was never added to the WAR.

This merge request updates the HIRS_AttestationCA's gradle build to copy the VERSION file to the proper directory upon installation.

Closes #3