### PR TITLE
[#61] Remove Magic String Usage from PersistenceConfiguration

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/persist/DeviceHealthManagerImpl.java
+++ b/HIRS_Utils/src/main/java/hirs/persist/DeviceHealthManagerImpl.java
@@ -34,7 +34,7 @@ public class DeviceHealthManagerImpl implements DeviceHealthManager {
     private AlertManager alertManager;
 
     @Autowired
-    @Qualifier("general_db_man_bean")
+    @Qualifier(PersistenceConfiguration.DEVICE_STATE_MANAGER_BEAN_NAME)
     private DeviceStateManager deviceStateManager;
 
     @Autowired

--- a/HIRS_Utils/src/main/java/hirs/persist/PersistenceConfiguration.java
+++ b/HIRS_Utils/src/main/java/hirs/persist/PersistenceConfiguration.java
@@ -18,6 +18,12 @@ import org.springframework.orm.hibernate4.LocalSessionFactoryBean;
 @Configuration
 @Import({ HibernateConfiguration.class })
 public class PersistenceConfiguration {
+
+    /**
+     * The bean name to retrieve the default/general implementation of {@link DeviceStateManager}.
+     */
+    public static final String DEVICE_STATE_MANAGER_BEAN_NAME = "general_db_man_bean";
+
     @Autowired
     private LocalSessionFactoryBean sessionFactory;
 
@@ -140,7 +146,7 @@ public class PersistenceConfiguration {
      *
      * @return {@link DeviceStateManager}
      */
-    @Bean(name = "general_db_man_bean")
+    @Bean(name = DEVICE_STATE_MANAGER_BEAN_NAME)
     public DeviceStateManager generalDeviceStateManager() {
         DBDeviceStateManager manager = new DBDeviceStateManager(sessionFactory.getObject());
         setDbManagerRetrySettings(manager);

--- a/HIRS_Utils/src/test/java/hirs/persist/DeviceHealthManagerImplTest.java
+++ b/HIRS_Utils/src/test/java/hirs/persist/DeviceHealthManagerImplTest.java
@@ -46,7 +46,7 @@ public class DeviceHealthManagerImplTest {
     private AlertManager alertManager;
 
     @Mock
-    @Qualifier("general_db_man_bean")
+    @Qualifier(PersistenceConfiguration.DEVICE_STATE_MANAGER_BEAN_NAME)
     private DeviceStateManager deviceStateManager;
 
     @Mock


### PR DESCRIPTION
Super simple MR to remove the use of a magic string that originated in the HIRS_Utils PersistenceConfiguration class.

Closes #61 