### PR TITLE
[#43] Additional certificate fields to display.

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
@@ -15,6 +15,7 @@ import hirs.data.persist.certificate.IssuedAttestationCertificate;
 import hirs.data.persist.certificate.PlatformCredential;
 import hirs.data.persist.certificate.attributes.PlatformConfiguration;
 import hirs.persist.CertificateManager;
+import java.math.BigInteger;
 
 /**
  * Utility class for mapping certificate information in to string maps. These are used to display
@@ -44,6 +45,11 @@ public final class CertificateStringMapBuilder {
             data.put("issuer", certificate.getIssuer());
             //Serial number in hex value
             data.put("serialNumber", Long.toHexString(certificate.getSerialNumber().longValue()));
+            if (certificate.getAuthoritySerialNumber() != null
+                    && certificate.getAuthoritySerialNumber() != BigInteger.ZERO) {
+                data.put("authSerialNumber", Long.toHexString(certificate
+                        .getAuthoritySerialNumber().longValue()));
+            }
             data.put("beginValidity", certificate.getBeginValidity().toString());
             data.put("endValidity", certificate.getEndValidity().toString());
             data.put("signature", Arrays.toString(certificate.getSignature()));
@@ -58,8 +64,8 @@ public final class CertificateStringMapBuilder {
                 data.put("isSelfSigned", "false");
             }
 
-            data.put("authInfoAccess", certificate.getAuthInfoAccess());
             data.put("authKeyId", certificate.getAuthKeyId());
+            data.put("authInfoAccess", certificate.getAuthInfoAccess());
             data.put("signatureAlgorithm", certificate.getSignatureAlgorithm());
             if (certificate.getEncodedPublicKey() != null) {
                 data.put("encodedPublicKey",
@@ -68,9 +74,10 @@ public final class CertificateStringMapBuilder {
             }
 
             if (certificate.getPublicKeyModulusHexValue() != null) {
-                data.put("publicKeyValue", certificate.getPublicKeyModulusHexValue());
+                data.put("publicKeyValue", Arrays.toString(certificate
+                        .getPublicKeyModulusHexValue()));
                 data.put("publicKeySize", Integer.toString(certificate
-                        .getPublicKeyModulusHexValue().length()
+                        .getPublicKeyModulusHexValue().length
                         * Certificate.MIN_ATTR_CERT_LENGTH));
             }
 
@@ -91,7 +98,7 @@ public final class CertificateStringMapBuilder {
                     data.put("missingChainIssuer", missingCert.getIssuer());
                 }
                 //Find all certificates that could be the issuer certificate based on subject name
-                for (Certificate issuerCert:CertificateAuthorityCredential
+                for (Certificate issuerCert : CertificateAuthorityCredential
                         .select(certificateManager)
                         .bySubject(certificate.getIssuer())
                         .getCertificates()) {

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Set;
@@ -44,7 +45,7 @@ public final class CertificateStringMapBuilder {
             data.put("issuer", certificate.getIssuer());
             //Serial number in hex value
             data.put("serialNumber", Long.toHexString(certificate.getSerialNumber().longValue()));
-            if (certificate.getAuthoritySerialNumber() != null) {
+            if (!certificate.getAuthoritySerialNumber().equals(BigInteger.ZERO)) {
                 data.put("authSerialNumber", Long.toHexString(certificate
                         .getAuthoritySerialNumber().longValue()));
             }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
@@ -64,9 +64,6 @@ public final class CertificateStringMapBuilder {
             }
 
             data.put("authKeyId", certificate.getAuthKeyId());
-            if (certificate.getAuthInfoAccess() != null) {
-                data.put("authInfoAccess", certificate.getAuthInfoAccess());
-            }
             data.put("crlPoints", certificate.getCrlPoints());
             data.put("signatureAlgorithm", certificate.getSignatureAlgorithm());
             if (certificate.getEncodedPublicKey() != null) {
@@ -210,6 +207,7 @@ public final class CertificateStringMapBuilder {
             //x509 credential version
             data.put("x509Version", Integer.toString(certificate
                     .getX509CredentialVersion()));
+            data.put("authInfoAccess", certificate.getAuthInfoAccess());
             data.put("credentialType", certificate.getCredentialType());
         } else {
             LOGGER.error(notFoundMessage);
@@ -239,6 +237,7 @@ public final class CertificateStringMapBuilder {
             data.put("version", certificate.getVersion());
             data.put("policyReference", certificate.getPolicyReference());
             data.put("crlPoints", certificate.getCrlPoints());
+            data.put("authInfoAccess", certificate.getAuthInfoAccess());
             data.put("credentialType", certificate.getCredentialType());
             //x509 credential version
             data.put("x509Version", Integer.toString(certificate

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
@@ -47,6 +47,8 @@ public final class CertificateStringMapBuilder {
             data.put("beginValidity", certificate.getBeginValidity().toString());
             data.put("endValidity", certificate.getEndValidity().toString());
             data.put("signature", Arrays.toString(certificate.getSignature()));
+            data.put("signatureSize", Integer.toString(certificate.getSignature().length
+                    * Certificate.MIN_ATTR_CERT_LENGTH));
 
             if (certificate.getSubject() != null) {
                 data.put("subject", certificate.getSubject());
@@ -56,9 +58,29 @@ public final class CertificateStringMapBuilder {
                 data.put("isSelfSigned", "false");
             }
 
+            data.put("authInfoAccess", certificate.getAuthInfoAccess());
+            data.put("authKeyId", certificate.getAuthKeyId());
+            data.put("signatureAlgorithm", certificate.getSignatureAlgorithm());
             if (certificate.getEncodedPublicKey() != null) {
                 data.put("encodedPublicKey",
                         Arrays.toString(certificate.getEncodedPublicKey()));
+                data.put("publicKeyAlgorithm", certificate.getPublicKeyAlgorithm());
+            }
+
+            if (certificate.getPublicKeyModulusHexValue() != null) {
+                data.put("publicKeyValue", certificate.getPublicKeyModulusHexValue());
+                data.put("publicKeySize", Integer.toString(certificate
+                        .getPublicKeyModulusHexValue().length()
+                        * Certificate.MIN_ATTR_CERT_LENGTH));
+            }
+
+            if (certificate.getKeyUsage() != null) {
+                data.put("keyUsage", certificate.getKeyUsage());
+            }
+
+            if (certificate.getExtendedKeyUsage() != null
+                    && !certificate.getExtendedKeyUsage().isEmpty()) {
+                data.put("extendedKeyUsage", certificate.getExtendedKeyUsage());
             }
 
             //Get issuer ID if not self signed
@@ -179,6 +201,10 @@ public final class CertificateStringMapBuilder {
             data.putAll(getGeneralCertificateInfo(certificate, certificateManager));
             data.put("subjectKeyIdentifier",
                     Arrays.toString(certificate.getSubjectKeyIdentifier()));
+            //x509 credential version
+            data.put("x509Version", Integer.toString(certificate
+                    .getX509CredentialVersion()));
+            data.put("credentialType", certificate.getCredentialType());
         } else {
             LOGGER.error(notFoundMessage);
         }
@@ -202,12 +228,15 @@ public final class CertificateStringMapBuilder {
         if (certificate != null) {
             data.putAll(getGeneralCertificateInfo(certificate, certificateManager));
             // Set extra fields
-            data.put("credentialType", certificate.getCredentialType());
             data.put("manufacturer", certificate.getManufacturer());
             data.put("model", certificate.getModel());
             data.put("version", certificate.getVersion());
             data.put("policyReference", certificate.getPolicyReference());
             data.put("revocationLocator", certificate.getRevocationLocator());
+            data.put("credentialType", certificate.getCredentialType());
+            //x509 credential version
+            data.put("x509Version", Integer.toString(certificate
+                    .getX509CredentialVersion()));
             // Add hashmap with TPM information if available
             if (certificate.getTpmSpecification() != null) {
                 data.putAll(

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
@@ -74,11 +74,8 @@ public final class CertificateStringMapBuilder {
             }
 
             if (certificate.getPublicKeyModulusHexValue() != null) {
-                data.put("publicKeyValue", Arrays.toString(certificate
-                        .getPublicKeyModulusHexValue()));
-                data.put("publicKeySize", Integer.toString(certificate
-                        .getPublicKeyModulusHexValue().length
-                        * Certificate.MIN_ATTR_CERT_LENGTH));
+                data.put("publicKeyValue", certificate.getPublicKeyModulusHexValue());
+                data.put("publicKeySize", null);
             }
 
             if (certificate.getKeyUsage() != null) {

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
@@ -45,8 +45,7 @@ public final class CertificateStringMapBuilder {
             data.put("issuer", certificate.getIssuer());
             //Serial number in hex value
             data.put("serialNumber", Long.toHexString(certificate.getSerialNumber().longValue()));
-            if (certificate.getAuthoritySerialNumber() != null
-                    && certificate.getAuthoritySerialNumber() != BigInteger.ZERO) {
+            if (certificate.getAuthoritySerialNumber() != BigInteger.ZERO) {
                 data.put("authSerialNumber", Long.toHexString(certificate
                         .getAuthoritySerialNumber().longValue()));
             }
@@ -65,7 +64,10 @@ public final class CertificateStringMapBuilder {
             }
 
             data.put("authKeyId", certificate.getAuthKeyId());
-            data.put("authInfoAccess", certificate.getAuthInfoAccess());
+            if (certificate.getAuthInfoAccess() != null) {
+                data.put("authInfoAccess", certificate.getAuthInfoAccess());
+            }
+            data.put("crlPoints", certificate.getCrlPoints());
             data.put("signatureAlgorithm", certificate.getSignatureAlgorithm());
             if (certificate.getEncodedPublicKey() != null) {
                 data.put("encodedPublicKey",
@@ -236,7 +238,7 @@ public final class CertificateStringMapBuilder {
             data.put("model", certificate.getModel());
             data.put("version", certificate.getVersion());
             data.put("policyReference", certificate.getPolicyReference());
-            data.put("revocationLocator", certificate.getRevocationLocator());
+            data.put("crlPoints", certificate.getCrlPoints());
             data.put("credentialType", certificate.getCredentialType());
             //x509 credential version
             data.put("x509Version", Integer.toString(certificate

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
@@ -15,7 +15,6 @@ import hirs.data.persist.certificate.IssuedAttestationCertificate;
 import hirs.data.persist.certificate.PlatformCredential;
 import hirs.data.persist.certificate.attributes.PlatformConfiguration;
 import hirs.persist.CertificateManager;
-import java.math.BigInteger;
 
 /**
  * Utility class for mapping certificate information in to string maps. These are used to display
@@ -45,7 +44,7 @@ public final class CertificateStringMapBuilder {
             data.put("issuer", certificate.getIssuer());
             //Serial number in hex value
             data.put("serialNumber", Long.toHexString(certificate.getSerialNumber().longValue()));
-            if (certificate.getAuthoritySerialNumber() != BigInteger.ZERO) {
+            if (certificate.getAuthoritySerialNumber() != null) {
                 data.put("authSerialNumber", Long.toHexString(certificate
                         .getAuthoritySerialNumber().longValue()));
             }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
@@ -73,7 +73,7 @@ public final class CertificateStringMapBuilder {
 
             if (certificate.getPublicKeyModulusHexValue() != null) {
                 data.put("publicKeyValue", certificate.getPublicKeyModulusHexValue());
-                data.put("publicKeySize", null);
+                data.put("publicKeySize", String.valueOf(certificate.getPublicKeySize()));
             }
 
             if (certificate.getKeyUsage() != null) {

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
@@ -199,7 +199,7 @@
                                 <div id="keyUsage" class="col col-md-8 vertical">${initialData.keyUsage}</div>
                             </c:when>
                             <c:otherwise>
-                                <div id="keyUsage" class="col col-md-8 vertical">NOT SPECIFIED</div>
+                                <div id="keyUsage" class="col col-md-8 vertical">Not Specified</div>
                             </c:otherwise>
                         </c:choose>
                     </div>
@@ -237,7 +237,7 @@
                                 <div id="keyUsage" class="col col-md-8 vertical">${initialData.keyUsage}</div>
                             </c:when>
                             <c:otherwise>
-                                <div id="keyUsage" class="col col-md-8 vertical">NOT SPECIFIED</div>
+                                <div id="keyUsage" class="col col-md-8 vertical">Not Specified</div>
                             </c:otherwise>
                         </c:choose>
                     </div>
@@ -303,6 +303,7 @@
                                 <div>EK Certificate:&nbsp;<span>${initialData.holderIssuer}</span></div>
                             </c:if>
                                 <div id="certificateid">
+                                    <div>EK Identifier:&nbsp;
                                     <c:choose>
                                         <c:when test="${not empty initialData.ekId}">
                                             <span>
@@ -312,9 +313,10 @@
                                             </span>
                                         </c:when>
                                         <c:otherwise>
-                                            <div><span>${initialData.holderSerialNumber}</span></div>
+                                            <span>${initialData.holderSerialNumber}</span>
                                         </c:otherwise>
                                     </c:choose>
+                                    </div>
                                 </div>                                
                         </div>
                     </div>
@@ -718,7 +720,7 @@
                         $("#authorityKeyIdentifier").html(parseSerialNumber(authorityKeyIdentifier));
                     </c:when>
                     <c:otherwise>
-                        $("#authorityKeyIdentifier").html("NOT SPECIFIED");
+                        $("#authorityKeyIdentifier").html("Not Specified");
                     </c:otherwise>
                 </c:choose>
 

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
@@ -209,6 +209,12 @@
                             </div>
                         </c:when>
                     </c:choose>
+                    <c:if test="${initialData.crlPoints}">
+                        <div class="row">
+                            <div class="col-md-1 col-md-offset-1"><span class="colHeader">Revocation Locator</span></div>
+                            <div id="revocationLocator" class="col col-md-8"><a href="${initialData.crlPoints}">${initialData.crlPoints}</div>
+                        </div>
+                    </c:if>
                     <div class="row">
                         <div class="col-md-1 col-md-offset-1"><span class="colHeader">Key Usage</span></div>                        
                         <c:choose>
@@ -252,10 +258,10 @@
                             </c:choose>
                         </div>
                     </div>
-                    <c:if test="${initialData.revocationLocator}">
+                    <c:if test="${initialData.crlPoints}">
                         <div class="row">
                             <div class="col-md-1 col-md-offset-1"><span class="colHeader">Revocation Locator</span></div>
-                            <div id="revocationLocator" class="col col-md-8">${initialData.revocationLocator}</div>
+                            <div id="revocationLocator" class="col col-md-8"><a href="${initialData.crlPoints}">${initialData.crlPoints}</div>
                         </div>
                     </c:if>
                     <div class="row">

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
@@ -64,21 +64,31 @@
                             </c:choose>
                         </span>
                     </div>
-                    <div>Authority Key Identifier:&nbsp;<span id="authorityKeyIdentifier"></span></div>
+                    <div>Authority Key Identifier:&nbsp;
+                        <span id="authorityKeyIdentifier"></span>
+                    </div>
                     <c:if test="${not empty initialData.authInfoAccess}">
-                    <div>Authority Info Access:&nbsp;<span><a href="${initialData.authInfoAccess}">${initialData.authInfoAccess}</a></span></div>                    
+                        <div>Authority Info Access:&nbsp;<span>
+                                <a href="${initialData.authInfoAccess}">${initialData.authInfoAccess}</a>
+                            </span>
+                        </div>
+                    </c:if>
+                    <c:if test="${not empty initialData.authSerialNumber}">
+                        <div>Authority Serial Number:&nbsp;
+                            <span id="authSerialNumber"></span>
+                        </div>
                     </c:if>
                     <c:if test="${param.type!='issued'}">
                         <span class="chainIcon">
                             <!-- Icon with link for missing certificate for the chain -->
                             <c:choose>
                                 <c:when test="${initialData.isSelfSigned == 'true'}">
-                                     <img src="${icons}/ic_all_inclusive_black_24dp.png"
-                                                    title="Self sign certificate.">
+                                    <img src="${icons}/ic_all_inclusive_black_24dp.png"
+                                         title="Self sign certificate.">
                                 </c:when>
                                 <c:when test="${empty initialData.missingChainIssuer}">
                                     <img src="${icons}/ic_checkbox_marked_circle_black_green_24dp.png"
-                                            title="All certificates in the chain were found.">
+                                         title="All certificates in the chain were found.">
                                 </c:when>
                                 <c:otherwise>
                                     <img src="${icons}/ic_error_red_24dp.png"
@@ -124,13 +134,13 @@
                             <div class="panel-heading">
                                 <a role="button" data-toggle="collapse" class="collapsed" href="#signatureSizecollapse"
                                    aria-expanded="true" data-placement="top" aria-controls="signatureSizecollapse">
-                                    Algorithm & Size
+                                    Algorithm
                                 </a>                                                                      
                             </div>
                             <div id="signatureSizecollapse" class="panel-body collapse" role="tabpanel" aria-labelledby="headingOne" aria-expanded="false">
                                 <div>
                                     <span class="fieldValue">
-                                        ${initialData.signatureAlgorithm} / ${initialData.signatureSize} bits
+                                        ${initialData.signatureAlgorithm} / ${initialData.signatureSize}
                                     </span>
                                 </div>                                                               
                             </div>
@@ -142,34 +152,41 @@
                 <div class="row">
                     <div class="col-md-1 col-md-offset-1"><span class="colHeader">Public Key</span></div>
                     <div id="publicKeySection" class="col col-md-8">
-                    <div class="panel-body">
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <a role="button" data-toggle="collapse" class="collapsed" href="#publicKeycollapse"
-                                   aria-expanded="true" data-placement="top" aria-controls="publicKeycollapse">
-                                    Public Key
-                                </a>                                                                    
+                        <div class="panel-body">
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <a role="button" data-toggle="collapse" class="collapsed" href="#publicKeycollapse"
+                                       aria-expanded="true" data-placement="top" aria-controls="publicKeycollapse">
+                                        Public Key
+                                    </a>                                                                    
+                                </div>
+                                <div id="publicKeycollapse" class="panel-body collapse" role="tabpanel" aria-labelledby="headingOne" aria-expanded="false">
+                                    <c:choose>
+                                        <c:when test="${not empty initialData.publicKeyValue}">
+                                            <div id="encodedPublicKey" class="fieldValue"></div>                        
+                                        </c:when>
+                                        <c:otherwise>
+                                            <div id="encodedPublicKey" class="fieldValue"></div>                                    
+                                        </c:otherwise>
+                                    </c:choose>
+                                </div>
                             </div>
-                            <div id="publicKeycollapse" class="panel-body collapse" role="tabpanel" aria-expanded="false">
-                                <div id="encodedPublicKey" class="fieldValue"></div>
+                            <div class="panel panel-default">
+                                <div class="panel-heading">
+                                    <a role="button" data-toggle="collapse" class="collapsed" href="#publicKeySizecollapse"
+                                       aria-expanded="true" data-placement="top" aria-controls="publicKeySizecollapse">
+                                        Algorithm
+                                    </a>                                                                      
+                                </div>
+                                <div id="publicKeySizecollapse" class="panel-body collapse" role="tabpanel" aria-expanded="false">
+                                    <div>
+                                        <span class="fieldValue">
+                                            ${initialData.publicKeyAlgorithm}
+                                        </span>
+                                    </div>                                                               
+                                </div>
                             </div>
                         </div>
-                        <div class="panel panel-default">
-                            <div class="panel-heading">
-                                <a role="button" data-toggle="collapse" class="collapsed" href="#publicKeySizecollapse"
-                                   aria-expanded="true" data-placement="top" aria-controls="publicKeySizecollapse">
-                                    Algorithm & Size
-                                </a>                                                                      
-                            </div>
-                            <div id="publicKeySizecollapse" class="panel-body collapse" role="tabpanel" aria-expanded="false">
-                                <div>
-                                    <span class="fieldValue">
-                                        ${initialData.publicKeyAlgorithm} / ${initialData.publicKeySize} bits
-                                    </span>
-                                </div>                                                               
-                            </div>
-                        </div>
-                    </div>
                     </div>
                 </div>
             </c:if>
@@ -199,11 +216,7 @@
                                 <div id="keyUsage" class="col col-md-8 vertical">${initialData.keyUsage}</div>
                             </c:when>
                             <c:otherwise>
-<<<<<<< HEAD
                                 <div id="keyUsage" class="col col-md-8 vertical">Not Specified</div>
-=======
-                                <div id="keyUsage" class="col col-md-8 vertical">NOT SPECIFIED</div>
->>>>>>> b349a3baa765b041db8b6ce7091e4772bc078384
                             </c:otherwise>
                         </c:choose>
                     </div>
@@ -228,12 +241,23 @@
                     </div>
                     <div class="row">
                         <div class="col-md-1 col-md-offset-1"><span class="colHeader">Policy Reference</span></div>
-                        <div id="policyReference" class="col col-md-8">${initialData.policyReference}</div>
+                        <div id="policyReference" class="col col-md-8">
+                            <c:choose>
+                                <c:when test="${not empty initialData.policyReference}">
+                                    ${initialData.policyReference}
+                                </c:when>
+                                <c:otherwise>
+                                    Not Specified
+                                </c:otherwise>
+                            </c:choose>
+                        </div>
                     </div>
-                    <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Revocation Locator</span></div>
-                        <div id="revocationLocator" class="col col-md-8">${initialData.revocationLocator}</div>
-                    </div>
+                    <c:if test="${initialData.revocationLocator}">
+                        <div class="row">
+                            <div class="col-md-1 col-md-offset-1"><span class="colHeader">Revocation Locator</span></div>
+                            <div id="revocationLocator" class="col col-md-8">${initialData.revocationLocator}</div>
+                        </div>
+                    </c:if>
                     <div class="row">
                         <div class="col-md-1 col-md-offset-1"><span class="colHeader">Key Usage</span></div>                        
                         <c:choose>
@@ -241,22 +265,18 @@
                                 <div id="keyUsage" class="col col-md-8 vertical">${initialData.keyUsage}</div>
                             </c:when>
                             <c:otherwise>
-<<<<<<< HEAD
                                 <div id="keyUsage" class="col col-md-8 vertical">Not Specified</div>
-=======
-                                <div id="keyUsage" class="col col-md-8 vertical">NOT SPECIFIED</div>
->>>>>>> b349a3baa765b041db8b6ce7091e4772bc078384
                             </c:otherwise>
                         </c:choose>
                     </div>
-                        <c:choose>
-                            <c:when test="${not empty initialData.extendedKeyUsage}">
-                                <div class="row">
-                                    <div class="col-md-1 col-md-offset-1"><span class="colHeader">Extended Key Usage</span></div>
-                                    <div id="extendedKeyUsage" class="col col-md-8 vertical">${initialData.extendedKeyUsage}</div>
-                                </div>
-                            </c:when>
-                        </c:choose>
+                    <c:choose>
+                        <c:when test="${not empty initialData.extendedKeyUsage}">
+                            <div class="row">
+                                <div class="col-md-1 col-md-offset-1"><span class="colHeader">Extended Key Usage</span></div>
+                                <div id="extendedKeyUsage" class="col col-md-8 vertical">${initialData.extendedKeyUsage}</div>
+                            </div>
+                        </c:when>
+                    </c:choose>
                     <!-- Need to test this -->
                     <div class="row">
                         <div class="col-md-1 col-md-offset-1">
@@ -310,8 +330,8 @@
                             <c:if test="${not empty initialData.holderIssuer}">
                                 <div>EK Certificate:&nbsp;<span>${initialData.holderIssuer}</span></div>
                             </c:if>
-                                <div id="certificateid">
-                                    <div>EK Identifier:&nbsp;
+                            <div id="certificateid">
+                                <div>EK Identifier:&nbsp;
                                     <c:choose>
                                         <c:when test="${not empty initialData.ekId}">
                                             <span>
@@ -324,8 +344,8 @@
                                             <span>${initialData.holderSerialNumber}</span>
                                         </c:otherwise>
                                     </c:choose>
-                                    </div>
-                                </div>                                
+                                </div>
+                            </div>                                
                         </div>
                     </div>
                     <div class="row">
@@ -384,12 +404,12 @@
                                             <h4 class="panel-title">
                                                 <a role="button" data-toggle="collapse" data-parent="#tbbsecurity" class="collapsed"
                                                    href="#ccinfocollapse" aria-expanded="false" aria-controls="ccinfocollapse">
-                                                  Common Criteria Measures Information
+                                                    Common Criteria Measures Information
                                                 </a>
                                             </h4>
                                         </div>
                                         <div id="ccinfocollapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
-                                          <div class="panel-body">
+                                            <div class="panel-body">
                                                 <div id="ccinfo" class="row">
                                                     <div class="tbbsecurityLine">
                                                         <span class="fieldHeader">Version:</span>
@@ -470,7 +490,7 @@
                                                             <div class="tbbsecurityLine">
                                                                 <span class="fieldHeader">Target Hash Value:</span>
                                                                 <span class="fieldValue">${ccinfo.getTargetUri().getHashValue()}</span>
-                                                           </div>
+                                                            </div>
                                                         </c:if>
                                                     </c:if>
                                                 </div>
@@ -486,12 +506,12 @@
                                             <h4 class="panel-title">
                                                 <a role="button" data-toggle="collapse" data-parent="#tbbsecurity" class="collapsed"
                                                    href="#fipscollapse" aria-expanded="false" aria-controls="fipscollapse">
-                                                  FIPS Level
+                                                    FIPS Level
                                                 </a>
                                             </h4>
                                         </div>
                                         <div id="fipscollapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
-                                          <div class="panel-body">
+                                            <div class="panel-body">
                                                 <div id="fipsLevel" class="row">
                                                     <div class="tbbsecurityLine">
                                                         <span class="fieldHeader">Version:</span>
@@ -522,12 +542,12 @@
                                         <h4 class="panel-title">
                                             <a role="button" data-toggle="collapse" data-parent="#tbbsecurity" class="collapsed"
                                                href="#iso9000collapse" aria-expanded="false" aria-controls="iso9000collapse">
-                                              ISO 9000
+                                                ISO 9000
                                             </a>
                                         </h4>
                                     </div>
                                     <div id="iso9000collapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingThree">
-                                      <div class="panel-body">
+                                        <div class="panel-body">
                                             <div id="iso9000" class="row">
                                                 <div class="tbbsecurityLine">
                                                     <c:choose>
@@ -568,12 +588,12 @@
                                             <h4 class="panel-title">
                                                 <a role="button" data-toggle="collapse" data-parent="#platformConfiguration" class="collapsed"
                                                    href="#componentIdentifiercollapse" aria-expanded="true" aria-controls="componentIdentifiercollapse">
-                                                  Components
+                                                    Components
                                                 </a>
                                             </h4>
                                         </div>
                                         <div id="componentIdentifiercollapse" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="headingOne" aria-expanded="true">
-                                          <div class="panel-body">
+                                            <div class="panel-body">
                                                 <div id="componentIdentifier" class="row">
                                                     <c:forEach items="${initialData.componentsIdentifier}" var="component">
                                                         <div class="component col col-md-4">
@@ -619,12 +639,12 @@
                                             <h4 class="panel-title">
                                                 <a role="button" data-toggle="collapse" data-parent="#platformConfiguration" class="collapsed"
                                                    href="#platformPropertiescollapse" aria-expanded="false" aria-controls="platformPropertiescollapse">
-                                                  Platform Properties
+                                                    Platform Properties
                                                 </a>
                                             </h4>
                                         </div>
                                         <div id="platformPropertiescollapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
-                                          <div class="panel-body">
+                                            <div class="panel-body">
                                                 <div id="platformProperties" class="row">
                                                     <c:forEach items="${initialData.platformProperties}" var="property">
                                                         <div class="component col col-md-4">
@@ -650,12 +670,12 @@
                                             <h4 class="panel-title">
                                                 <a role="button" data-toggle="collapse" data-parent="#platformConfiguration" class="collapsed"
                                                    href="#platformPropertiesURIcollapse" aria-expanded="false" aria-controls="platformPropertiesURIcollapse">
-                                                  Platform Properties URI
+                                                    Platform Properties URI
                                                 </a>
                                             </h4>
                                         </div>
                                         <div id="platformPropertiesURIcollapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingThree">
-                                          <div class="panel-body">
+                                            <div class="panel-body">
                                                 <div id="platformPropertiesURI" class="row">
                                                     <span class="fieldHeader">URI:</span>
                                                     <a href="${initialData.platformPropertiesURI.getUniformResourceIdentifier()}">
@@ -705,14 +725,15 @@
             </c:choose>
         </div>
         <script>
-            $(document).ready(function() {
+            $(document).ready(function () {
                 var type = "${param.type}";
                 var signature = ${initialData.signature};
                 var serialNumber = '${initialData.serialNumber}';
                 var authorityKeyIdentifier = '${initialData.authKeyId}';
+                var authoritySerialNumber = '${initialData.authSerialNumber}';
 
                 //Format validity time
-                $("#validity span").each(function(){
+                $("#validity span").each(function () {
                     $(this).text(formatDateTime($(this).text()));
                 });
 
@@ -721,54 +742,62 @@
 
                 //Convert byte array to string
                 $("#serialNumber").html(parseSerialNumber(serialNumber));
-                
+
                 // authority key ID
-                <c:choose>
-                    <c:when test="${not empty initialData.authKeyId}">
-                        $("#authorityKeyIdentifier").html(parseSerialNumber(authorityKeyIdentifier));
-                    </c:when>
-                    <c:otherwise>
-<<<<<<< HEAD
-                        $("#authorityKeyIdentifier").html("Not Specified");
-=======
-                        $("#authorityKeyIdentifier").html("NOT SPECIFIED");
->>>>>>> b349a3baa765b041db8b6ce7091e4772bc078384
-                    </c:otherwise>
-                </c:choose>
-
-                <c:if test="${not empty initialData.encodedPublicKey}">
-                    //Change publick key byte to hex
-                    var publicKey = ${initialData.encodedPublicKey};
-                    $("#encodedPublicKey").html(byteToHexString(publicKey));
+            <c:choose>
+                <c:when test="${not empty initialData.authKeyId}">
+                $("#authorityKeyIdentifier").html(parseSerialNumber(authorityKeyIdentifier));
+                </c:when>
+                <c:otherwise>
+                $("#authorityKeyIdentifier").html("Not Specified");
+                </c:otherwise>
+            </c:choose>
+                
+                <c:if test="${not empty initialData.authSerialNumber}">
+                    //Convert string to serial String
+                    $("#authSerialNumber").html(parseSerialNumber(authoritySerialNumber));
                 </c:if>
+            <c:choose>
+                <c:when test="${not empty initialData.publicKeyValue}">
+                var publicKey = ${initialData.publicKeyValue};
+                $("#encodedPublicKey").html(byteToHexString(publicKey));
+                </c:when>
+                <c:otherwise>
+                    <c:if test="${not empty initialData.encodedPublicKey}">
+                //Change public key byte to hex
+                var encPublicKey = ${initialData.encodedPublicKey};
+                $("#encodedPublicKey").html(byteToHexString(encPublicKey));
+                    </c:if>
+                </c:otherwise>
+            </c:choose>
 
-                <c:if test="${not empty initialData.subjectKeyIdentifier}">
-                    //Change subject byte to hex only for CACertificate
-                    if(type === "certificateauthority"){
-                        var subjectKeyIdentifier = ${initialData.subjectKeyIdentifier};
-                        $("#subjectKeyIdentifier").html(byteToHexString(subjectKeyIdentifier));
-                    }
-                </c:if>
+            <c:if test="${not empty initialData.subjectKeyIdentifier}">
+                //Change subject byte to hex only for CACertificate
+                if (type === "certificateauthority") {
+                    var subjectKeyIdentifier = ${initialData.subjectKeyIdentifier};
+                    $("#subjectKeyIdentifier").html(byteToHexString(subjectKeyIdentifier));
+                }
+            </c:if>
 
                 //Initiliaze tooltips
                 $('[data-toggle="tooltip"]').tooltip();
 
                 //Vertical alignment on data columns
-                $('.vertical').each(function(){
+                $('.vertical').each(function () {
                     $(this).css({
                         'line-height': $(this).height() + 'px'
                     });
-                });                
+                });
 
                 //Change link width
-                $("#headingOne, #headingTwo, #headingThree").each(function(e) {
+                $("#headingOne, #headingTwo, #headingThree").each(function (e) {
                     var width = $(this).width();
                     //Get link width
                     var linkWidth = $(this).find('a').width();
 
                     //Change width for the link
                     $(this).find('a').css({
-                        "padding-right": (width-linkWidth) + "px"
+                        "padding-right": (width - linkWidth) + "px"
                     });
                 });
             });

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
@@ -51,16 +51,23 @@
                 <div class="col-md-1 col-md-offset-1"><span class="colHeader">Issuer</span></div>
                 <div id="issuer" class="col col-md-8">
                     <!-- Display the issuer, and provide a link to the issuer details if provided -->
-                    <c:choose>
-                        <c:when test="${not empty initialData.issuerID}">
-                            <a href="${portal}/certificate-details?id=${initialData.issuerID}&type=certificateauthority">
-                                ${initialData.issuer}
-                            </a>
-                        </c:when>
-                        <c:otherwise>
-                            ${initialData.issuer}
-                          </c:otherwise>
-                    </c:choose>
+                    <div>Distinguished Name:&nbsp;<span>
+                            <c:choose>
+                                <c:when test="${not empty initialData.issuerID}">
+                                    <a href="${portal}/certificate-details?id=${initialData.issuerID}&type=certificateauthority">
+                                        ${initialData.issuer}
+                                    </a>
+                                </c:when>
+                                <c:otherwise>
+                                    ${initialData.issuer}
+                                </c:otherwise>
+                            </c:choose>
+                        </span>
+                    </div>
+                    <div>Authority Key Identifier:&nbsp;<span id="authorityKeyIdentifier"></span></div>
+                    <c:if test="${not empty initialData.authInfoAccess}">
+                    <div>Authority Info Access:&nbsp;<span><a href="${initialData.authInfoAccess}">${initialData.authInfoAccess}</a></span></div>                    
+                    </c:if>
                     <c:if test="${param.type!='issued'}">
                         <span class="chainIcon">
                             <!-- Icon with link for missing certificate for the chain -->
@@ -100,39 +107,120 @@
                 </div>
             </div>
             <div class="row">
-                <div class="col-md-1 col-md-offset-1"><span class="colHeader">Signature</span></div>
-                <div id="signature" class="col col-md-8"></div>
-            </div>
+                <div class="col-md-1 col-md-offset-1"><span class="colHeader">Signature</span></div><div id="signatureSection" class="col col-md-8">
+                    <div class="panel-body">
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <a role="button" data-toggle="collapse" class="collapsed" href="#signatureComponentcollapse"
+                                   aria-expanded="true" data-placement="top" aria-controls="signatureComponentcollapse">
+                                    Signature
+                                </a>
+                            </div>
+                            <div id="signatureComponentcollapse" class="panel-body collapse" role="tabpanel" aria-labelledby="headingOne" aria-expanded="false">
+                                <div id="signature" class="fieldValue"></div>                                                                  
+                            </div>
+                        </div>
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <a role="button" data-toggle="collapse" class="collapsed" href="#signatureSizecollapse"
+                                   aria-expanded="true" data-placement="top" aria-controls="signatureSizecollapse">
+                                    Algorithm & Size
+                                </a>                                                                      
+                            </div>
+                            <div id="signatureSizecollapse" class="panel-body collapse" role="tabpanel" aria-labelledby="headingOne" aria-expanded="false">
+                                <div>
+                                    <span class="fieldValue">
+                                        ${initialData.signatureAlgorithm} / ${initialData.signatureSize} bits
+                                    </span>
+                                </div>                                                               
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>    
             <c:if test="${not empty initialData.encodedPublicKey}">
                 <div class="row">
                     <div class="col-md-1 col-md-offset-1"><span class="colHeader">Public Key</span></div>
-                    <div id="encodedPublicKey" class="col col-md-8"></div>
+                    <div id="publicKeySection" class="col col-md-8">
+                    <div class="panel-body">
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <a role="button" data-toggle="collapse" class="collapsed" href="#publicKeycollapse"
+                                   aria-expanded="true" data-placement="top" aria-controls="publicKeycollapse">
+                                    Public Key
+                                </a>                                                                    
+                            </div>
+                            <div id="publicKeycollapse" class="panel-body collapse" role="tabpanel" aria-expanded="false">
+                                <div id="encodedPublicKey" class="fieldValue"></div>
+                            </div>
+                        </div>
+                        <div class="panel panel-default">
+                            <div class="panel-heading">
+                                <a role="button" data-toggle="collapse" class="collapsed" href="#publicKeySizecollapse"
+                                   aria-expanded="true" data-placement="top" aria-controls="publicKeySizecollapse">
+                                    Algorithm & Size
+                                </a>                                                                      
+                            </div>
+                            <div id="publicKeySizecollapse" class="panel-body collapse" role="tabpanel" aria-expanded="false">
+                                <div>
+                                    <span class="fieldValue">
+                                        ${initialData.publicKeyAlgorithm} / ${initialData.publicKeySize} bits
+                                    </span>
+                                </div>                                                               
+                            </div>
+                        </div>
+                    </div>
+                    </div>
                 </div>
             </c:if>
+            <div class="row">
+                <div class="col-md-1 col-md-offset-1"><span class="colHeader">X509 Credential Version</span></div>
+                <div id="credentialVersion" class="col col-md-8 vertical">${initialData.x509Version} (v${initialData.x509Version + 1})</div>
+            </div>
+            <div class="row">
+                <div class="col-md-1 col-md-offset-1"><span class="colHeader">Credential Type</span></div>
+                <div id="credentialType" class="col col-md-8">${initialData.credentialType}</div>
+            </div>
             <!-- Add the different fields based on the certificate type -->
             <c:choose>
                 <c:when test="${param.type=='certificateauthority'}">
+                    <c:choose>
+                        <c:when test="${not empty initialData.subjectKeyIdentifier}">
+                            <div class="row">
+                                <div class="col-md-1 col-md-offset-1"><span class="colHeader">Subject Key Identifier</span></div>
+                                <div id="subjectKeyIdentifier" class="col col-md-8 vertical"></div>
+                            </div>
+                        </c:when>
+                    </c:choose>
                     <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Subject Key Identifier</span></div>
-                        <div id="subjectKeyIdentifier" class="col col-md-8"></div>
+                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Key Usage</span></div>                        
+                        <c:choose>
+                            <c:when test="${not empty initialData.keyUsage}">
+                                <div id="keyUsage" class="col col-md-8 vertical">${initialData.keyUsage}</div>
+                            </c:when>
+                            <c:otherwise>
+                                <div id="keyUsage" class="col col-md-8 vertical">NOT SPECIFIED</div>
+                            </c:otherwise>
+                        </c:choose>
                     </div>
+                    <c:choose>
+                        <c:when test="${not empty initialData.extendedKeyUsage}">
+                            <div class="row">
+                                <div class="col-md-1 col-md-offset-1"><span class="colHeader">Extended Key Usage</span></div>
+                                <div id="extendedKeyUsage" class="col col-md-8 vertical">${initialData.extendedKeyUsage}</div>
+                            </div>
+                        </c:when>
+                    </c:choose>
                 </c:when>
                 <c:when test="${param.type=='endorsement'}">
                     <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Credential Type</span></div>
-                        <div id="credentialType" class="col col-md-8">${initialData.credentialType}</div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Manufacturer</span></div>
-                        <div id="manufacturer" class="col col-md-8">${initialData.manufacturer}</div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Model</span></div>
-                        <div id="model" class="col col-md-8">${initialData.model}</div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Version</span></div>
-                        <div id="version" class="col col-md-8">${initialData.version}</div>
+                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">TPM</span></div>
+                        <div id="subjectAltName" class="col col-md-8">
+                            <div id="manufacturer">Manufacturer:&nbsp;<span>${initialData.manufacturer}</span></div>
+                            <div id="model">Model:&nbsp;<span>${initialData.model}</span></div>
+                            <div id="version">Version:&nbsp;<span>${initialData.version}</span></div>
+                            <div id="serial">Serial NR:&nbsp;<span><!-- optional --></span></div>
+                        </div>  
                     </div>
                     <div class="row">
                         <div class="col-md-1 col-md-offset-1"><span class="colHeader">Policy Reference</span></div>
@@ -142,39 +230,68 @@
                         <div class="col-md-1 col-md-offset-1"><span class="colHeader">Revocation Locator</span></div>
                         <div id="revocationLocator" class="col col-md-8">${initialData.revocationLocator}</div>
                     </div>
+                    <div class="row">
+                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Key Usage</span></div>                        
+                        <c:choose>
+                            <c:when test="${not empty initialData.keyUsage}">
+                                <div id="keyUsage" class="col col-md-8 vertical">${initialData.keyUsage}</div>
+                            </c:when>
+                            <c:otherwise>
+                                <div id="keyUsage" class="col col-md-8 vertical">NOT SPECIFIED</div>
+                            </c:otherwise>
+                        </c:choose>
+                    </div>
+                        <c:choose>
+                            <c:when test="${not empty initialData.extendedKeyUsage}">
+                                <div class="row">
+                                    <div class="col-md-1 col-md-offset-1"><span class="colHeader">Extended Key Usage</span></div>
+                                    <div id="extendedKeyUsage" class="col col-md-8 vertical">${initialData.extendedKeyUsage}</div>
+                                </div>
+                            </c:when>
+                        </c:choose>
                     <!-- Need to test this -->
                     <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">TPM Specification</span></div>
+                        <div class="col-md-1 col-md-offset-1">
+                            <span class="colHeader">
+                                <a role="button" data-toggle="collapse" class="collapsed" href="#tpmSpecificationInner"
+                                   aria-expanded="true" data-placement="top" aria-controls="tpmSpecificationInner">
+                                    TPM Specification
+                                </a>
+                            </span>
+                        </div>
                         <div id="tpmSpecification" class="col col-md-8">
-                            <div>Family:&nbsp;<span>${initialData.TPMSpecificationFamily}</span></div>
-                            <div>Level:&nbsp;<span>${initialData.TPMSpecificationLevel}</span></div>
-                            <div>Revision:&nbsp;<span>${initialData.TPMSpecificationRevision}</span></div>
+                            <div id="tpmSpecificationInner" class="panel-body collapse" role="tabpanel" aria-expanded="false">
+                                <div>Family:&nbsp;<span>${initialData.TPMSpecificationFamily}</span></div>
+                                <div>Level:&nbsp;<span>${initialData.TPMSpecificationLevel}</span></div>
+                                <div>Revision:&nbsp;<span>${initialData.TPMSpecificationRevision}</span></div>
+                            </div>
                         </div>
                     </div>
                     <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">TPM Security Assertion</span></div>
+                        <div class="col-md-1 col-md-offset-1">
+                            <span class="colHeader">
+                                <a role="button" data-toggle="collapse" class="collapsed" href="#tpmSecurityAssertionInner"
+                                   aria-expanded="true" data-placement="top" aria-controls="tpmSecurityAssertionInner">
+                                    TPM Security Assertion
+                                </a>
+                            </span>
+                        </div>
                         <div id="tpmSecurityAssertion" class="col col-md-8">
-                        <div>Version:&nbsp;<span>${initialData.TPMSecurityAssertionsVersion}</span></div>
-                        <div>Field Upgradeable:&nbsp;<span>${initialData.TPMSecurityAssertionsFieldUpgradeable}</span></div>
-                        <div>ek Generation Type:&nbsp;<span>${initialData.TPMSecurityAssertionsEkGenType}</span></div>
-                        <div>ek Generation Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkGenLoc}</span></div>
-                        <div>ek Certificate Generation Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkCertGenLoc}</span></div>
+                            <div id="tpmSecurityAssertionInner" class="panel-body collapse" role="tabpanel" aria-expanded="false">
+                                <div>Version:&nbsp;<span>${initialData.TPMSecurityAssertionsVersion}</span></div>
+                                <div>Field Upgradeable:&nbsp;<span>${initialData.TPMSecurityAssertionsFieldUpgradeable}</span></div>
+                                <div>ek Generation Type:&nbsp;<span>${initialData.TPMSecurityAssertionsEkGenType}</span></div>
+                                <div>ek Generation Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkGenLoc}</span></div>
+                                <div>ek Certificate Generation Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkCertGenLoc}</span></div>
+                            </div>
                         </div>
                     </div>
                 </c:when>
                 <c:when test="${param.type=='platform'}">
-                    <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">X509 Credential Version</span></div>
-                        <div id="credentialVersion" class="col col-md-8 vertical">${initialData.x509Version} (v${initialData.x509Version + 1})</div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Credential Type</span></div>
-                        <div id="credentialType" class="col col-md-8">${initialData.credentialType}</div>
-                    </div>
                     <c:if test="${not empty initialData.CPSuri}">
                         <div class="row">
                             <div class="col-md-1 col-md-offset-1"><span class="colHeader">Certification Practice Statement URI</span></div>
-                            <div id="credentialType" class="col col-md-8 vertical">
+                            <div id="certificateCPSU" class="col col-md-8 vertical">
                                 <a href="${initialData.CPSuri}"> ${initialData.CPSuri}</a>
                             </div>
                         </div>
@@ -183,7 +300,7 @@
                         <div class="col-md-1 col-md-offset-1"><span class="colHeader">Holder</span></div>
                         <div id="holder" class="col col-md-8">
                             <c:if test="${not empty initialData.holderIssuer}">
-                                <div><span>${initialData.holderIssuer}</span></div>
+                                <div>EK Certificate:&nbsp;<span>${initialData.holderIssuer}</span></div>
                             </c:if>
                                 <div id="certificateid">
                                     <c:choose>
@@ -202,17 +319,14 @@
                         </div>
                     </div>
                     <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Manufacturer</span></div>
-                        <div id="manufacturer" class="col col-md-8">${initialData.manufacturer}</div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Model</span></div>
-                        <div id="model" class="col col-md-8">${initialData.model}</div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">Version</span></div>
-                        <div id="version" class="col col-md-8">${initialData.version}</div>
-                    </div>
+                        <div class="col-md-1 col-md-offset-1"><span class="colHeader">TPM</span></div>
+                        <div id="subjectAltName" class="col col-md-8">
+                            <div id="manufacturer">Manufacturer:&nbsp;<span>${initialData.manufacturer}</span></div>
+                            <div id="model">Model:&nbsp;<span>${initialData.model}</span></div>
+                            <div id="version">Version:&nbsp;<span>${initialData.version}</span></div>
+                            <div id="serial">Serial NR:&nbsp;<span><!-- optional --></span></div>
+                        </div>                        
+                    </div>                    
                     <c:choose>
                         <c:when test="${fn:contains(initialData.credentialType, 'TCG')}">
                             <div class="row">
@@ -585,6 +699,7 @@
                 var type = "${param.type}";
                 var signature = ${initialData.signature};
                 var serialNumber = '${initialData.serialNumber}';
+                var authorityKeyIdentifier = '${initialData.authKeyId}';
 
                 //Format validity time
                 $("#validity span").each(function(){
@@ -596,6 +711,16 @@
 
                 //Convert byte array to string
                 $("#serialNumber").html(parseSerialNumber(serialNumber));
+                
+                // authority key ID
+                <c:choose>
+                    <c:when test="${not empty initialData.authKeyId}">
+                        $("#authorityKeyIdentifier").html(parseSerialNumber(authorityKeyIdentifier));
+                    </c:when>
+                    <c:otherwise>
+                        $("#authorityKeyIdentifier").html("NOT SPECIFIED");
+                    </c:otherwise>
+                </c:choose>
 
                 <c:if test="${not empty initialData.encodedPublicKey}">
                     //Change publick key byte to hex

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
@@ -181,7 +181,7 @@
                                 <div id="publicKeySizecollapse" class="panel-body collapse" role="tabpanel" aria-expanded="false">
                                     <div>
                                         <span class="fieldValue">
-                                            ${initialData.publicKeyAlgorithm}
+                                            ${initialData.publicKeyAlgorithm} / ${initialData.publicKeySize}
                                         </span>
                                     </div>                                                               
                                 </div>

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
@@ -759,8 +759,8 @@
                 </c:if>
             <c:choose>
                 <c:when test="${not empty initialData.publicKeyValue}">
-                var publicKey = ${initialData.publicKeyValue};
-                $("#encodedPublicKey").html(byteToHexString(publicKey));
+                var publicKey = '${initialData.publicKeyValue}';
+                $("#encodedPublicKey").html(parseHexString(publicKey));
                 </c:when>
                 <c:otherwise>
                     <c:if test="${not empty initialData.encodedPublicKey}">

--- a/HIRS_AttestationCAPortal/src/main/webapp/common/common.js
+++ b/HIRS_AttestationCAPortal/src/main/webapp/common/common.js
@@ -7,6 +7,16 @@ function byteToHexString(arr){
     return (str.substring(0, str.length - 2)).toUpperCase();
 }
 
+//Parse hex string for display
+function parseHexString(hexString) {
+    var str = hexString.toUpperCase();
+    //Do not parse if there is 2 characters
+    if(str.length === 2) {
+        return str;
+    }
+    return str.match(/.{2}/g).join(': ');
+}
+
 //Parse the HEX string value to display as byte hex string
 function parseSerialNumber(hexString){
     var str = hexString.toUpperCase();

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -257,6 +257,7 @@ public abstract class Certificate extends ArchivableEntity {
     private String authorityKeyIdentifier;
     private String authorityInfoAccess;
     private String crlPoints;
+    private int publicKeySize;
 
 
     /**
@@ -287,6 +288,7 @@ public abstract class Certificate extends ArchivableEntity {
         this.authorityInfoAccess = null;
         this.authoritySerialNumber = BigInteger.ZERO;
         this.crlPoints = null;
+        this.publicKeySize = 0;
     }
 
     /**
@@ -342,8 +344,10 @@ public abstract class Certificate extends ArchivableEntity {
                 this.subject = x509Certificate.getSubjectX500Principal().getName();
                 this.encodedPublicKey = x509Certificate.getPublicKey().getEncoded();
                 BigInteger publicKeyModulus = getPublicKeyModulus(x509Certificate);
+
                 if (publicKeyModulus != null) {
                     this.publicKeyModulusHexValue = publicKeyModulus.toString(HEX_BASE);
+                    this.publicKeySize = publicKeyModulus.bitLength();
                 } else {
                     this.publicKeyModulusHexValue = null;
                 }
@@ -387,6 +391,7 @@ public abstract class Certificate extends ArchivableEntity {
                 this.subjectOrganization = null;
                 this.encodedPublicKey = null;
                 this.publicKeyModulusHexValue = null;
+                this.publicKeySize = 0;
 
                 authKeyIdentifier = AuthorityKeyIdentifier
                         .fromExtensions(attCertInfo.getExtensions());
@@ -959,6 +964,14 @@ public abstract class Certificate extends ArchivableEntity {
      */
     public String getSubject() {
         return subject;
+    }
+
+    /**
+     * Getter for the Public Key Size.
+     * @return bit count.
+     */
+    public int getPublicKeySize() {
+        return publicKeySize;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -79,6 +79,7 @@ public abstract class Certificate extends ArchivableEntity {
     private static final String MALFORMED_CERT_MESSAGE = "Malformed certificate detected.";
     private static final int MAX_CERT_LENGTH_BYTES = 2048;
     private static final int MAX_NUMERIC_PRECISION = 49; // Can store up to 160 bit values
+    private static final int MAX_PUB_KEY_MODULUS_HEX_LENGTH = 1024;
     private static final int KEY_USAGE_BIT0 = 0;
     private static final int KEY_USAGE_BIT1 = 1;
     private static final int KEY_USAGE_BIT2 = 2;
@@ -193,8 +194,8 @@ public abstract class Certificate extends ArchivableEntity {
 
     // We're currently seeing 2048-bit keys, which is 512 hex digits.
     // Using a max length of 1024 for future-proofing.
-    @Column(length = MAX_CERT_LENGTH_BYTES, nullable = true)
-    private final byte[] publicKeyModulusHexValue;
+    @Column(length = MAX_PUB_KEY_MODULUS_HEX_LENGTH, nullable = true)
+    private final String publicKeyModulusHexValue;
 
     @Column(length = MAX_CERT_LENGTH_BYTES, nullable = false)
     private final byte[] signature;
@@ -336,7 +337,7 @@ public abstract class Certificate extends ArchivableEntity {
                 this.encodedPublicKey = x509Certificate.getPublicKey().getEncoded();
                 BigInteger publicKeyModulus = getPublicKeyModulus(x509Certificate);
                 if (publicKeyModulus != null) {
-                    this.publicKeyModulusHexValue = publicKeyModulus.toByteArray();
+                    this.publicKeyModulusHexValue = publicKeyModulus.toString(HEX_BASE);
                 } else {
                     this.publicKeyModulusHexValue = null;
                 }
@@ -924,14 +925,10 @@ public abstract class Certificate extends ArchivableEntity {
 
     /**
      * Getter for the hex value.
-     * @return a byte array for the public key
+     * @return a string for the public key
      */
-    public byte[] getPublicKeyModulusHexValue() {
-        if (publicKeyModulusHexValue != null) {
-            return publicKeyModulusHexValue.clone();
-        }
-
-        return new byte[0];
+    public String getPublicKeyModulusHexValue() {
+        return publicKeyModulusHexValue;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -243,7 +243,7 @@ public abstract class Certificate extends ArchivableEntity {
     private final BigInteger authoritySerialNumber;
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // this is not an IP address; PMD thinks it is
-    private static final String POLICY_CONTRAINTS = "2.5.29.36";
+    private static final String POLICY_CONSTRAINTS = "2.5.29.36";
 
     // we don't need to persist this, but we don't want to unpack this cert multiple times
     @Transient
@@ -356,7 +356,7 @@ public abstract class Certificate extends ArchivableEntity {
                 this.issuerOrganization = getOrganization(this.issuer);
                 this.subjectOrganization = getOrganization(this.subject);
                 this.policyConstraints = x509Certificate
-                        .getExtensionValue(POLICY_CONTRAINTS);
+                        .getExtensionValue(POLICY_CONSTRAINTS);
                 authKeyIdentifier = AuthorityKeyIdentifier
                         .getInstance((DLSequence) getExtensionValue(
                                 Extension.authorityKeyIdentifier.getId()));
@@ -435,6 +435,7 @@ public abstract class Certificate extends ArchivableEntity {
         } else {
             this.authoritySerialNumber = BigInteger.ZERO;
         }
+
         this.certificateHash = Arrays.hashCode(this.certificateBytes);
         this.certAndTypeHash = Objects.hash(certificateHash, getClass().getSimpleName());
     }
@@ -684,8 +685,10 @@ public abstract class Certificate extends ArchivableEntity {
     }
 
     /**
+     * Getter for the CRL Distribution that is reference by the Revocation Locator
+     * on the portal.
      *
-     * @return A list of ulrs that inform the location of the certificate revocation lists
+     * @return A list of URLs that inform the location of the certificate revocation lists
      * @throws java.io.IOException
      */
     private String getCRLDistributionPoint() throws IOException {
@@ -912,6 +915,8 @@ public abstract class Certificate extends ArchivableEntity {
     }
 
     /**
+     * Getter the Certificate's Serial Number.
+     *
      * @return this certificate's serial number
      */
     public BigInteger getSerialNumber() {
@@ -919,16 +924,21 @@ public abstract class Certificate extends ArchivableEntity {
     }
 
     /**
+     * Getter for the Authority's Serial Number.
+     *
      * @return this Authority's Key ID serial number.
      */
     public BigInteger getAuthoritySerialNumber() {
-        if (this.authoritySerialNumber != null) {
+        if (authoritySerialNumber != null) {
             return authoritySerialNumber;
         }
+
         return BigInteger.ZERO;
     }
 
     /**
+     * Getter for the Holder's Serial Number.
+     *
      * @return this certificate's holder serial number
      */
     public BigInteger getHolderSerialNumber() {

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -240,7 +240,7 @@ public abstract class Certificate extends ArchivableEntity {
     private final BigInteger holderSerialNumber;
     private String holderIssuer;
     @Column(nullable = true, precision = MAX_NUMERIC_PRECISION, scale = 0)
-    private final BigInteger authoritySerialNumber;
+    private BigInteger authoritySerialNumber;
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // this is not an IP address; PMD thinks it is
     private static final String POLICY_CONSTRAINTS = "2.5.29.36";
@@ -432,8 +432,6 @@ public abstract class Certificate extends ArchivableEntity {
         if (authKeyIdentifier != null) {
             this.authorityKeyIdentifier = authKeyIdentifierToString(authKeyIdentifier);
             this.authoritySerialNumber = authKeyIdentifier.getAuthorityCertSerialNumber();
-        } else {
-            this.authoritySerialNumber = BigInteger.ZERO;
         }
 
         this.certificateHash = Arrays.hashCode(this.certificateBytes);
@@ -929,11 +927,7 @@ public abstract class Certificate extends ArchivableEntity {
      * @return this Authority's Key ID serial number.
      */
     public BigInteger getAuthoritySerialNumber() {
-        if (authoritySerialNumber != null) {
-            return authoritySerialNumber;
-        }
-
-        return BigInteger.ZERO;
+        return authoritySerialNumber;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -26,6 +26,14 @@ import org.bouncycastle.util.encoders.Base64;
 import org.bouncycastle.asn1.ASN1GeneralizedTime;
 import org.bouncycastle.asn1.ASN1Object;
 import org.bouncycastle.asn1.DERTaggedObject;
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.DERIA5String;
+import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.asn1.DLSequence;
+import org.bouncycastle.asn1.x509.AccessDescription;
+import org.bouncycastle.asn1.x509.AuthorityInformationAccess;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.x509.extension.X509ExtensionUtil;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -46,6 +54,7 @@ import java.security.SignatureException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.security.cert.CertificateParsingException;
 import java.security.cert.X509Certificate;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -70,6 +79,31 @@ public abstract class Certificate extends ArchivableEntity {
     private static final int MAX_CERT_LENGTH_BYTES = 2048;
     private static final int MAX_NUMERIC_PRECISION = 49; // Can store up to 160 bit values
     private static final int MAX_PUB_KEY_MODULUS_HEX_LENGTH = 1024;
+    private static final int KEY_USAGE_BIT0 = 0;
+    private static final int KEY_USAGE_BIT1 = 1;
+    private static final int KEY_USAGE_BIT2 = 2;
+    private static final int KEY_USAGE_BIT3 = 3;
+    private static final int KEY_USAGE_BIT4 = 4;
+    private static final int KEY_USAGE_BIT5 = 5;
+    private static final int KEY_USAGE_BIT6 = 6;
+    private static final int KEY_USAGE_BIT7 = 7;
+    private static final int KEY_USAGE_BIT8 = 8;
+    private static final String KEY_USAGE_DS = "DIGITAL SIGNATURE";
+    private static final String KEY_USAGE_NR = "NON-REPUDIATION";
+    private static final String KEY_USAGE_KE = "KEY ENCIPHERMENT";
+    private static final String KEY_USAGE_DE = "DATA ENCIPHERMENT";
+    private static final String KEY_USAGE_KA = "KEY AGREEMENT";
+    private static final String KEY_USAGE_KC = "KEY CERT SIGN";
+    private static final String KEY_USAGE_CS = "CRL SIGN";
+    private static final String KEY_USAGE_EO = "ENCIPHER ONLY";
+    private static final String KEY_USAGE_DO = "DECIPHER ONLY";
+    private static final String ECDSA_OID = "1.2.840.10045.4.3.2";
+    private static final String RSA256_OID = "1.2.840.113549.1.1.11";
+    private static final String RSA384_OID = "1.2.840.113549.1.1.12";
+    private static final String RSA512_OID = "1.2.840.113549.1.1.13";
+    private static final String RSA224_OID = "1.2.840.113549.1.1.14";
+    private static final String RSA256_STRING = "SHA256WithRSA";
+    private static final String ECDSA_STRING = "SHA256WithECDSA";
 
     private static final Logger LOGGER = LogManager.getLogger(Certificate.class);
 
@@ -196,13 +230,28 @@ public abstract class Certificate extends ArchivableEntity {
      * Holds the name of the 'holderSerialNumber' field.
      */
     public static final String HOLDER_SERIAL_NUMBER_FIELD = "holderSerialNumber";
+
     @Column(nullable = false, precision = MAX_NUMERIC_PRECISION, scale = 0)
     private final BigInteger holderSerialNumber;
     private String holderIssuer;
 
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // this is not an IP address; PMD thinks it is
+    private static final String AUTHORITY_KEY_IDENTIFIER = "2.5.29.35";
+    private static final String AUTHORITY_INFO_ACCESS = "1.3.6.1.5.5.7.1.1";
+    @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // this is not an IP address; PMD thinks it is
+    private static final String POLICY_CONTRAINTS = "2.5.29.36";
+
     // we don't need to persist this, but we don't want to unpack this cert multiple times
     @Transient
     private X509Certificate parsedX509Cert = null;
+
+    private String signatureAlgorithm;
+    private String publicKeyAlgorithm;
+    private String keyUsage;
+    private String extendedKeyUsage;
+    private byte[] policyConstraints;
+    private String authorityKeyIdentifier;
+    private String authorityInfoAccess;
 
 
     /**
@@ -224,6 +273,13 @@ public abstract class Certificate extends ArchivableEntity {
         this.certAndTypeHash = 0;
         this.holderSerialNumber = BigInteger.ZERO;
         this.holderIssuer = null;
+        this.publicKeyAlgorithm = null;
+        this.signatureAlgorithm = null;
+        this.keyUsage = null;
+        this.extendedKeyUsage = null;
+        this.policyConstraints = null;
+        this.authorityKeyIdentifier = null;
+        this.authorityInfoAccess = null;
     }
 
     /**
@@ -283,12 +339,31 @@ public abstract class Certificate extends ArchivableEntity {
                 } else {
                     this.publicKeyModulusHexValue = null;
                 }
+                this.publicKeyAlgorithm = x509Certificate.getPublicKey().getAlgorithm();
+                this.signatureAlgorithm = x509Certificate.getSigAlgName();
                 this.signature = x509Certificate.getSignature();
                 this.beginValidity = x509Certificate.getNotBefore();
                 this.endValidity = x509Certificate.getNotAfter();
                 this.holderSerialNumber = BigInteger.ZERO;
                 this.issuerOrganization = getOrganization(this.issuer);
                 this.subjectOrganization = getOrganization(this.subject);
+                this.policyConstraints = x509Certificate
+                        .getExtensionValue(POLICY_CONTRAINTS);
+                this.authorityKeyIdentifier = getAuthorityKeyIdentifier();
+                this.authorityInfoAccess = getAuthorityInfoAccess();
+                this.keyUsage = parseKeyUsage(x509Certificate.getKeyUsage());
+                
+                try {
+                    if (x509Certificate.getExtendedKeyUsage() != null) {
+                        StringBuilder sb = new StringBuilder();
+                        for (String s : x509Certificate.getExtendedKeyUsage()) {
+                            sb.append(String.format("%s%n", s));
+                        }
+                        this.extendedKeyUsage = sb.toString();
+                    }
+                } catch (CertificateParsingException ex) {
+                    // do nothing
+                }
                 break;
 
             case ATTRIBUTE_CERTIFICATE:
@@ -300,6 +375,17 @@ public abstract class Certificate extends ArchivableEntity {
                 this.subjectOrganization = null;
                 this.encodedPublicKey = null;
                 this.publicKeyModulusHexValue = null;
+
+                switch (attCert.getSignatureAlgorithm().getAlgorithm().getId()) {
+                    case RSA256_OID:
+                        this.signatureAlgorithm = RSA256_STRING;
+                        break;
+                    case ECDSA_OID:
+                        this.signatureAlgorithm = ECDSA_STRING;
+                        break;
+                    default:
+                        break;
+                }
 
                 // Get attribute certificate information
                 this.serialNumber = attCertInfo.getSerialNumber().getValue();
@@ -441,6 +527,164 @@ public abstract class Certificate extends ArchivableEntity {
         return possiblePEM.contains(PEM_HEADER) || possiblePEM.contains(PEM_ATTRIBUTE_HEADER);
     }
 
+    private String parseKeyUsage(final boolean[] bools) {
+        StringBuilder sb = new StringBuilder();
+
+        if (bools != null) {
+            for (int i = 0; i < bools.length; i++) {
+                if (bools[i]) {
+                    sb.append(getKeyUsageString(i));
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * Return the string associated with the boolean slot.
+     * @param bit associated with the location in the array.
+     * @return string value of the bit set.
+     */
+    private String getKeyUsageString(final int bit) {
+        String tempStr = "";
+
+        switch (bit) {
+            case KEY_USAGE_BIT0:
+                tempStr = String.format("%s%n", KEY_USAGE_DS);
+                break;
+            case KEY_USAGE_BIT1:
+                tempStr = String.format("%s%n", KEY_USAGE_NR);
+                break;
+            case KEY_USAGE_BIT2:
+                tempStr = String.format("%s%n", KEY_USAGE_KE);
+                break;
+            case KEY_USAGE_BIT3:
+                tempStr = String.format("%s%n", KEY_USAGE_DE);
+                break;
+            case KEY_USAGE_BIT4:
+                tempStr = String.format("%s%n", KEY_USAGE_KA);
+                break;
+            case KEY_USAGE_BIT5:
+                tempStr = String.format("%s%n", KEY_USAGE_KC);
+                break;
+            case KEY_USAGE_BIT6:
+                tempStr = String.format("%s%n", KEY_USAGE_CS);
+                break;
+            case KEY_USAGE_BIT7:
+                tempStr = String.format("%s%n", KEY_USAGE_EO);
+                break;
+            case KEY_USAGE_BIT8:
+                tempStr = String.format("%s%n", KEY_USAGE_DO);
+                break;
+            default:
+                break;
+        }
+
+        return tempStr;
+    }
+
+    /**
+     * Gets the contents of requested OID.
+     *
+     * @param oid Object Identifier
+     * @return ASN1Primitive Content related to the requested OID
+     * @throws java.io.IOException
+     */
+    private ASN1Primitive getExtensionValue(final String oid) throws IOException {
+        byte[] extensionValue = getX509Certificate().getExtensionValue(oid);
+        ASN1Primitive asn1Primitive = null;
+        ASN1InputStream asn1InputStream = null;
+
+        if (extensionValue != null) {
+            try {
+                asn1InputStream = new ASN1InputStream(extensionValue);
+                DEROctetString oct = (DEROctetString) asn1InputStream.readObject();
+                asn1InputStream.close();
+                asn1InputStream = new ASN1InputStream(oct.getOctets());
+                asn1Primitive = asn1InputStream.readObject();
+            } catch (IOException ioEx) {
+                LOGGER.error(ioEx);
+            } finally {
+                if (asn1InputStream != null) {
+                    asn1InputStream.close();
+                }
+            }
+        }
+
+        return asn1Primitive;
+    }
+
+    /**
+     * Getter for the AuthorityInfoAccess extension value on list format.
+     *
+     * @return List Authority info access list
+     */
+    private String getAuthorityInfoAccess() {
+        StringBuilder sb = new StringBuilder();
+
+        try {
+            byte[] authAccess = getX509Certificate().getExtensionValue(
+                    Extension.authorityInfoAccess.getId());
+            if (authAccess != null && authAccess.length > 0) {
+                AuthorityInformationAccess authInfoAccess = AuthorityInformationAccess
+                        .getInstance(X509ExtensionUtil.fromExtensionValue(authAccess));
+                for (AccessDescription desc : authInfoAccess.getAccessDescriptions()) {
+                    if (desc.getAccessLocation().getTagNo() == GeneralName
+                            .uniformResourceIdentifier) {
+                        sb.append(String.format("%s%n", ((DERIA5String) desc
+                                .getAccessLocation()
+                                .getName())
+                                .getString()));
+                    }
+                }
+            }
+        } catch (IOException ioEx) {
+            LOGGER.error(ioEx);
+        }
+
+        return sb.toString();
+    }
+
+
+    /**
+     * Getter for the AuthorityKeyIdentier associated with the certificate.
+     *
+     * @return the authority key identifier
+     * @throws java.io.IOException
+     */
+    private String getAuthorityKeyIdentifier() throws IOException {
+        DLSequence sequence = (DLSequence) getExtensionValue(Extension
+                .authorityKeyIdentifier.getId());
+        if (sequence == null || sequence.size() == 0) {
+            return "";
+        }
+
+        DERTaggedObject taggedObject = (DERTaggedObject) sequence.getObjectAt(0);
+
+        String tempStr = taggedObject.getObject().toString();
+        if (tempStr.startsWith("#")) {
+            return tempStr.replaceFirst("#", "");
+        }
+
+        return tempStr;
+    }
+
+    /**
+     * Getter for the x509 Platform Certificate version.
+     * @return a big integer representing the certificate version. If there
+     * is an error, return the max value to visible show error.
+     */
+    public int getX509CredentialVersion() {
+        try {
+            return getX509Certificate().getVersion() - 1;
+        } catch (IOException ex) {
+            LOGGER.warn("X509 Credential Version not found.");
+            LOGGER.error(ex);
+            return Integer.MAX_VALUE;
+        }
+    }
+
     /**
      * Checks if another certificate is the issuer for this certificate.
      *
@@ -548,6 +792,66 @@ public abstract class Certificate extends ArchivableEntity {
     }
 
     /**
+     * Getter for the Authority Info Access List.
+     * @return return a list of Info Access
+     */
+    public String getAuthInfoAccess() {
+        return authorityInfoAccess;
+    }
+
+    /**
+     * Getter for the authorityKeyIdentifier.
+     * @return the ID String
+     */
+    public String getAuthKeyId() {
+        return authorityKeyIdentifier;
+    }
+
+    /**
+     * Getter for the policy statement.
+     * @return cloned bit representation of constraints
+     */
+    public byte[] getPolicyConstraints() {
+        if (policyConstraints != null) {
+            return policyConstraints.clone();
+        }
+
+        return new byte[0];
+    }
+
+    /**
+     * Getter for the keyUsage info.
+     * @return key usages
+     */
+    public String getKeyUsage() {
+        return keyUsage;
+    }
+
+    /**
+     * Getter for the extended key info.
+     * @return extended key usages
+     */
+    public String getExtendedKeyUsage() {
+        return extendedKeyUsage;
+    }
+
+    /**
+     * Getter for the algorithm.
+     * @return algorithm for the signature
+     */
+    public String getSignatureAlgorithm() {
+        return signatureAlgorithm;
+    }
+
+    /**
+     * Getter for the public key algorithm.
+     * @return  public key algorithm
+     */
+    public String getPublicKeyAlgorithm() {
+        return publicKeyAlgorithm;
+    }
+
+    /**
      * @return this certificate's serial number
      */
     public BigInteger getSerialNumber() {
@@ -592,6 +896,14 @@ public abstract class Certificate extends ArchivableEntity {
         } else {
             return encodedPublicKey.clone();
         }
+    }
+
+    /**
+     * Getter for the hex value as a string.
+     * @return a string for the public key
+     */
+    public String getPublicKeyModulusHexValue() {
+        return publicKeyModulusHexValue;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -240,7 +240,7 @@ public abstract class Certificate extends ArchivableEntity {
     private final BigInteger holderSerialNumber;
     private String holderIssuer;
     @Column(nullable = true, precision = MAX_NUMERIC_PRECISION, scale = 0)
-    private BigInteger authoritySerialNumber;
+    private final BigInteger authoritySerialNumber;
 
     @SuppressWarnings("PMD.AvoidUsingHardCodedIP") // this is not an IP address; PMD thinks it is
     private static final String POLICY_CONSTRAINTS = "2.5.29.36";
@@ -434,9 +434,16 @@ public abstract class Certificate extends ArchivableEntity {
                 throw new IllegalArgumentException("Cannot recognize certificate type.");
         }
 
+        BigInteger authSerialNumber = null;
         if (authKeyIdentifier != null) {
             this.authorityKeyIdentifier = authKeyIdentifierToString(authKeyIdentifier);
-            this.authoritySerialNumber = authKeyIdentifier.getAuthorityCertSerialNumber();
+            authSerialNumber = authKeyIdentifier.getAuthorityCertSerialNumber();
+        }
+
+        if (authSerialNumber != null) {
+            this.authoritySerialNumber = authSerialNumber;
+        } else {
+            this.authoritySerialNumber = BigInteger.ZERO;
         }
 
         this.certificateHash = Arrays.hashCode(this.certificateBytes);

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -352,7 +352,7 @@ public abstract class Certificate extends ArchivableEntity {
                 this.authorityKeyIdentifier = getAuthorityKeyIdentifier();
                 this.authorityInfoAccess = getAuthorityInfoAccess();
                 this.keyUsage = parseKeyUsage(x509Certificate.getKeyUsage());
-                
+
                 try {
                     if (x509Certificate.getExtendedKeyUsage() != null) {
                         StringBuilder sb = new StringBuilder();

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -351,13 +351,8 @@ public abstract class Certificate extends ArchivableEntity {
                         .getExtensionValue(POLICY_CONTRAINTS);
                 this.authorityKeyIdentifier = getAuthorityKeyIdentifier();
                 this.authorityInfoAccess = getAuthorityInfoAccess();
-<<<<<<< HEAD
                 this.keyUsage = parseKeyUsage(x509Certificate.getKeyUsage());
 
-=======
-
-                this.keyUsage = parseKeyUsage(x509Certificate.getKeyUsage());
->>>>>>> b349a3baa765b041db8b6ce7091e4772bc078384
                 try {
                     if (x509Certificate.getExtendedKeyUsage() != null) {
                         StringBuilder sb = new StringBuilder();
@@ -632,16 +627,9 @@ public abstract class Certificate extends ArchivableEntity {
             byte[] authAccess = getX509Certificate().getExtensionValue(
                     Extension.authorityInfoAccess.getId());
             if (authAccess != null && authAccess.length > 0) {
-<<<<<<< HEAD
                 AuthorityInformationAccess authInfoAccess = AuthorityInformationAccess
                         .getInstance(X509ExtensionUtil.fromExtensionValue(authAccess));
                 for (AccessDescription desc : authInfoAccess.getAccessDescriptions()) {
-=======
-                AuthorityInformationAccess infoAccess = AuthorityInformationAccess
-                        .getInstance(X509ExtensionUtil
-                        .fromExtensionValue(authAccess));
-                for (AccessDescription desc : infoAccess.getAccessDescriptions()) {
->>>>>>> b349a3baa765b041db8b6ce7091e4772bc078384
                     if (desc.getAccessLocation().getTagNo() == GeneralName
                             .uniformResourceIdentifier) {
                         sb.append(String.format("%s%n", ((DERIA5String) desc
@@ -653,10 +641,6 @@ public abstract class Certificate extends ArchivableEntity {
             }
         } catch (IOException ioEx) {
             LOGGER.error(ioEx);
-<<<<<<< HEAD
-=======
-            return "";
->>>>>>> b349a3baa765b041db8b6ce7091e4772bc078384
         }
 
         return sb.toString();
@@ -687,14 +671,9 @@ public abstract class Certificate extends ArchivableEntity {
     }
 
     /**
-<<<<<<< HEAD
      * Getter for the x509 Platform Certificate version.
      * @return a big integer representing the certificate version. If there
      * is an error, return the max value to visible show error.
-=======
-     * Get the x509 Platform Certificate version.
-     * @return a big integer representing the certificate version.
->>>>>>> b349a3baa765b041db8b6ce7091e4772bc078384
      */
     public int getX509CredentialVersion() {
         try {

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/CertificateAuthorityCredential.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/CertificateAuthorityCredential.java
@@ -26,6 +26,13 @@ public class CertificateAuthorityCredential extends Certificate {
     @Column
     private final byte[] subjectKeyIdentifier;
 
+    /*
+     * this field is part of the TCG CA specification, but has not yet been found in
+     * manufacturer-provided CAs, and is therefore not currently parsed
+     */
+    @Column
+    private String credentialType = "TCPA Trusted Platform Module Endorsement";
+
     /**
      * This class enables the retrieval of CertificateAuthorityCredentials by their attributes.
      */
@@ -99,6 +106,15 @@ public class CertificateAuthorityCredential extends Certificate {
         subjectKeyIdentifier = null;
     }
 
+
+    /**
+     * Get the credential type label.
+     * @return the credential type label.
+     */
+    public String getCredentialType() {
+        return credentialType;
+    }
+
     /**
      * @return this certificate's subject key identifier.
      */
@@ -110,6 +126,7 @@ public class CertificateAuthorityCredential extends Certificate {
     }
 
     @Override
+    @SuppressWarnings("checkstyle:avoidinlineconditionals")
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -123,13 +140,19 @@ public class CertificateAuthorityCredential extends Certificate {
 
         CertificateAuthorityCredential that = (CertificateAuthorityCredential) o;
 
+        if (this.credentialType != null ? !credentialType.equals(that.credentialType)
+                : that.credentialType != null) {
+            return false;
+        }
+
         return Arrays.equals(subjectKeyIdentifier, that.subjectKeyIdentifier);
     }
 
     @Override
-    @SuppressWarnings("checkstyle:magicnumber")
+    @SuppressWarnings({"checkstyle:magicnumber", "checkstyle:avoidinlineconditionals"})
     public int hashCode() {
         int result = super.hashCode();
+        result = 31 * result + (credentialType != null ? credentialType.hashCode() : 0);
         result = 31 * result + Arrays.hashCode(subjectKeyIdentifier);
         return result;
     }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/PlatformCredential.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/PlatformCredential.java
@@ -74,7 +74,10 @@ public class PlatformCredential extends DeviceAssociatedCertificate {
     private static final String PLATFORM_CONFIGURATION = "2.23.133.5.1.7.1";
     private static final String PLATFORM_CONFIGURATION_V2 = "2.23.133.5.1.7.2";
 
-    //TCG Platform Specification values
+    /**
+     * TCG Platform Specification values
+     * At this time these are placeholder values.
+     */
     private static final Map<String, String> TCG_PLATFORM_MAP = new HashMap<String, String>() {{
         put("#00000000", "Client");
         put("#00000001", "Server");
@@ -401,11 +404,7 @@ public class PlatformCredential extends DeviceAssociatedCertificate {
      * @return the platform specification platform class
      */
     public String getPlatformClass() {
-        if (platformClass != null && !platformClass.isEmpty()) {
-            return TCG_PLATFORM_MAP.get(platformClass);
-        } else {
-            return platformClass;
-        }
+        return TCG_PLATFORM_MAP.get(platformClass);
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentIdentifier.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentIdentifier.java
@@ -112,8 +112,7 @@ public class ComponentIdentifier {
                     .getObjectAt(COMPONENT_IDENTIFIER))
                     .toString();
         } else if (sequence.getObjectAt(tag) instanceof DEROctetString) {
-            componentClass = sequence.getObjectAt(tag).toString();
-            tag++;
+            componentClass = sequence.getObjectAt(tag++).toString();
         }
 
         //Mandatory values

--- a/HIRS_Utils/src/test/java/hirs/data/persist/certificate/PlatformCredentialTest.java
+++ b/HIRS_Utils/src/test/java/hirs/data/persist/certificate/PlatformCredentialTest.java
@@ -220,7 +220,7 @@ public class PlatformCredentialTest {
         Assert.assertEquals(credential.getMajorVersion(), 1);
         Assert.assertEquals(credential.getMinorVersion(), 2);
         Assert.assertEquals(credential.getRevisionLevel(), 1);
-        Assert.assertEquals(credential.getPlatformClass(), "1");
+        Assert.assertEquals(credential.getPlatformClass(), null);
     }
 
     /**
@@ -269,7 +269,7 @@ public class PlatformCredentialTest {
         Assert.assertEquals(credential.getMajorVersion(), 1);
         Assert.assertEquals(credential.getMinorVersion(), 2);
         Assert.assertEquals(credential.getRevisionLevel(), 1);
-        Assert.assertEquals(credential.getPlatformClass(), "1");
+        Assert.assertEquals(credential.getPlatformClass(), null);
     }
 
     /**


### PR DESCRIPTION
In addition to the added fields in #43, I have placed some additional spec defined 'behaviors' on new and present fields.  If a field is a 'must' and 'critical' but has no listed information 'NOT SPECIFIED' is displayed.  If it is 'should' or 'may', the field is hidden instead.

Also, some fields were combined.  Some where made into button panels and some of them have been defaulted to collapsed on certificate details page.

Closes #43 