### PR TITLE
[#95] Resolve Log4cplus Error complaining about no appenders

### DIFF
--- a/HIRS_ProvisionerTPM2/include/Logger.h
+++ b/HIRS_ProvisionerTPM2/include/Logger.h
@@ -18,7 +18,7 @@ namespace log {
 class Logger {
  private:
     static const char* const kDefaultProvisionerLoggerName;
-    static const char* const PROP_FILE_LOC;
+    static const char* const kPropFileLocation;
 
     const log4cplus::Logger kLogger;
 

--- a/HIRS_ProvisionerTPM2/src/Logger.cpp
+++ b/HIRS_ProvisionerTPM2/src/Logger.cpp
@@ -17,7 +17,7 @@ using hirs::log::Logger;
 using hirs::properties::Properties;
 
 const char* const Logger::kDefaultProvisionerLoggerName = "tpm2_provisioner";
-const char* const Logger::PROP_FILE_LOC = "/etc/hirs/logging.properties";
+const char* const Logger::kPropFileLocation = "/etc/hirs/logging.properties";
 
 static std::once_flag configureRootLoggerOnce;
 
@@ -36,8 +36,8 @@ Logger::Logger(const string loggerName)
 void Logger::setThresholdFromLoggingProperties(log4cplus::Logger logger) {
     // if logging.properties exists, attempt to set the
     // appropriate level for the given logger
-    if (fileExists(PROP_FILE_LOC)) {
-        Properties props(PROP_FILE_LOC);
+    if (fileExists(kPropFileLocation)) {
+        Properties props(kPropFileLocation);
 
         string loggerName = logger.getName();
         string logLevelKey = loggerName + ".level";
@@ -45,19 +45,7 @@ void Logger::setThresholdFromLoggingProperties(log4cplus::Logger logger) {
             string level = props.get(logLevelKey);
             int l4cpLevel = log4cplus::getLogLevelManager().fromString(level);
             if (l4cpLevel != log4cplus::NOT_SET_LOG_LEVEL) {
-                LOG4CPLUS_INFO(
-                        logger,
-                        LOG4CPLUS_TEXT(
-                                "Configuring logger " + loggerName
-                                + " with level " + level));
                 logger.setLogLevel(l4cpLevel);
-            } else {
-                LOG4CPLUS_INFO(
-                        logger,
-                        LOG4CPLUS_TEXT(
-                            "Unable to configure logger " + loggerName
-                            + " with level " + level
-                            + "; no such level found."));
             }
         }
     }


### PR DESCRIPTION
The main issue that was causing the error to appear was the fact that we statically create the Loggers for 5 of our classes in `HIRS_ProvisionerTPM2`. The way the `logging.properties` loading method was written in `Logger.cpp` it attempted to Log the new log level of the loggers.

The problem was that this all happens before we even get to the `main` method and initialize `Log4cplus` to begin with. Since Log4cplus wasn't initialized, when it attempted to update the log level for these `static` loggers and then Log what their new log levels were, it would throw the error.

This pull request just removes those unnecessary log statements and the problem is resolved.

Closes #95 