### PR TITLE
[#108] Validity Check for Base and Delta Certs

### DIFF
--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
@@ -93,6 +93,7 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
     // mocked
     private SupplyChainPolicy policy;
     private PlatformCredential pc;
+//    private PlatformCredential delta;
     private EndorsementCredential ec;
     private HashSet<PlatformCredential> pcs;
     private Device device;
@@ -134,8 +135,13 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
         pcs = new HashSet<PlatformCredential>();
         pcs.add(pc);
 
+        /*
+         * Mock delta platform credential here
+         */
+
         Set<Certificate> resultPcs = new HashSet<>();
         resultPcs.add(pc);
+        //resultPcs.add(delta);
 
         // mock credential retrieval
         when(certificateManager.get(any(EndorsementCredential.Selector.class)))
@@ -176,6 +182,11 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
         doReturn(new AppraisalStatus(PASS, "")).when(supplyChainCredentialValidator)
                 .validatePlatformCredentialAttributes(eq(pc), any(DeviceInfoReport.class),
                         any(EndorsementCredential.class));
+/*
+        doReturn(new AppraisalStatus(PASS, "")).when(supplyChainCredentialValidator)
+                .validateDeltaPlatformCredentialAttributes(eq(delta), any(DeviceInfoReport.class),
+                        any(PlatformCredential.class));
+*/
 
         Assert.assertEquals(service.validateSupplyChain(ec, pcs,
                 device).getOverallValidationResult(), PASS);

--- a/HIRS_Utils/src/main/java/hirs/data/persist/SupplyChainValidation.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/SupplyChainValidation.java
@@ -35,7 +35,7 @@ public class SupplyChainValidation extends ArchivableEntity {
          * Validation of a platform credential's attributes.
          */
         PLATFORM_CREDENTIAL_ATTRIBUTES,
-        
+
         /**
          * Validation of a delta platform credential's attributes.
          */

--- a/HIRS_Utils/src/main/java/hirs/data/persist/SupplyChainValidation.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/SupplyChainValidation.java
@@ -27,14 +27,19 @@ public class SupplyChainValidation extends ArchivableEntity {
         ENDORSEMENT_CREDENTIAL,
 
         /**
-         * Validation of a platform credential.
+         * Validation of a platform credential and also delta platform credentials from spec 1.1.
          */
         PLATFORM_CREDENTIAL,
 
         /**
          * Validation of a platform credential's attributes.
          */
-        PLATFORM_CREDENTIAL_ATTRIBUTES
+        PLATFORM_CREDENTIAL_ATTRIBUTES,
+        
+        /**
+         * Validation of a delta platform credential's attributes.
+         */
+        DELTA_PLATFORM_CREDENTIAL_ATTRIBUTES
     }
 
     @Column

--- a/HIRS_Utils/src/main/java/hirs/validation/CredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/CredentialValidator.java
@@ -35,6 +35,19 @@ public interface CredentialValidator {
     AppraisalStatus validatePlatformCredentialAttributes(PlatformCredential pc,
                                                          DeviceInfoReport deviceInfoReport,
                                                          EndorsementCredential ec);
+
+    /**
+     * Checks if the delta credential's attributes are valid.
+     * @param delta the delta credential to verify
+     * @param deviceInfoReport The device info report containing
+     *                         serial number of the platform to be validated.
+     * @param base the base credential from the same identity request
+     *                              as the delta credential.
+     * @return the result of the validation.
+     */
+    AppraisalStatus validateDeltaPlatformCredentialAttributes(PlatformCredential delta,
+                                                              DeviceInfoReport deviceInfoReport,
+                                                              PlatformCredential base);
     /**
      * Checks if the endorsement credential is valid.
      *

--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -251,6 +251,27 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
         return validatePlatformCredentialAttributesV1p2(platformCredential, deviceInfoReport);
     }
 
+    /**
+     * Checks if the delta credential's attributes are valid.
+     * @param deltaPlatformCredential the delta credential to verify
+     * @param deviceInfoReport The device info report containing
+     *                         serial number of the platform to be validated.
+     * @param basePlatformCredential the base credential from the same identity request
+     *                              as the delta credential.
+     * @return the result of the validation.
+     */
+    @Override
+    public AppraisalStatus validateDeltaPlatformCredentialAttributes(
+            final PlatformCredential deltaPlatformCredential,
+            final DeviceInfoReport deviceInfoReport,
+            final PlatformCredential basePlatformCredential) {
+
+        /*
+         * Code here to check the holder and attribute status fields
+         */
+        return validatePlatformCredentialAttributesV2p0(deltaPlatformCredential, deviceInfoReport);
+    }
+
     private static AppraisalStatus validatePlatformCredentialAttributesV1p2(
             final PlatformCredential platformCredential,
             final DeviceInfoReport deviceInfoReport) {


### PR DESCRIPTION
This is generally how I plan to distinguish and check base and delta certs accordingly.

I decided to assign SupplyChainValidationServiceImpl.baseCredential in the policy.isPcValidationEnabled() loop to avoid looping through the set of PlatformCredential objects again just to find it.  baseCredential is then used to determine in the subsequent policy.isPcAttributeValidationEnabled() loop whether to validate a base or a delta credential, each with their respective methods in SupplyChainCredentialValidator.

Closes #108 