### PR TITLE
[#6] Update Platform Credentials details page to display the Holder Information

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
@@ -257,6 +257,17 @@ public final class CertificateStringMapBuilder {
                     Integer.toString(certificate.getMinorVersion()));
             data.put("revisionLevel",
                     Integer.toString(certificate.getRevisionLevel()));
+            data.put("holderSerialNumber", certificate.getHolderSerialNumber()
+                            .toString(Certificate.HEX_BASE)
+                            .replaceAll("(?<=..)(..)", ":$1"));
+            data.put("holderIssuer", certificate.getHolderIssuer());
+            EndorsementCredential ekCertificate = EndorsementCredential
+                    .select(certificateManager)
+                    .bySerialNumber(certificate.getHolderSerialNumber())
+                    .getCertificate();
+            if (ekCertificate != null) {
+                data.put("ekId", ekCertificate.getId().toString());
+            }
 
             //x509 credential version
             data.put("x509Version", certificate.getX509CredentialVersion());

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
@@ -180,6 +180,28 @@
                         </div>
                     </c:if>
                     <div class="row">
+                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Holder</span></div>
+                        <div id="holder" class="col col-md-8">
+                            <c:if test="${not empty initialData.holderIssuer}">
+                                <div><span>${initialData.holderIssuer}</span></div>
+                            </c:if>
+                                <div id="certificateid">
+                                    <c:choose>
+                                        <c:when test="${not empty initialData.ekId}">
+                                            <span>
+                                                <a href="${portal}/certificate-details?id=${initialData.ekId}&type=endorsement">
+                                                    ${initialData.holderSerialNumber}
+                                                </a>
+                                            </span>
+                                        </c:when>
+                                        <c:otherwise>
+                                            <div><span>${initialData.holderSerialNumber}</span></div>
+                                        </c:otherwise>
+                                    </c:choose>
+                                </div>                                
+                        </div>
+                    </div>
+                    <div class="row">
                         <div class="col-md-1 col-md-offset-1"><span class="colHeader">Manufacturer</span></div>
                         <div id="manufacturer" class="col col-md-8">${initialData.manufacturer}</div>
                     </div>

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -196,6 +196,7 @@ public abstract class Certificate extends ArchivableEntity {
     public static final String HOLDER_SERIAL_NUMBER_FIELD = "holderSerialNumber";
     @Column(nullable = false, precision = MAX_NUMERIC_PRECISION, scale = 0)
     private final BigInteger holderSerialNumber;
+    private String holderIssuer;
 
     // we don't need to persist this, but we don't want to unpack this cert multiple times
     @Transient
@@ -220,6 +221,7 @@ public abstract class Certificate extends ArchivableEntity {
         this.certificateHash = 0;
         this.certAndTypeHash = 0;
         this.holderSerialNumber = BigInteger.ZERO;
+        this.holderIssuer = null;
     }
 
     /**
@@ -302,8 +304,10 @@ public abstract class Certificate extends ArchivableEntity {
                                             .getBaseCertificateID()
                                             .getSerial()
                                             .getValue();
+                this.holderIssuer = attCertInfo.getHolder()
+                        .getBaseCertificateID().getIssuer()
+                        .getNames()[0].getName().toString();
                 this.signature = attCert.getSignatureValue().getBytes();
-
                 this.issuer = getAttributeCertificateIssuerNames(
                                         attCertInfo.getIssuer())[0].toString();
                 this.issuerOrganization = getOrganization(this.issuer);
@@ -504,6 +508,14 @@ public abstract class Certificate extends ArchivableEntity {
      */
     public BigInteger getHolderSerialNumber() {
         return holderSerialNumber;
+    }
+
+    /**
+     * Getter for the Certificate's Holder Common Name information.
+     * @return this certificate's holder issuer as a string.
+     */
+    public String getHolderIssuer() {
+        return this.holderIssuer;
     }
 
     /**


### PR DESCRIPTION
This merge request adds Holder information for platform credentials.  This will display the common name and associated holder serial number.  If the holder serial number is linked to an existing endorsement certificate, a link will be provided.  Otherwise just display the serial number of the endorsement link.