### PR TITLE
[#135] tpm_version prints output containing nulls.

### DIFF
--- a/HIRS_ProvisionerTPM2/src/tpm_version.cpp
+++ b/HIRS_ProvisionerTPM2/src/tpm_version.cpp
@@ -114,6 +114,9 @@ class SapiContext {
 string reversedStringValue(UINT32 value) {
     string stringValue(sizeof value, 0);
     std::memcpy(&stringValue[0], &value, stringValue.size());  // copy bytes in
+    // get rid of all contained null values
+    stringValue.erase(std::remove(stringValue.begin(), stringValue.end(), '\0'),
+       stringValue.end());
     std::reverse(stringValue.begin(), stringValue.end());  // reverse the bytes
     return stringValue;
 }


### PR DESCRIPTION
The tpm_version tool can sometimes print a null
value as part of the TPM major version if the major
version is less than 4 characters. These nulls are
now removed before printing.