### PR TITLE
[#85] Incorrect package dependencies for Ubuntu.

### DIFF
--- a/HIRS_ProvisionerTPM2/CMakeLists.txt
+++ b/HIRS_ProvisionerTPM2/CMakeLists.txt
@@ -258,7 +258,7 @@ if (${DISTRIBUTION} STREQUAL "Ubuntu")
     set(CPACK_GENERATOR "DEB")
     set(CPACK_DEBIAN_PACKAGE_NAME "HIRSProvisionerTPM2.0")
     set(CPACK_DEBIAN_PACKAGE_SECTION "admin")
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "liblog4cplus-1.1-9(>=1.1.2), libcurl4-openssl-dev(>=7.0.0), paccor, procps(>=3.3.0)")
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "liblog4cplus-1.1-9(>=1.1.2), libcurl3(>=7.0.0), paccor, procps(>=3.3.0)")
     # Set variables specific to Ubuntu release version
     if (${DISTRIBUTION_VERSION} STREQUAL "16.04")
         set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, libre2-1v5(>=20160201), libprotobuf9v5(>=2.4.1)")


### PR DESCRIPTION
HIRS_ProvisionerTPM2/CMakeLists.txt claims the Ubuntu
deb package depends on libcurl4-openssl-dev; it should
actually depend on libcurl3 which provides libcurl.so.4.
The former package depends on the later, so it would
install the right package, but it is preferable to only
require what is needed.

Closes #85.