### PR TITLE
[#17] Adding ability to delete Attestation Certificates on the ACA.

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/issued-certificates.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/issued-certificates.jsp
@@ -109,6 +109,7 @@
                                 var html = '';
                                 html += certificateDetailsLink('issued', full.id, true);
                                 html += certificateDownloadLink(full.id, pagePath);
+                                html += certificateDeleteLink(full.id, pagePath);
 
                                 return html;
                             }


### PR DESCRIPTION
This pull request adds the trashcan icon to the Attestation Certificates page of the portal.  
Fixes #17 