### PR TITLE
[#103] Blanks changed to 'Not Specified'

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/data/persist/ComponentInfo.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/ComponentInfo.java
@@ -194,9 +194,13 @@ public class ComponentInfo implements Serializable {
         this.componentModel = componentModel.trim();
         if (componentSerial != null) {
             this.componentSerial = componentSerial.trim();
+        } else {
+            this.componentSerial = DeviceInfoReport.NOT_SPECIFIED;
         }
         if (componentRevision != null) {
             this.componentRevision = componentRevision.trim();
+        } else {
+            this.componentRevision = DeviceInfoReport.NOT_SPECIFIED;
         }
     }
 
@@ -216,9 +220,8 @@ public class ComponentInfo implements Serializable {
                                      final String componentModel,
                                      final String componentSerial,
                                      final String componentRevision) {
-        return !(
-                StringUtils.isEmpty(componentManufacturer)  || StringUtils.isEmpty(componentModel)
-        );
+        return !(StringUtils.isEmpty(componentManufacturer)
+                || StringUtils.isEmpty(componentModel));
     }
 
     @Override

--- a/HIRS_Utils/src/main/java/hirs/data/persist/SupplyChainValidation.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/SupplyChainValidation.java
@@ -48,7 +48,7 @@ public class SupplyChainValidation extends ArchivableEntity {
             joinColumns = { @JoinColumn(name = "validation_id", nullable = false) })
     private final List<Certificate> certificatesUsed;
 
-    @Column
+    @Column(columnDefinition = "VARCHAR(700)")
     private final String message;
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentIdentifier.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentIdentifier.java
@@ -1,5 +1,6 @@
 package hirs.data.persist.certificate.attributes;
 
+import hirs.data.persist.DeviceInfoReport;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -55,11 +56,11 @@ public class ComponentIdentifier {
      * Default constructor.
      */
     public ComponentIdentifier() {
-        componentClass = null;
-        componentManufacturer = null;
-        componentModel = null;
-        componentSerial = null;
-        componentRevision = null;
+        componentClass = DeviceInfoReport.NOT_SPECIFIED;
+        componentManufacturer = new DERUTF8String(DeviceInfoReport.NOT_SPECIFIED);
+        componentModel = new DERUTF8String(DeviceInfoReport.NOT_SPECIFIED);
+        componentSerial = new DERUTF8String(DeviceInfoReport.NOT_SPECIFIED);
+        componentRevision = new DERUTF8String(DeviceInfoReport.NOT_SPECIFIED);
         componentManufacturerId = null;
         fieldReplaceable = null;
         componentAddress = new ArrayList<>();
@@ -120,8 +121,8 @@ public class ComponentIdentifier {
         componentModel = DERUTF8String.getInstance(sequence.getObjectAt(tag++));
 
         //Optional values (default to null or empty)
-        componentSerial = null;
-        componentRevision = null;
+        componentSerial = new DERUTF8String(DeviceInfoReport.NOT_SPECIFIED);
+        componentRevision = new DERUTF8String(DeviceInfoReport.NOT_SPECIFIED);
         componentManufacturerId = null;
         fieldReplaceable = null;
         componentAddress = new ArrayList<>();

--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -499,8 +499,8 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
         // on the leftovers in the lists and the policy in place.
         final List<ComponentIdentifier> pcComponents = new ArrayList<>();
         for (ComponentIdentifier component : untrimmedPcComponents) {
-            DERUTF8String componentSerial = new DERUTF8String("");
-            DERUTF8String componentRevision = new DERUTF8String("");
+            DERUTF8String componentSerial = new DERUTF8String(DeviceInfoReport.NOT_SPECIFIED);
+            DERUTF8String componentRevision = new DERUTF8String(DeviceInfoReport.NOT_SPECIFIED);
             if (component.getComponentSerial() != null) {
                 componentSerial = new DERUTF8String(
                         component.getComponentSerial().getString().trim());

--- a/HIRS_Utils/src/test/java/hirs/data/persist/certificate/PlatformCredentialTest.java
+++ b/HIRS_Utils/src/test/java/hirs/data/persist/certificate/PlatformCredentialTest.java
@@ -396,7 +396,7 @@ public class PlatformCredentialTest {
      * @throws URISyntaxException if there is a problem constructing the cert's URI
      */
     @Test
-    public final void testPlatformConfiguarion() throws IOException, URISyntaxException {
+    public final void testPlatformConfiguration() throws IOException, URISyntaxException {
 
         URL resource = this.getClass().getResource(TEST_PLATFORM_CERT2_1);
         Path certPath = Paths.get(resource.toURI());
@@ -484,7 +484,7 @@ public class PlatformCredentialTest {
      * @throws URISyntaxException if there is a problem constructing the cert's URI
      */
     @Test
-    public final void testPlatformConfiguarion2() throws IOException, URISyntaxException {
+    public final void testPlatformConfiguration2() throws IOException, URISyntaxException {
 
         URL resource = this.getClass().getResource(TEST_PLATFORM_CERT2_2);
         Path certPath = Paths.get(resource.toURI());
@@ -522,7 +522,7 @@ public class PlatformCredentialTest {
      * @throws URISyntaxException if there is a problem constructing the cert's URI
      */
     @Test
-    public final void testPlatformConfiguarion3() throws IOException, URISyntaxException {
+    public final void testPlatformConfiguration3() throws IOException, URISyntaxException {
 
         URL resource = this.getClass().getResource(TEST_PLATFORM_CERT2_3);
         Path certPath = Paths.get(resource.toURI());
@@ -553,7 +553,9 @@ public class PlatformCredentialTest {
         Assert.assertTrue(component.getComponentModel()
                                         .getString()
                                         .equals("BIOS"));
-        Assert.assertNull(component.getComponentSerial());
+        Assert.assertTrue(component.getComponentSerial()
+                                        .getString()
+                                        .equalsIgnoreCase("Not Specified"));
         Assert.assertTrue(component.getComponentRevision()
                                         .getString()
                                         .equals("DNKBLi5v.86A.0019.2017.0804.1146"));
@@ -593,7 +595,7 @@ public class PlatformCredentialTest {
      * @throws URISyntaxException if there is a problem constructing the cert's URI
      */
     @Test
-    public final void testPlatformConfiguarion4() throws IOException, URISyntaxException {
+    public final void testPlatformConfiguration4() throws IOException, URISyntaxException {
 
         URL resource = this.getClass().getResource(TEST_PLATFORM_CERT2_4);
         Path certPath = Paths.get(resource.toURI());


### PR DESCRIPTION
The suppy chain validation has reported non-matches for components that are initialized as null or blank or never initialized by code but by COTS. The end results is validation failure because the certificate compare will be null and the device report will list blank or Not Specified. This issue is to synch all to 'Not Specified'. Previous blank was set but that still caused issue with a blank compared to a 'Not Specified'.

Closes #103 