### PR TITLE
[#122] Add clean up of dangling docker containers for TPM 2.0 system tests

### DIFF
--- a/.ci/system-tests/run-system-tests-tpm2.sh
+++ b/.ci/system-tests/run-system-tests-tpm2.sh
@@ -30,11 +30,11 @@ do
   tpm2_container_status="$(docker inspect $tpm2_container_id --format='{{.State.Status}}')"
 done
 
-# Store container exit codes
+# Store container exit code
 tpm2_container_exit_code="$(docker inspect $tpm2_container_id --format='{{.State.ExitCode}}')"
 echo "TPM2 Container Exit Code: $tpm2_container_exit_code"
 
-# Display container logs
+# Display container log
 echo ""
 echo "===========hirs-aca-provisioner-tpm2 System Tests Log:==========="
 docker logs $tpm2_container_id

--- a/.ci/system-tests/run-system-tests-tpm2.sh
+++ b/.ci/system-tests/run-system-tests-tpm2.sh
@@ -53,6 +53,7 @@ echo ""
 docker container prune --force
 echo ""
 
+# Return container exit code
 if [[ $tpm2_container_exit_code == 0 ]]
 then
     echo "SUCCESS: TPM 2.0 System tests passed"

--- a/.ci/system-tests/run-system-tests-tpm2.sh
+++ b/.ci/system-tests/run-system-tests-tpm2.sh
@@ -45,7 +45,14 @@ echo ""
 # Clean up services and network
 docker-compose down
 
-# Return container exit codes
+# Clean up dangling containers
+echo "Cleaning up dangling containers..."
+echo ""
+docker ps -a
+echo ""
+docker container prune --force
+echo ""
+
 if [[ $tpm2_container_exit_code == 0 ]]
 then
     echo "SUCCESS: TPM 2.0 System tests passed"


### PR DESCRIPTION
docker-compose down is not cleaning up the hirs-aca-provisioner-tpm2 container for the TPM 2.0 system tests. Probably will need to add a "docker container prune" to the run-system-tests-tpm2 script.