### PR TITLE
[#14] Parallelize Subproject CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,22 @@ sudo: true
 
 language: java
 
+env:
+  matrix:
+    - SUBPROJECT=HIRS_Utils
+    - SUBPROJECT=HIRS_Provisioner
+    - SUBPROJECT=HIRS_ProvisionerTPM2
+    - SUBPROJECT=HIRS_Structs
+    - SUBPROJECT=HIRS_AttestationCA
+    - SUBPROJECT=HIRS_AttestationCAPortal
+    - SUBPROJECT=TPM_Utils
+    - SUBPROJECT=tpm_module
+
 services:
   - docker
 
 before_install:
-  - docker build -t hirs-centos7 .
+  - docker pull hirs/hirs-ci:centos7
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -22,5 +33,4 @@ cache:
 install: true
 
 script:
-  - docker run --rm hirs-centos7 /bin/bash -c "cd /root/HIRS; git checkout ${TRAVIS_BRANCH}; make -C tpm_module/"
-  - docker run --rm hirs-centos7 /bin/bash -c "cd /root/HIRS; git checkout ${TRAVIS_BRANCH}; ./gradlew build"
+  - docker run --rm hirs/hirs-ci:centos7 /bin/bash -c "cd /root/HIRS; git checkout ${TRAVIS_BRANCH}; ./gradlew :$SUBPROJECT:build"

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,4 +5,5 @@ include 'TPM_Utils',
         'HIRS_ProvisionerTPM2',
         'HIRS_Structs',
         'HIRS_AttestationCA',
-        'HIRS_AttestationCAPortal'
+        'HIRS_AttestationCAPortal',
+        'tpm_module'

--- a/tpm_module/build.gradle
+++ b/tpm_module/build.gradle
@@ -1,10 +1,15 @@
-task build(type:Exec) {
+task make(type: Exec) {
     outputs.file 'tpm_module'
     inputs.dir fileTree(dir: '.').include('main.cpp').include('*.hpp')
     commandLine 'make'
 }
 
-task clean() {
+task cleanUp() {
     delete 'tpm_module', 'main.d', 'main.o'
 }
 
+task fullBuild(type: GradleBuild) {
+    tasks = ['cleanUp', 'make']
+}
+
+build.dependsOn tasks.fullBuild


### PR DESCRIPTION
This MR improves the Travis CI build time by taking advantage of their Build Matrix feature. This allows us to parallelize building/testing the subprojects all at the same time. In particular, this optimization shaves off about 4-5 minutes total.

Doesn't close the issue #14 just yet, as we're waiting to hear on if we can pre-build a Docker image and host it on Docker Hub.