### PR TITLE
[#96] Validation tooltip update

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
@@ -12,6 +12,22 @@
 
     <jsp:body>
         <ul>
+            <%-- Endorsement validation --%>
+            <div class="aca-input-box">
+                <form:form method="POST" modelAttribute="initialData" action="policy/update-ec-validation">
+                    <li>Endorsement Credential Validation: ${initialData.enableEcValidation ? 'Enabled' : 'Disabled'}
+                        <my:editor id="ecPolicyEditor" label="Edit Settings ">
+                            <div class="radio">
+                                <label><input id="ecTop" type="radio" name="ecValidate" ${initialData.enableEcValidation ? 'checked' : ''}  value="checked"/> Endorsement Credentials will be validated</label>
+                            </div>
+                            <div class="radio">
+                                <label><input id="ecBot" type="radio" name="ecValidate" ${initialData.enableEcValidation ? '' : 'checked'} value="unchecked"/> Endorsement Credentials will not be validated</label>
+                            </div>
+                        </my:editor>
+                    </li>
+                </form:form>
+            </div>
+            
             <%-- Platform validation --%>
             <div class="aca-input-box">
                 <form:form method="POST" modelAttribute="initialData" action="policy/update-pc-validation">
@@ -38,22 +54,6 @@
                             </div>
                             <div class="radio">
                                 <label><input id="pcAttrBot" type="radio" name="pcAttributeValidate" ${initialData.enablePcCertificateAttributeValidation ? '' : 'checked'}  value="unchecked"/> Platform Credential Attributes will not be validated</label>
-                            </div>
-                        </my:editor>
-                    </li>
-                </form:form>
-            </div>
-
-            <%-- Endorsement validation --%>
-            <div class="aca-input-box">
-                <form:form method="POST" modelAttribute="initialData" action="policy/update-ec-validation">
-                    <li>Endorsement Credential Validation: ${initialData.enableEcValidation ? 'Enabled' : 'Disabled'}
-                        <my:editor id="ecPolicyEditor" label="Edit Settings ">
-                            <div class="radio">
-                                <label><input id="ecTop" type="radio" name="ecValidate" ${initialData.enableEcValidation ? 'checked' : ''}  value="checked"/> Endorsement Credentials will be validated</label>
-                            </div>
-                            <div class="radio">
-                                <label><input id="ecBot" type="radio" name="ecValidate" ${initialData.enableEcValidation ? '' : 'checked'} value="unchecked"/> Endorsement Credentials will not be validated</label>
                             </div>
                         </my:editor>
                     </li>

--- a/HIRS_Utils/src/test/java/hirs/validation/SupplyChainCredentialValidatorTest.java
+++ b/HIRS_Utils/src/test/java/hirs/validation/SupplyChainCredentialValidatorTest.java
@@ -487,7 +487,7 @@ public class SupplyChainCredentialValidatorTest {
                 + "Platform model did not match\n"
                 + "Platform version did not match\n"
                 + "Platform serial did not match\n"
-                + "There are unmatched components\n";
+                + "There are unmatched components:\n";
 
         AppraisalStatus result =
                 supplyChainCredentialValidator.validatePlatformCredentialAttributes(
@@ -1108,7 +1108,8 @@ public class SupplyChainCredentialValidatorTest {
                 + "Platform model did not match\n"
                 + "Platform version did not match\n"
                 + "Platform serial did not match\n"
-                + "There are unmatched components\n";
+                + "There are unmatched components:\n"
+                + "Manufacturer=Intel, Model=platform2018\n";
 
         AppraisalStatus result =
                 supplyChainCredentialValidator.validatePlatformCredentialAttributes(
@@ -1235,7 +1236,7 @@ public class SupplyChainCredentialValidatorTest {
                 + "Platform model did not match\n"
                 + "Platform version did not match\n"
                 + "Platform serial did not match\n"
-                + "There are unmatched components\n";
+                + "There are unmatched components:\n";
 
         AppraisalStatus result =
                 supplyChainCredentialValidator.validatePlatformCredentialAttributes(
@@ -1720,7 +1721,8 @@ public class SupplyChainCredentialValidatorTest {
                         deviceInfoReport);
         Assert.assertEquals(result.getAppStatus(), AppraisalStatus.Status.FAIL);
         Assert.assertEquals(result.getMessage(), "Component manufacturer is empty\n"
-                + "There are unmatched components\n");
+                + "There are unmatched components:\n"
+                + "Manufacturer=, Model=Core i7\n");
 
         platformCredential = setupMatchingPlatformCredential(deviceInfoReport);
         result = SupplyChainCredentialValidator
@@ -1775,7 +1777,8 @@ public class SupplyChainCredentialValidatorTest {
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport);
         Assert.assertEquals(result.getAppStatus(), AppraisalStatus.Status.FAIL);
-        Assert.assertEquals(result.getMessage(), "There are unmatched components\n");
+        Assert.assertEquals(result.getMessage(), "There are unmatched components:\n"
+                + "Manufacturer=ACME, Model=TNT\n");
     }
 
     /**
@@ -1837,7 +1840,8 @@ public class SupplyChainCredentialValidatorTest {
                         deviceInfoReport);
         Assert.assertEquals(result.getAppStatus(), AppraisalStatus.Status.FAIL);
         Assert.assertEquals(result.getMessage(), "Component manufacturer is empty\n"
-                + "There are unmatched components\n");
+                + "There are unmatched components:\n"
+                + "Manufacturer=, Model=Core i7\n");
 
         platformCredential = setupMatchingPlatformCredential(deviceInfoReport);
         result = SupplyChainCredentialValidator


### PR DESCRIPTION
 Updating code to list what specifically is unmatched for platform components on the validation page when there is a failure.

Updates include a small shift for the policy page, putting the correct order for setting them (top to bottom). Updated unit tests for the additional text that now appears on the tool tip for the validation failure icon.

Closes #96 