### PR TITLE
Fix Style Issue in Build

### DIFF
--- a/HIRS_ProvisionerTPM2/src/Tpm2ToolsUtils.cpp
+++ b/HIRS_ProvisionerTPM2/src/Tpm2ToolsUtils.cpp
@@ -63,7 +63,7 @@ Tpm2ToolsVersion Tpm2ToolsVersionChecker::findTpm2ToolsVersion() {
             try {
                 return kVersionMap.at(version);
             }
-            catch (const out_of_range& oor) {
+            catch (const out_of_range& outOfRange) {
                 // If no version found, version is unsupported, throw exception
                 stringstream ss;
                 ss << "Unsupported Tpm2 Tools Version Detected: " << version;

--- a/HIRS_ProvisionerTPM2/src/Utils.cpp
+++ b/HIRS_ProvisionerTPM2/src/Utils.cpp
@@ -86,7 +86,6 @@ namespace file_utils {
         stringstream ss;
         ifstream t(filename);
         if (!t.good()) {
-            stringstream ss;
             ss << "Unable to open file: " << filename;
             throw HirsRuntimeException(ss.str(),
                                        "Utils.cpp::file_utils::fileToString");


### PR DESCRIPTION
A couple of variables had conflicting names and the inner scope was
shadowing the outer. Style checker was complaining. Deleted one inner
definition and renamed another variable.