### PR TITLE
[#27] Fix TPMSecurityAssertions Parsing in EndorsementCredential

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/TPMSecurityAssertions.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/TPMSecurityAssertions.java
@@ -12,7 +12,7 @@ import java.math.BigInteger;
  *
  * Future iterations of this code may want to reference
  * www.trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf
- * for specifications for TPM 2.0.
+ * for specifications for TPM 2.0 (pg. 19).
  */
 @Embeddable
 public class TPMSecurityAssertions {

--- a/HIRS_Utils/src/test/java/hirs/data/persist/certificate/EndorsementCredentialTest.java
+++ b/HIRS_Utils/src/test/java/hirs/data/persist/certificate/EndorsementCredentialTest.java
@@ -190,16 +190,21 @@ public class EndorsementCredentialTest {
      *
      * @throws IOException if there is a problem reading the cert file at the given path
      */
-    @Test(enabled = false)
-    // TODO(apldev3): Reenable test when update to security assertions is made in
-    // EndorsementCredential
+    @Test
     public void testTpmSecurityAssertionsParsing() throws IOException {
         Path fPath = Paths.get(CertificateTest.class
                 .getResource(EK_CERT_WITH_SECURITY_ASSERTIONS).getPath());
         EndorsementCredential ec = new EndorsementCredential(fPath);
 
-        // TODO(apldev3): Make assertions about TPMSecurityAssertions fields
-        System.out.println(ec);
+        TPMSecurityAssertions securityAssertions = ec.getTpmSecurityAssertions();
+        Assert.assertEquals(securityAssertions.getVersion(), BigInteger.ONE);
+        Assert.assertTrue(securityAssertions.isFieldUpgradeable());
+        Assert.assertEquals(securityAssertions.getEkGenType(),
+                TPMSecurityAssertions.EkGenerationType.INJECTED);
+        Assert.assertEquals(securityAssertions.getEkGenLoc(),
+                TPMSecurityAssertions.EkGenerationLocation.TPM_MANUFACTURER);
+        Assert.assertEquals(securityAssertions.getEkCertGenLoc(),
+                TPMSecurityAssertions.EkGenerationLocation.TPM_MANUFACTURER);
     }
 
 }


### PR DESCRIPTION
Update `EndorsementCredential` to correctly parse the `TPMSecurityAssertions` objects per the specification on pg.19 at www.trustedcomputinggroup.org/wp-content/uploads/Credential_Profile_EK_V2.0_R14_published.pdf

Closes #27