### PR TITLE
[#47] Prevent deletion of external dependencies for TPM 2.0 Provisioner

### DIFF
--- a/HIRS_ProvisionerTPM2/build.gradle
+++ b/HIRS_ProvisionerTPM2/build.gradle
@@ -1,10 +1,5 @@
-task cleanup() {
-    delete 'build'
-}
-
-task prep(type: Exec) {
-    workingDir './'
-    commandLine 'mkdir', 'build'
+task cleanup(type: Delete) {
+	delete fileTree(dir: 'build', exclude: 'lib/')
 }
 
 task cmake(type: Exec) {
@@ -18,7 +13,7 @@ task make(type: Exec) {
 }
 
 task fullBuild(type: GradleBuild) {
-	tasks = ['cleanup', 'prep', 'cmake', 'make']
+	tasks = ['cleanup', 'cmake', 'make']
 }
 
 build.dependsOn tasks.fullBuild

--- a/HIRS_ProvisionerTPM2/package/package.tpm2.centos7.sh
+++ b/HIRS_ProvisionerTPM2/package/package.tpm2.centos7.sh
@@ -12,8 +12,15 @@ fi
 cd $( dirname "${BASH_SOURCE[0]}" )
 
 # Ensure clean build environment
-rm -rf BUILD
-mkdir BUILD
+shopt -s extglob
+# Delete everything but downloaded dependencies
+rm -rf BUILD/!(lib)
+shopt -u extglob
+
+# Make BUILD directory if it doesn't already exist
+if [ ! -d "BUILD" ]; then
+    mkdir BUILD
+fi
 
 # Navigate to build directory
 cd BUILD

--- a/HIRS_ProvisionerTPM2/package/package.tpm2.ubuntu.sh
+++ b/HIRS_ProvisionerTPM2/package/package.tpm2.ubuntu.sh
@@ -12,8 +12,15 @@ fi
 cd $( dirname "${BASH_SOURCE[0]}" )
 
 # Ensure clean build environment
-rm -rf BUILD
-mkdir BUILD
+shopt -s extglob
+# Delete everything but downloaded dependencies
+rm -rf BUILD/!(lib)
+shopt -u extglob
+
+# Make BUILD directory if it doesn't already exist
+if [ ! -d "BUILD" ]; then
+    mkdir BUILD
+fi
 
 # Navigate to build directory
 cd BUILD


### PR DESCRIPTION
This merge request updates the Gradle Build and TPM 2.0 Provisioner packaging scripts to avoid deleting the `lib` folder in the target build directory. In doing so, this effectively "caches" the external dependencies and allows for CMake to detect and make use of the dependencies that were already downloaded.

Closes #47 