### PR TITLE
[#7] Support Building (Not Packaging) on Ubuntu 18.04

### DIFF
--- a/HIRS_ProvisionerTPM2/docs/developer-dependencies-debian.md
+++ b/HIRS_ProvisionerTPM2/docs/developer-dependencies-debian.md
@@ -1,0 +1,22 @@
+Developer Dependencies
+======================
+
+These are the dependencies currently used by the TPM2 Provisioner project that must be supplied by the development environment (in this case Debian-based) in order to properly build and package the project.
+
+Please look up their respective names in the appropriate repositories.
+
+If no available repository for the development environment contains the dependencies at an acceptable version level, it is expected that the packages be retrieved and built from their respective source repositories.
+
+| Dependency        | Version used | Minimum required   | Repository            | Project repository                     |
+| ----------------- | ------------ | ------------------ | --------------------- | -------------------------------------- |
+| cppcheck          | 1.82         | 1.72               | Ubuntu 18.04 base     | http://cppcheck.sourceforge.net/       |
+| doxygen           | 1.8.13       | 1.8.0 (estimated)  | Ubuntu 18.04 base     | https://github.com/doxygen/doxygen     |
+| graphviz          | 2.40.1       | 2.28.0 (estimated) | Ubuntu 18.04 base     | https://gitlab.com/graphviz/graphviz   |
+| liblog4cplus-dev  | 1.1.2        | 1.1.2              | Ubuntu 18.04 base     | https://github.com/log4cplus/log4cplus |
+| libssl-dev        | 1.1.0g       | 1.0.2g (estimated) | Ubuntu 18.04 base     | https://github.com/openssl/openssl     |
+| protobuf-compiler | 3.0.0        | 2.4.1 (estimated)  | Ubuntu 18.04 base     | https://github.com/google/protobuf     |
+| libprotobuf-dev   | 3.0.0        | 2.4.1 (estimated)  | Ubuntu 18.04 base     | https://github.com/google/protobuf     |
+| libre2-dev        | 20180201     | 20160201           | Ubuntu 18.04 base     | https://github.com/google/re2          |
+| libsapi-dev       | 1.0.0        | 1.0.0              | Ubuntu 18.04 base     | https://github.com/intel/tpm2-tss      |
+| cmake             | 3.10.2       | 2.6.0 (estimated)  | Ubuntu 18.04 base     | https://cmake.org/                     |
+| git               | 2.17.1       | 1.6.0 (estimated)  | Ubuntu 18.04 base     | https://github.com/git/git             |

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -411,7 +411,9 @@ string CommandTpm2::activateIdentity() {
         // Erase unnecessary zero padding due
         s.erase(2 + numBytesInCred, 134 - 2 - numBytesInCred);
         // Prepend header: MAGIC_NUMBER (0xBADCC0DE) + Version (0x00000001)
-        s.insert(s.begin(), {0xBA, 0xDC, 0xC0, 0xDE, 0x00, 0x00, 0x00, 0x01});
+        s.insert(s.begin(), {static_cast<char>(0xBA), static_cast<char>(0xDC),
+                             static_cast<char>(0xC0), static_cast<char>(0xDE),
+                             0x00, 0x00, 0x00, 0x01});
         writeBinaryFile(s, kDefaultIdentityClaimResponseFilename);
     }
 


### PR DESCRIPTION
This is a small merge request that ensures that the full Gradle build will complete in an Ubuntu 18.04 development environment. In theory, it should also work on Ubuntu 17.10, but this has not been formally tested.

In order to test this MR, an Ubuntu development environment needs to be built with all of the dependencies that have been listed in the new `developer-dependencies-debian.md` file. Once they've been installed the usual build instructions should be followed for building the TPM 2.0 Provisioner and the rest of the HIRS project.

**NOTE:** This merge request does not provide support for TPM 2.0 provisioning in Debian environments. This is merely the first step in getting there. As such, this does not close issue the issue.