### PR TITLE
 [#38] ACA checks uploaded EK Certs if one is not provided during prov…

### DIFF
--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/AbstractAttestationCertificateAuthorityTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/AbstractAttestationCertificateAuthorityTest.java
@@ -1,7 +1,6 @@
 package hirs.attestationca;
 
 import com.google.protobuf.ByteString;
-import hirs.attestationca.exceptions.IdentityProcessingException;
 import hirs.utils.HexUtils;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.ArrayUtils;
@@ -159,9 +158,9 @@ public class AbstractAttestationCertificateAuthorityTest {
 
     /**
      * Tests {@link AbstractAttestationCertificateAuthority#processIdentityClaimTpm2(byte[])}
-     * where the byte array is null. Expects an identity processing exception to be thrown.
+     * where the byte array is null. Expects an illegal argument exception to be thrown.
      */
-    @Test(expectedExceptions = IdentityProcessingException.class)
+    @Test(expectedExceptions = IllegalArgumentException.class)
     public void testProcessIdentityClaimTpm2NullRequest() {
         aca.processIdentityClaimTpm2(null);
     }


### PR DESCRIPTION
...isioning

This MR requires #39 to be merged before this should go in. Once it does, this is actually a very small merge request to ensure that the ACA checks for any uploaded EK Certificates when performing TPM 2.0 Provisioning. In it's current state, it would check for uploaded Platform Certificates, but not uploaded EK Certificates, which does not keep in line with the original TPM 1.2 Provisioner.

Closes #38