### PR TITLE
[#58] Modify while loop condition to read all lines

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/data/persist/TPMBaseline.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/TPMBaseline.java
@@ -23,6 +23,7 @@ import java.util.Set;
 public abstract class TPMBaseline extends Baseline {
 
     private static final Logger LOGGER = LogManager.getLogger(TPMBaseline.class);
+    private static final String NOT_SPECIFIED = "Not Specified";
 
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "TPMBaselineRecords",
@@ -272,5 +273,35 @@ public abstract class TPMBaseline extends Baseline {
         }
 
         return pcrRecords.remove(record);
+    }
+
+    /**
+     * Checks the properties of FirmwareInfo, HardwareInfo, OSInfo, and TPMInfo and the contents of
+     * pcrRecords to determine if this instance of TPMBaseline is empty or not.
+     *
+     * @return true if baseline has no data
+     */
+    public boolean isEmpty() {
+        LOGGER.debug("Check for empty baseline");
+        return (firmwareInfo.getBiosReleaseDate().equals(NOT_SPECIFIED)
+                && firmwareInfo.getBiosVendor().equals(NOT_SPECIFIED)
+                && firmwareInfo.getBiosVersion().equals(NOT_SPECIFIED)
+                && hardwareInfo.getBaseboardSerialNumber().equals(NOT_SPECIFIED)
+                && hardwareInfo.getChassisSerialNumber().equals(NOT_SPECIFIED)
+                && hardwareInfo.getManufacturer().equals(NOT_SPECIFIED)
+                && hardwareInfo.getProductName().equals(NOT_SPECIFIED)
+                && hardwareInfo.getSystemSerialNumber().equals(NOT_SPECIFIED)
+                && hardwareInfo.getVersion().equals(NOT_SPECIFIED)
+                && osInfo.getDistribution().equals(NOT_SPECIFIED)
+                && osInfo.getDistributionRelease().equals(NOT_SPECIFIED)
+                && osInfo.getOSArch().equals(NOT_SPECIFIED)
+                && osInfo.getOSName().equals(NOT_SPECIFIED)
+                && osInfo.getOSVersion().equals(NOT_SPECIFIED)
+                && tpmInfo.getTPMMake().equals(NOT_SPECIFIED)
+                && tpmInfo.getTPMVersionMajor() == 0
+                && tpmInfo.getTPMVersionMinor() == 0
+                && tpmInfo.getTPMVersionRevMajor() == 0
+                && tpmInfo.getTPMVersionRevMinor() == 0
+                && pcrRecords.isEmpty());
     }
 }

--- a/HIRS_Utils/src/test/java/hirs/data/persist/TPMBaselineTest.java
+++ b/HIRS_Utils/src/test/java/hirs/data/persist/TPMBaselineTest.java
@@ -623,6 +623,24 @@ public class TPMBaselineTest extends SpringPersistenceTest {
         Assert.assertEquals(baseline.getTPMInfo(), tpmInfo);
     }
 
+    /**
+     * Verify that a baseline with valid data returns false from isEmpty().
+     */
+    @Test
+    public final void testIsEmptyFalse() {
+        final TpmWhiteListBaseline baseline = getDefaultWhiteListBaseline();
+        Assert.assertFalse(baseline.isEmpty());
+    }
+
+    /**
+     * Verify that a baseline with no data returns true from isEmpty().
+     */
+    @Test
+    public final void testIsEmptyTrue() {
+        final TpmWhiteListBaseline baseline = new TpmWhiteListBaseline();
+        Assert.assertTrue(baseline.isEmpty());
+    }
+
     private TpmWhiteListBaseline getDefaultWhiteListBaseline() {
         final int pcr0 = 0;
         TpmWhiteListBaseline baseline = new TpmWhiteListBaseline("TestTpmWhiteListBaseline");

--- a/HIRS_Utils/src/test/java/hirs/tpm/TPMBaselineGeneratorTest.java
+++ b/HIRS_Utils/src/test/java/hirs/tpm/TPMBaselineGeneratorTest.java
@@ -88,6 +88,7 @@ public class TPMBaselineGeneratorTest {
      *             if error encountered when retrieving measurement entries from
      *             input stream
      */
+    @Test
     public final void generateBaselineFromCSVFileNullBaselineName()
             throws IOException, ParseException, TPMBaselineGeneratorException {
         Exception expectedEx = null;
@@ -131,6 +132,7 @@ public class TPMBaselineGeneratorTest {
      * @throws ParseException
      *             if error encountered parsing data
      */
+    @Test
     public final void generateBaselineFromCSVFileContainsNoRecords()
             throws IOException, ParseException {
         Exception expectedEx = null;
@@ -187,6 +189,7 @@ public class TPMBaselineGeneratorTest {
      * @throws ParseException
      *             if error encountered parsing data
      */
+    @Test
     public final void generateBaselineFromCSVFileContainsInvalidRecords()
             throws IOException, ParseException {
         Exception expectedEx = null;


### PR DESCRIPTION
TPM Baselines (whitelist and blacklist) that were created via csv file upload were observed to be consistently missing exactly one record.

The cause was the while() loop condition in TPMBaselineGenerator.parseBaseline().  The BufferedReader.ready() function that governed the loop only reports on the availability of the underlying stream for reading, not the content of that stream.  By calling reader.readLine() at the end of each iteration the loop would exit after reading the last line of a file but before processing and adding it to the baseline object.  Checking reader.readLine() directly to govern the while loop avoids this problem.

Closes #58 