### PR TITLE
[#130] Fixed Doxygen warnings.

### DIFF
--- a/HIRS_ProvisionerTPM2/config/doxygen.config
+++ b/HIRS_ProvisionerTPM2/config/doxygen.config
@@ -309,7 +309,7 @@ AUTOLINK_SUPPORT       = YES
 # diagrams that involve STL classes more complete and accurate.
 # The default value is: NO.
 
-BUILTIN_STL_SUPPORT    = NO
+BUILTIN_STL_SUPPORT    = YES
 
 # If you use Microsoft's C++/CLI language, you should set this option to YES to
 # enable parsing support.

--- a/HIRS_ProvisionerTPM2/src/Properties.cpp
+++ b/HIRS_ProvisionerTPM2/src/Properties.cpp
@@ -125,7 +125,8 @@ namespace properties {
          * Retrieve the value associated with the given key.  If no such key exists in these properties,
          * this method will return the given default value.
          *
-         * @param key
+         * @param key the name of the property being searched for
+         * @param defaultValue the default value to return if none is found
          * @return the key's associated value, or the given default if no value is set
          */
         string Properties::get(const string& key, const string& defaultValue) {


### PR DESCRIPTION
There were some warnings generated by Doxygen when compiling.
One was from an undocumented parameter for a method in the
Properties class. Many others were due to a setting that prevented
Doxygen from being able to associate function declarations with
their definitions if their parameters used standard library objects.

Closes #130.