### PR TITLE
[#78] hirs-provisioner-tpm2 on path after installation.

### DIFF
--- a/.ci/docker/Dockerfile.centos7
+++ b/.ci/docker/Dockerfile.centos7
@@ -4,7 +4,7 @@ MAINTAINER apl.dev3@jhuapl.edu
 
 # Install packages for building HIRS
 RUN yum -y update && yum clean all
-RUN yum install -y java-1.8.0-openjdk-devel protobuf-compiler rpm-build epel-release cmake make git gcc-c++ doxygen graphviz python libssh2-devel openssl protobuf-devel tpm2-tss-devel trousers-devel
+RUN yum install -y java-1.8.0-openjdk-devel protobuf-compiler rpm-build epel-release cmake make git gcc-c++ doxygen graphviz python libssh2-devel openssl protobuf-devel tpm2-tss-devel trousers-devel libcurl-devel
 RUN yum install -y cppcheck log4cplus-devel re2-devel
 
 # Set Environment Variables

--- a/.ci/docker/Dockerfile.ubuntu18
+++ b/.ci/docker/Dockerfile.ubuntu18
@@ -4,7 +4,7 @@ MAINTAINER apl.dev3@jhuapl.edu
 
 # Install packages for building HIRS
 RUN apt-get update -y && apt-get upgrade -y && apt-get clean -y
-RUN apt-get -y install openjdk-8-jdk protobuf-compiler build-essential devscripts lintian debhelper cmake make git g++ doxygen graphviz cppcheck liblog4cplus-dev libssl-dev libprotobuf-dev libre2-dev libsapi-dev trousers libtspi-dev
+RUN apt-get -y install openjdk-8-jdk protobuf-compiler build-essential devscripts lintian debhelper cmake make git g++ doxygen graphviz cppcheck liblog4cplus-dev libssl-dev libprotobuf-dev libre2-dev libsapi-dev trousers libtspi-dev libcurl4-openssl-dev
 
 # Set Environment Variables
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64

--- a/HIRS_ProvisionerTPM2/CMakeLists.txt
+++ b/HIRS_ProvisionerTPM2/CMakeLists.txt
@@ -110,7 +110,8 @@ configure_file ("${CMAKE_SOURCE_DIR}/include/Tss.h.in"
 # Download necessary 3rd party libraries
 # Setup for CPR
 configure_file(lib/CPR.CMakeLists.txt.in ${CMAKE_BINARY_DIR}/lib/cpr-download/CMakeLists.txt)
-set(BUILD_CPR_TESTS OFF CACHE BOOL "" FORCE)
+set(USE_SYSTEM_CURL ON CACHE BOOL "Do not allow CPR to use its own version of curl." FORCE)
+set(BUILD_CPR_TESTS OFF CACHE BOOL "Do not waste time running CPR unit tests" FORCE)
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
         RESULT_VARIABLE result
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/lib/cpr-download)
@@ -257,7 +258,7 @@ if (${DISTRIBUTION} STREQUAL "Ubuntu")
     set(CPACK_GENERATOR "DEB")
     set(CPACK_DEBIAN_PACKAGE_NAME "HIRSProvisionerTPM2.0")
     set(CPACK_DEBIAN_PACKAGE_SECTION "admin")
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "liblog4cplus-1.1-9(>=1.1.2), libcurlpp0(>=0.7), paccor, procps(>=3.3.0)")
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "liblog4cplus-1.1-9(>=1.1.2), libcurl4-openssl-dev(>=7.0.0), paccor, procps(>=3.3.0)")
     # Set variables specific to Ubuntu release version
     if (${DISTRIBUTION_VERSION} STREQUAL "16.04")
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libre2-1v5(>=20160201), libprotobuf9v5(>=2.4.1)")

--- a/HIRS_ProvisionerTPM2/docs/dependencies-centos.md
+++ b/HIRS_ProvisionerTPM2/docs/dependencies-centos.md
@@ -8,7 +8,8 @@ Please look up their respective names in the CentOS repositories.
 **NOTE**: Please consult [the developer dependency list](./developer-dependencies-centos.md) and make sure both the regular lib and the devel libs are installed.
 
 | Dependency | Version used | Minimum required  | Repository required   | Project repository                          |
-| ---------- | ------------ | ----------------- | --------------------- | ------------------------------------------- |
+| -----------| ------------ | ----------------- | --------------------- | ------------------------------------------- |
+| libcurl    | 7.29.0       | 7.0.0 (estimated) | CentOS 7 base         | https://github.com/curl/curl                |
 | log4cplus  | 1.1.2        | 1.1.2             | CentOS 7 epel-release | https://github.com/log4cplus/log4cplus      |
 | protobuf   | 2.5.0        | 2.4.1 (estimated) | CentOS 7 base         | https://github.com/google/protobuf          |
 | re2        | 20160401     | 20160201          | CentOS 7 epel-release | https://github.com/google/re2               |

--- a/HIRS_ProvisionerTPM2/docs/developer-dependencies-centos.md
+++ b/HIRS_ProvisionerTPM2/docs/developer-dependencies-centos.md
@@ -13,6 +13,7 @@ If no available repository for the development environment contains the dependen
 | doxygen           | 1.8.13       | 1.8.0 (estimated)  | CentOS 7 base         | https://github.com/doxygen/doxygen     |
 | graphviz          | 2.30.1       | 2.28.0 (estimated) | CentOS 7 base         | https://gitlab.com/graphviz/graphviz   |
 | gcc-c++           | 4.8.5        | 4.8.5              | CentOS 7 base         | https://gcc.gnu.org/                   |
+| libcurl-devel     | 7.29.0       | 7.0.0 (estimated)  | CentOS 7 base         | https://github.com/curl/curl           |
 | libssh2-devel     | 1.4.3        | 1.4.3 (estimated)  | CentOS 7 base         | https://github.com/libssh2/libssh2     |
 | log4cplus-devel   | 1.1.3        | 1.1.2              | CentOS 7 epel-release | https://github.com/log4cplus/log4cplus |
 | openssl-devel     | 1.0.2k       | 1.0.2g (estimated) | CentOS 7 base         | https://github.com/openssl/openssl     |

--- a/HIRS_ProvisionerTPM2/docs/developer-dependencies-debian.md
+++ b/HIRS_ProvisionerTPM2/docs/developer-dependencies-debian.md
@@ -7,16 +7,17 @@ Please look up their respective names in the appropriate repositories.
 
 If no available repository for the development environment contains the dependencies at an acceptable version level, it is expected that the packages be retrieved and built from their respective source repositories.
 
-| Dependency        | Version used | Minimum required   | Repository            | Project repository                     |
-| ----------------- | ------------ | ------------------ | --------------------- | -------------------------------------- |
-| cppcheck          | 1.82         | 1.72               | Ubuntu 18.04 base     | http://cppcheck.sourceforge.net/       |
-| doxygen           | 1.8.13       | 1.8.0 (estimated)  | Ubuntu 18.04 base     | https://github.com/doxygen/doxygen     |
-| graphviz          | 2.40.1       | 2.28.0 (estimated) | Ubuntu 18.04 base     | https://gitlab.com/graphviz/graphviz   |
-| liblog4cplus-dev  | 1.1.2        | 1.1.2              | Ubuntu 18.04 base     | https://github.com/log4cplus/log4cplus |
-| libssl-dev        | 1.1.0g       | 1.0.2g (estimated) | Ubuntu 18.04 base     | https://github.com/openssl/openssl     |
-| protobuf-compiler | 3.0.0        | 2.4.1 (estimated)  | Ubuntu 18.04 base     | https://github.com/google/protobuf     |
-| libprotobuf-dev   | 3.0.0        | 2.4.1 (estimated)  | Ubuntu 18.04 base     | https://github.com/google/protobuf     |
-| libre2-dev        | 20180201     | 20160201           | Ubuntu 18.04 base     | https://github.com/google/re2          |
-| libsapi-dev       | 1.0.0        | 1.0.0              | Ubuntu 18.04 base     | https://github.com/intel/tpm2-tss      |
-| cmake             | 3.10.2       | 2.6.0 (estimated)  | Ubuntu 18.04 base     | https://cmake.org/                     |
-| git               | 2.17.1       | 1.6.0 (estimated)  | Ubuntu 18.04 base     | https://github.com/git/git             |
+| Dependency           | Version used | Minimum required   | Repository            | Project repository                     |
+| -------------------- | ------------ | ------------------ | --------------------- | -------------------------------------- |
+| cppcheck             | 1.82         | 1.72               | Ubuntu 18.04 base     | http://cppcheck.sourceforge.net/       |
+| doxygen              | 1.8.13       | 1.8.0 (estimated)  | Ubuntu 18.04 base     | https://github.com/doxygen/doxygen     |
+| graphviz             | 2.40.1       | 2.28.0 (estimated) | Ubuntu 18.04 base     | https://gitlab.com/graphviz/graphviz   |
+| libcurl4-openssl-dev | 7.47.0       | 7.0.0 (estimated)  | Ubuntu 18.04 base     | https://github.com/curl/curl           |
+| liblog4cplus-dev     | 1.1.2        | 1.1.2              | Ubuntu 18.04 base     | https://github.com/log4cplus/log4cplus |
+| libssl-dev           | 1.1.0g       | 1.0.2g (estimated) | Ubuntu 18.04 base     | https://github.com/openssl/openssl     |
+| protobuf-compiler    | 3.0.0        | 2.4.1 (estimated)  | Ubuntu 18.04 base     | https://github.com/google/protobuf     |
+| libprotobuf-dev      | 3.0.0        | 2.4.1 (estimated)  | Ubuntu 18.04 base     | https://github.com/google/protobuf     |
+| libre2-dev           | 20180201     | 20160201           | Ubuntu 18.04 base     | https://github.com/google/re2          |
+| libsapi-dev          | 1.0.0        | 1.0.0              | Ubuntu 18.04 base     | https://github.com/intel/tpm2-tss      |
+| cmake                | 3.10.2       | 2.6.0 (estimated)  | Ubuntu 18.04 base     | https://cmake.org/                     |
+| git                  | 2.17.1       | 1.6.0 (estimated)  | Ubuntu 18.04 base     | https://github.com/git/git             |

--- a/HIRS_ProvisionerTPM2/package/rpm-post-install.sh
+++ b/HIRS_ProvisionerTPM2/package/rpm-post-install.sh
@@ -8,7 +8,6 @@ fi
 HIRS_SITE_CONFIG="/etc/hirs/hirs-site.config"
 
 mkdir -p /var/log/hirs/provisioner
-ln /usr/local/lib/libcurl.so /usr/lib64/libcurl.so
 ln -s -f /usr/local/bin/hirs-provisioner-tpm2 /usr/sbin/hirs-provisioner-tpm2
 ln -s -f /usr/local/bin/tpm_aca_provision /usr/sbin/tpm_aca_provision
 


### PR DESCRIPTION
There was a problem in the rpm-post-install.sh script
that ran as part of the CentOS7 rpm installation where
a link was being created called libcurl.so which pointed
to libcurl.so.4. If the link could not be created because
it already existed, the script would quit before finishing
and never place hirs-provisioner-tpm2 in a directory on
the PATH.

The proper solution was to link hirs-provisioner against
libcurl.so.4 so that it is clear which version of the API
was compiled against. This was not happening because
we were linking against a version of curl build by the CPR
project which was not properly embedding the SONAME in the
shared object file. By linking instead against the shared
object file distributed in the development package of
libcurl, hirs-provisioner-tpm2 now looks for libcurl.so.4
rather than the generic libcurl.so. This will prevent our
executable from breaking if libcurl.so gets updated to point
to a newer version of libcurl that uses a different API.

Closes #78.