### PR TITLE
Add selector for Endorsement Credential and Platform Credential Deletion

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/EndorsementCredential.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/EndorsementCredential.java
@@ -52,6 +52,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  *
@@ -144,6 +145,18 @@ public class EndorsementCredential extends DeviceAssociatedCertificate {
          */
         public Selector byVersion(final String version) {
             setFieldValue(VERSION_FIELD, version);
+            return this;
+        }
+
+        /**
+         * Specify a device id that certificates must have to be considered
+         * as matching.
+         *
+         * @param device the device id to query
+         * @return this instance (for chaining further calls)
+         */
+        public Selector byDeviceId(final UUID device) {
+            setFieldValue(DEVICE_ID_FIELD, device);
             return this;
         }
     }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/PlatformCredential.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/PlatformCredential.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Transient;
@@ -148,6 +149,18 @@ public class PlatformCredential extends DeviceAssociatedCertificate {
          */
         public Selector byChassisSerialNumber(final String chassisSerialNumber) {
             setFieldValue(CHASSIS_SERIAL_NUMBER_FIELD, chassisSerialNumber);
+            return this;
+        }
+
+        /**
+         * Specify a device id that certificates must have to be considered
+         * as matching.
+         *
+         * @param device the device id to query
+         * @return this instance (for chaining further calls)
+         */
+        public Selector byDeviceId(final UUID device) {
+            setFieldValue(DEVICE_ID_FIELD, device);
             return this;
         }
     }


### PR DESCRIPTION
Adds a selector method to retrieve ECs and PCs by their associated device
so they can be deleted.