### PR TITLE
[#135] Fix DeviceInfoCollector's handling of C-Style Strings

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/client/collector/DeviceInfoCollector.java
+++ b/HIRS_Utils/src/main/java/hirs/client/collector/DeviceInfoCollector.java
@@ -293,10 +293,15 @@ public class DeviceInfoCollector extends AbstractCollector {
                         && tokens[VERSION_INDEX].equals("Version")) {
                     String[] versionTokens = tokens[VERSION_TOKEN_INDEX].split("\\.");
                     if (versionTokens.length == VERSION_TOKEN_LENGTH) {
-                        tpmVersionMajor = Short.parseShort(versionTokens[TPM_MAJOR_INDEX]);
-                        tpmVersionMinor = Short.parseShort(versionTokens[TPM_MINOR_INDEX]);
-                        tpmVersionRevMajor = Short.parseShort(versionTokens[TPM_REV_MAJOR_INDEX]);
-                        tpmVersionRevMinor = Short.parseShort(versionTokens[TPM_REV_MINOR_INDEX]);
+                        // Trim version tokens to avoid C-style strings w/ null characters
+                        tpmVersionMajor = Short.parseShort(
+                                versionTokens[TPM_MAJOR_INDEX].trim());
+                        tpmVersionMinor = Short.parseShort(
+                                versionTokens[TPM_MINOR_INDEX].trim());
+                        tpmVersionRevMajor = Short.parseShort(
+                                versionTokens[TPM_REV_MAJOR_INDEX].trim());
+                        tpmVersionRevMinor = Short.parseShort(
+                                versionTokens[TPM_REV_MINOR_INDEX].trim());
                         LOGGER.debug("Found TPM version {}.{}.{}.{}",
                                 tpmVersionMajor, tpmVersionMinor,
                                 tpmVersionRevMajor, tpmVersionRevMinor);


### PR DESCRIPTION
Threw in some calls to Trim the version tokens in the `collectTPMInfo` method. Issues were occurring with parsing C-Style strings into shorts on systems running the TPM2_Provisioner's `tpm_version` binary.

Closes #135