### PR TITLE
[#10] Fix representation of zero-valued hashes

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/data/persist/AbstractDigest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/AbstractDigest.java
@@ -134,30 +134,11 @@ public abstract class AbstractDigest {
             return DigestComparisonResultType.UNKNOWN;
         }
 
-        // if either byte array is all zeroes or the digest of an empty buffer, then the comparison
-        // result is UNKNOWN because the associated file was not read properly by IMA
-        if (isUnknownHash(this) || isUnknownHash(otherDigest)) {
-            return DigestComparisonResultType.UNKNOWN;
-        }
-
         if (this.equals(otherDigest)) {
             return DigestComparisonResultType.MATCH;
         }
 
         return DigestComparisonResultType.MISMATCH;
-    }
-
-    /**
-     * This method determines whether the given hash should be treated as 'unknown'.
-     * Current unknown/invalid hashes are measurements that are recorded in the IMA log that are:
-     * - all zero
-     * - the SHA1 digest of an empty buffer (no data)
-     *
-     * @param digest the digest that should be evaluated
-     * @return true if the given digest should be treated as invalid, false otherwise
-     */
-    private static boolean isUnknownHash(final AbstractDigest digest) {
-        return digest.equals(Digest.SHA1_ALL_ZERO) || digest.equals(Digest.SHA1_EMPTY);
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/Digest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/Digest.java
@@ -29,7 +29,7 @@ public final class Digest extends AbstractDigest {
     /**
      * A SHA1 digest whose content is all zeros.
      */
-    protected static final Digest SHA1_ALL_ZERO = new Digest(
+    public static final Digest SHA1_ZERO = new Digest(
             DigestAlgorithm.SHA1,
             new byte[SHA1_DIGEST_LENGTH]
     );
@@ -40,11 +40,11 @@ public final class Digest extends AbstractDigest {
     /**
      * A SHA1 digest whose content is the hash of an empty buffer.
      */
-    protected static final Digest SHA1_EMPTY;
+    public static final Digest SHA1_OF_NO_DATA;
 
     static {
         try {
-            SHA1_EMPTY = new Digest(
+            SHA1_OF_NO_DATA = new Digest(
                     DigestAlgorithm.SHA1,
                     Hex.decodeHex(SHA1_EMPTY_HEX.toCharArray())
             );

--- a/HIRS_Utils/src/test/java/hirs/data/persist/DigestTest.java
+++ b/HIRS_Utils/src/test/java/hirs/data/persist/DigestTest.java
@@ -368,51 +368,51 @@ public class DigestTest {
     }
 
     /**
-     * Tests that comparing two Digests with zeroized hashes indicates an UNKNOWN
-     * comparison type.
+     * Tests that comparing two Digests with hashes with values of zero gives a MATCH
+     * comparison result.
      */
     @Test
     public final void testCompareToDigestWithBothZeroizedHash() {
-        final Digest d1 = new Digest(DigestAlgorithm.SHA1, getZeroizedTestDigest(20));
-        final Digest d2 = new Digest(DigestAlgorithm.SHA1, getZeroizedTestDigest(20));
-        Assert.assertEquals(d1.compare(d2), DigestComparisonResultType.UNKNOWN);
-        Assert.assertEquals(d2.compare(d1), DigestComparisonResultType.UNKNOWN);
+        final Digest d1 = new Digest(DigestAlgorithm.SHA1, getZeroValueDigest(20));
+        final Digest d2 = new Digest(DigestAlgorithm.SHA1, getZeroValueDigest(20));
+        Assert.assertEquals(d1.compare(d2), DigestComparisonResultType.MATCH);
+        Assert.assertEquals(d2.compare(d1), DigestComparisonResultType.MATCH);
     }
 
     /**
-     * Tests that comparing two Digests with one zeroized hashes indicates an UNKNOWN
-     * comparison type.
+     * Tests that comparing two Digests, one with a hash of value zero, gives a MISMATCH
+     * comparison result.
      */
     @Test
     public final void testCompareToDigestWithOneZeroizedHash() {
         final Digest d1 = new Digest(DigestAlgorithm.SHA1, getTestDigest(20));
-        final Digest d2 = new Digest(DigestAlgorithm.SHA1, getZeroizedTestDigest(20));
-        Assert.assertEquals(d1.compare(d2), DigestComparisonResultType.UNKNOWN);
-        Assert.assertEquals(d2.compare(d1), DigestComparisonResultType.UNKNOWN);
+        final Digest d2 = new Digest(DigestAlgorithm.SHA1, getZeroValueDigest(20));
+        Assert.assertEquals(d1.compare(d2), DigestComparisonResultType.MISMATCH);
+        Assert.assertEquals(d2.compare(d1), DigestComparisonResultType.MISMATCH);
     }
 
     /**
-     * Tests that comparing two Digests with a hash of an empty file indicates an UNKNOWN
-     * comparison type.
+     * Tests that comparing two Digests with a hash of no data gives a MATCH
+     * comparison result.
      */
     @Test
     public final void testCompareToDigestWithBothEmptyHash() {
         final Digest d1 = new Digest(DigestAlgorithm.SHA1, getEmptySHA1Digest());
         final Digest d2 = new Digest(DigestAlgorithm.SHA1, getEmptySHA1Digest());
-        Assert.assertEquals(d1.compare(d2), DigestComparisonResultType.UNKNOWN);
-        Assert.assertEquals(d2.compare(d1), DigestComparisonResultType.UNKNOWN);
+        Assert.assertEquals(d1.compare(d2), DigestComparisonResultType.MATCH);
+        Assert.assertEquals(d2.compare(d1), DigestComparisonResultType.MATCH);
     }
 
     /**
-     * Tests that comparing two Digests with one being a hash of an empty file indicates an UNKNOWN
-     * comparison type.
+     * Tests that comparing two Digests, one with a hash of no data, gives a MISMATCH
+     * comparison result.
      */
     @Test
     public final void testCompareToDigestWithOneEmptyHash() {
         final Digest d1 = new Digest(DigestAlgorithm.SHA1, getTestDigest(20));
         final Digest d2 = new Digest(DigestAlgorithm.SHA1, getEmptySHA1Digest());
-        Assert.assertEquals(d1.compare(d2), DigestComparisonResultType.UNKNOWN);
-        Assert.assertEquals(d2.compare(d1), DigestComparisonResultType.UNKNOWN);
+        Assert.assertEquals(d1.compare(d2), DigestComparisonResultType.MISMATCH);
+        Assert.assertEquals(d2.compare(d1), DigestComparisonResultType.MISMATCH);
     }
 
     /**
@@ -455,7 +455,7 @@ public class DigestTest {
         return ret;
     }
 
-    private static byte[] getZeroizedTestDigest(final int count) {
+    private static byte[] getZeroValueDigest(final int count) {
         return new byte[count];
     }
 


### PR DESCRIPTION
Zero-value hashes, and hashes of no data, are now
considered as matches to equal values instead of
treating them as 'unknown'.