### PR TITLE
Attribute Validation Match Update

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/data/persist/ComponentInfo.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/ComponentInfo.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlElement;
 import java.io.Serializable;
 import java.util.Objects;
 
-import hirs.data.persist.certificate.attributes.ComponentIdentifier;
+import org.apache.logging.log4j.util.Strings;
 
 /**
  * ComponentInfo is a class to hold Hardware component information
@@ -197,12 +197,12 @@ public class ComponentInfo implements Serializable {
         if (componentSerial != null) {
             this.componentSerial = componentSerial.trim();
         } else {
-            this.componentSerial = ComponentIdentifier.EMPTY_COMPONENT;
+            this.componentSerial = Strings.EMPTY;
         }
         if (componentRevision != null) {
             this.componentRevision = componentRevision.trim();
         } else {
-            this.componentRevision = ComponentIdentifier.EMPTY_COMPONENT;
+            this.componentRevision = Strings.EMPTY;
         }
     }
 

--- a/HIRS_Utils/src/main/java/hirs/data/persist/ComponentInfo.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/ComponentInfo.java
@@ -15,6 +15,8 @@ import javax.xml.bind.annotation.XmlElement;
 import java.io.Serializable;
 import java.util.Objects;
 
+import hirs.data.persist.certificate.attributes.ComponentIdentifier;
+
 /**
  * ComponentInfo is a class to hold Hardware component information
  * such as manufacturer, model, serial number and version.
@@ -194,9 +196,13 @@ public class ComponentInfo implements Serializable {
         this.componentModel = componentModel.trim();
         if (componentSerial != null) {
             this.componentSerial = componentSerial.trim();
+        } else {
+            this.componentSerial = ComponentIdentifier.EMPTY_COMPONENT;
         }
         if (componentRevision != null) {
             this.componentRevision = componentRevision.trim();
+        } else {
+            this.componentRevision = ComponentIdentifier.EMPTY_COMPONENT;
         }
     }
 

--- a/HIRS_Utils/src/main/java/hirs/data/persist/ComponentInfo.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/ComponentInfo.java
@@ -15,7 +15,6 @@ import javax.xml.bind.annotation.XmlElement;
 import java.io.Serializable;
 import java.util.Objects;
 
-import org.apache.logging.log4j.util.Strings;
 
 /**
  * ComponentInfo is a class to hold Hardware component information
@@ -197,12 +196,12 @@ public class ComponentInfo implements Serializable {
         if (componentSerial != null) {
             this.componentSerial = componentSerial.trim();
         } else {
-            this.componentSerial = Strings.EMPTY;
+            this.componentSerial = StringUtils.EMPTY;
         }
         if (componentRevision != null) {
             this.componentRevision = componentRevision.trim();
         } else {
-            this.componentRevision = Strings.EMPTY;
+            this.componentRevision = StringUtils.EMPTY;
         }
     }
 

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentIdentifier.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentIdentifier.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.apache.logging.log4j.util.Strings;
 
 import org.bouncycastle.asn1.ASN1Boolean;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -33,6 +34,10 @@ public class ComponentIdentifier {
      * Variable for components that aren't set.
      */
     public static final String EMPTY_COMPONENT = "[Empty]";
+    /**
+     * Variable for components that aren't set.
+     */
+    public static final String NOT_SPECFIED_COMPONENT = "Not Specified";
     /**
      * Maximum number of configurations.
      */
@@ -73,10 +78,10 @@ public class ComponentIdentifier {
      * Default constructor.
      */
     public ComponentIdentifier() {
-        componentManufacturer = new DERUTF8String(EMPTY_COMPONENT);
-        componentModel = new DERUTF8String(EMPTY_COMPONENT);
-        componentSerial = new DERUTF8String(EMPTY_COMPONENT);
-        componentRevision = new DERUTF8String(EMPTY_COMPONENT);
+        componentManufacturer = new DERUTF8String(NOT_SPECFIED_COMPONENT);
+        componentModel = new DERUTF8String(NOT_SPECFIED_COMPONENT);
+        componentSerial = new DERUTF8String(Strings.EMPTY);
+        componentRevision = new DERUTF8String(Strings.EMPTY);
         componentManufacturerId = null;
         fieldReplaceable = null;
         componentAddress = new ArrayList<>();

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentIdentifier.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentIdentifier.java
@@ -32,7 +32,7 @@ public class ComponentIdentifier {
     /**
      * Variable for components that aren't set.
      */
-    public static final String EMPTY_COMPONENT = " --- ";
+    public static final String EMPTY_COMPONENT = "[Empty]";
     /**
      * Maximum number of configurations.
      */

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentIdentifier.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentIdentifier.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
 
 import org.bouncycastle.asn1.ASN1Boolean;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -80,8 +80,8 @@ public class ComponentIdentifier {
     public ComponentIdentifier() {
         componentManufacturer = new DERUTF8String(NOT_SPECFIED_COMPONENT);
         componentModel = new DERUTF8String(NOT_SPECFIED_COMPONENT);
-        componentSerial = new DERUTF8String(Strings.EMPTY);
-        componentRevision = new DERUTF8String(Strings.EMPTY);
+        componentSerial = new DERUTF8String(StringUtils.EMPTY);
+        componentRevision = new DERUTF8String(StringUtils.EMPTY);
         componentManufacturerId = null;
         fieldReplaceable = null;
         componentAddress = new ArrayList<>();

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/V2/AttributeStatus.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/V2/AttributeStatus.java
@@ -1,6 +1,7 @@
 package hirs.data.persist.certificate.attributes.V2;
 
-import org.apache.logging.log4j.util.Strings;
+import org.apache.commons.lang3.StringUtils;
+
 
 /**
  * A type to handle the security Level used in the FIPS Level.
@@ -30,7 +31,7 @@ public enum AttributeStatus {
     /**
      * Attribute Status for EMPTY.
      */
-    EMPTY_STATUS(Strings.EMPTY);
+    EMPTY_STATUS(StringUtils.EMPTY);
 
     private final String value;
 

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/V2/AttributeStatus.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/V2/AttributeStatus.java
@@ -1,6 +1,6 @@
 package hirs.data.persist.certificate.attributes.V2;
 
-import hirs.data.persist.certificate.attributes.ComponentIdentifier;
+import org.apache.logging.log4j.util.Strings;
 
 /**
  * A type to handle the security Level used in the FIPS Level.
@@ -28,9 +28,9 @@ public enum AttributeStatus {
      */
     REMOVED("removed"),
     /**
-     * Attribute Status for NOT_SPECIFIED.
+     * Attribute Status for EMPTY.
      */
-    NOT_SPECIFIED(ComponentIdentifier.EMPTY_COMPONENT);
+    EMPTY_STATUS(Strings.EMPTY);
 
     private final String value;
 

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/V2/ComponentIdentifierV2.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/V2/ComponentIdentifierV2.java
@@ -55,7 +55,7 @@ public class ComponentIdentifierV2 extends ComponentIdentifier {
         componentClass = new ComponentClass();
         certificateIdentifier = null;
         componentPlatformUri = null;
-        attributeStatus = AttributeStatus.NOT_SPECIFIED;
+        attributeStatus = AttributeStatus.EMPTY_STATUS;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/V2/PlatformPropertyV2.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/V2/PlatformPropertyV2.java
@@ -25,7 +25,7 @@ public class PlatformPropertyV2 extends PlatformProperty {
      */
     public PlatformPropertyV2() {
         super();
-        this.attributeStatus = AttributeStatus.NOT_SPECIFIED;
+        this.attributeStatus = AttributeStatus.EMPTY_STATUS;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -513,8 +513,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                 new ComponentIdentifier(
                         new DERUTF8String(component.getComponentManufacturer().getString().trim()),
                         new DERUTF8String(component.getComponentModel().getString().trim()),
-                        componentSerial,
-                        componentRevision,
+                        componentSerial, componentRevision,
                         component.getComponentManufacturerId(),
                         component.getFieldReplaceable(),
                         component.getComponentAddress()
@@ -557,8 +556,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
             // Now match up the components from the device info that are from the same
             // manufacturer and have a serial number. As matches are found, remove them from
             // both lists.
-            for (ComponentIdentifier pcComponent
-                    : pcComponentsFromManufacturerWithSerialNumber) {
+            for (ComponentIdentifier pcComponent : pcComponentsFromManufacturerWithSerialNumber) {
                 Optional<ComponentInfo> first
                         = deviceInfoComponentsFromManufacturer.stream()
                         .filter(componentInfo
@@ -588,8 +586,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
             // Now match up the components from the device info that are from the same
             // manufacturer and specify a value for the revision field. As matches are found,
             // remove them from both lists.
-            for (ComponentIdentifier pcComponent
-                    : pcComponentsFromManufacturerWithRevision) {
+            for (ComponentIdentifier pcComponent : pcComponentsFromManufacturerWithRevision) {
                 Optional<ComponentInfo> first
                         = deviceInfoComponentsFromManufacturer.stream()
                         .filter(info -> StringUtils.isNotEmpty(info.getComponentRevision()))

--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -633,9 +633,11 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
             for (ComponentIdentifier unmatchedComponent : pcUnmatchedComponents) {
                 LOGGER.error("Unmatched component " + umatchedComponentCounter++ + ": "
                         + unmatchedComponent);
-                sb.append(String.format("Manufacturer=%s, Model=%s%n",
+                sb.append(String.format("Manufacturer=%s, Model=%s, Serial=%s, Revision=%s%n",
                         unmatchedComponent.getComponentManufacturer(),
-                        unmatchedComponent.getComponentModel()));
+                        unmatchedComponent.getComponentModel(),
+                        unmatchedComponent.getComponentSerial(),
+                        unmatchedComponent.getComponentRevision()));
             }
             return sb.toString();
         }

--- a/HIRS_Utils/src/test/java/hirs/data/persist/certificate/PlatformCredentialTest.java
+++ b/HIRS_Utils/src/test/java/hirs/data/persist/certificate/PlatformCredentialTest.java
@@ -561,7 +561,7 @@ public class PlatformCredentialTest {
                                         .equals("BIOS"));
         Assert.assertTrue(component.getComponentSerial()
                                         .getString()
-                                        .equals(" --- "));
+                                        .equals("[Empty]"));
         Assert.assertTrue(component.getComponentRevision()
                                         .getString()
                                         .equals("DNKBLi5v.86A.0019.2017.0804.1146"));

--- a/HIRS_Utils/src/test/java/hirs/data/persist/certificate/PlatformCredentialTest.java
+++ b/HIRS_Utils/src/test/java/hirs/data/persist/certificate/PlatformCredentialTest.java
@@ -561,7 +561,7 @@ public class PlatformCredentialTest {
                                         .equals("BIOS"));
         Assert.assertTrue(component.getComponentSerial()
                                         .getString()
-                                        .equals("[Empty]"));
+                                        .equals(""));
         Assert.assertTrue(component.getComponentRevision()
                                         .getString()
                                         .equals("DNKBLi5v.86A.0019.2017.0804.1146"));

--- a/HIRS_Utils/src/test/java/hirs/validation/SupplyChainCredentialValidatorTest.java
+++ b/HIRS_Utils/src/test/java/hirs/validation/SupplyChainCredentialValidatorTest.java
@@ -1113,7 +1113,8 @@ public class SupplyChainCredentialValidatorTest {
                 + "Platform version did not match\n"
                 + "Platform serial did not match\n"
                 + "There are unmatched components:\n"
-                + "Manufacturer=Intel, Model=platform2018\n";
+                + "Manufacturer=Intel, Model=platform2018,"
+                + " Serial=BQKP52840678, Revision=1.0\n";
 
         AppraisalStatus result =
                 supplyChainCredentialValidator.validatePlatformCredentialAttributes(
@@ -1757,7 +1758,8 @@ public class SupplyChainCredentialValidatorTest {
         Assert.assertEquals(result.getAppStatus(), AppraisalStatus.Status.FAIL);
         Assert.assertEquals(result.getMessage(), "Component manufacturer is empty\n"
                 + "There are unmatched components:\n"
-                + "Manufacturer=, Model=Core i7\n");
+                + "Manufacturer=, Model=Core i7, Serial=Not Specified,"
+                + " Revision=Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz\n");
 
         platformCredential = setupMatchingPlatformCredential(deviceInfoReport);
         result = SupplyChainCredentialValidator
@@ -1813,7 +1815,7 @@ public class SupplyChainCredentialValidatorTest {
                         deviceInfoReport);
         Assert.assertEquals(result.getAppStatus(), AppraisalStatus.Status.FAIL);
         Assert.assertEquals(result.getMessage(), "There are unmatched components:\n"
-                + "Manufacturer=ACME, Model=TNT\n");
+                + "Manufacturer=ACME, Model=TNT, Serial=2, Revision=1.1\n");
     }
 
     /**
@@ -1876,7 +1878,8 @@ public class SupplyChainCredentialValidatorTest {
         Assert.assertEquals(result.getAppStatus(), AppraisalStatus.Status.FAIL);
         Assert.assertEquals(result.getMessage(), "Component manufacturer is empty\n"
                 + "There are unmatched components:\n"
-                + "Manufacturer=, Model=Core i7\n");
+                + "Manufacturer=, Model=Core i7, Serial=Not Specified,"
+                + " Revision=Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz\n");
 
         platformCredential = setupMatchingPlatformCredential(deviceInfoReport);
         result = SupplyChainCredentialValidator


### PR DESCRIPTION
The supply chain validation has reported non-matches for components that are initialized as null or blank or never initialized by code but by COTS. The end results is validation failure because the certificate compare will be null and the device report will list blank or Not Specified. This issue is to synch all to 'Not Specified'. Previous blank was set but that still caused issue with a blank compared to a 'Not Specified'.

Added additional information to be printed to the log when a failure occurs.

In addition, this issue may crop back up depending on what manufacturers do for empty slots on platforms.

Closes #103