### PR TITLE
[#55] Add displayTitle to Alert

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/data/persist/Alert.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/Alert.java
@@ -45,6 +45,9 @@ public class Alert extends ArchivableEntity {
     @Column(name = "device_name")
     private String deviceName;
 
+    @Column(name = "display_title", nullable = true)
+    private String displayTitle;
+
     @Column(name = "details")
     private String details;
 
@@ -348,6 +351,24 @@ public class Alert extends ArchivableEntity {
      */
     public final void setDeviceName(final String deviceName) {
         this.deviceName = deviceName;
+    }
+
+    /**
+     * Get the display title associated with this Alert.
+     *
+     * @return the display title if one has been set, and null otherwise
+     */
+    public String getDisplayTitle() {
+        return displayTitle;
+    }
+
+    /**
+     * Set the display title for this alert.
+     *
+     * @param displayTitle the desired display title (may be null)
+     */
+    public void setDisplayTitle(final String displayTitle) {
+        this.displayTitle = displayTitle;
     }
 
     /**

--- a/HIRS_Utils/src/test/java/hirs/data/persist/AlertTest.java
+++ b/HIRS_Utils/src/test/java/hirs/data/persist/AlertTest.java
@@ -19,6 +19,7 @@ public final class AlertTest {
     private static final String TEST_DEVICE_NAME = "MyTestDevice";
     private static final String RESOLVE_DESCRIPTION = "Record was added to baseline";
     private static final String TEST_BASELINE_NAME = "Alert Test Baseline";
+    private static final String TEST_DISPLAY_TITLE = "Display Title";
 
      /**
      * Tests that default values are applied by the public Alert constructor.
@@ -29,6 +30,7 @@ public final class AlertTest {
         Assert.assertEquals(alert.getSeverity(), Alert.Severity.UNSPECIFIED);
         Assert.assertEquals(alert.getType(), Alert.AlertType.UNSPECIFIED);
         Assert.assertEquals(alert.getSource(), Alert.Source.UNSPECIFIED);
+        Assert.assertNull(alert.getDisplayTitle());
     }
 
     /**
@@ -48,6 +50,16 @@ public final class AlertTest {
     public void testDetails() {
         Alert alert = new Alert(TEST_DETAILS);
         Assert.assertEquals(alert.getDetails(), TEST_DETAILS);
+    }
+
+    /**
+     * Test that the details can be set and retrieved.
+     */
+    @Test
+    public void testDisplayTitle() {
+        Alert alert = new Alert(TEST_DETAILS);
+        alert.setDisplayTitle(TEST_DISPLAY_TITLE);
+        Assert.assertEquals(alert.getDisplayTitle(), TEST_DISPLAY_TITLE);
     }
 
     /**


### PR DESCRIPTION
These changes simply add a field called 'displayTitle' to the Alert class to hold a human-readable title for each Alert instance.

Closes #55.