### PR TITLE
[#138] Add Platform Attribute Validation to System Tests (TPM 2.0 Emulator)

### DIFF
--- a/.ci/docker/Dockerfile.tpm2provisioner
+++ b/.ci/docker/Dockerfile.tpm2provisioner
@@ -9,4 +9,4 @@ RUN yum install -y tpm2-tools libcurl procps-ng vim-common wget dbus python-requ
 RUN mkdir paccor && pushd paccor && wget https://github.com/nsacyber/paccor/releases/download/v1.0.6r3/paccor-1.0.6-3.noarch.rpm && yum -y install paccor-*.rpm && popd
 
 # Install Software TPM for Provisioning
-RUN mkdir ibmtpm && pushd ibmtpm && wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm974.tar.gz && tar -zxvf ibmtpm974.tar.gz && cd src && make -j5 && popd
+RUN mkdir ibmtpm && pushd ibmtpm && wget https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm1119.tar.gz && tar -zxvf ibmtpm1119.tar.gz && cd src && make -j5 && popd

--- a/.ci/docker/docker-compose-tpm2.yml
+++ b/.ci/docker/docker-compose-tpm2.yml
@@ -27,11 +27,13 @@ services:
       entrypoint: /bin/bash -c
       command: [HIRS/.ci/integration-tests/setup-tpm2provisioner.sh;
                 HIRS/.ci/system-tests/systems-test-centos7-tpm2.sh]
+      devices:
+         - "/dev/mem:/dev/mem"
+      cap_add:
+         - sys_rawio
       networks:
          hirs_aca_system_tests:
             ipv4_address: ${HIRS_ACA_PROVISIONER_TPM2_IP}
-      environment:
-         - HIRS_ACA_PROVISIONER_TPM2_IP=${HIRS_ACA_PROVISIONER_TPM2_IP}
          - TPM_ENABLED=${TPM_ENABLED}
          - IMA_ENABLED=${IMA_ENABLED}
          - HIRS_ACA_PORTAL_IP=${HIRS_ACA_PORTAL_IP}

--- a/.ci/docker/docker-compose-tpm2.yml
+++ b/.ci/docker/docker-compose-tpm2.yml
@@ -1,3 +1,6 @@
+---
+# Run YAML Lint to verify this file prior to check-in.
+
 version: "3.1"
 
 services:
@@ -15,7 +18,7 @@ services:
          hirs_aca_system_tests:
             ipv4_address: ${HIRS_ACA_PORTAL_IP}
             aliases:
-              - ${HIRS_ACA_HOSTNAME}
+               - ${HIRS_ACA_HOSTNAME}
 
    tpm2provisioner:
       image: hirs/hirs-ci:tpm2provisioner
@@ -34,6 +37,8 @@ services:
       networks:
          hirs_aca_system_tests:
             ipv4_address: ${HIRS_ACA_PROVISIONER_TPM2_IP}
+      environment:
+         - HIRS_ACA_PROVISIONER_TPM2_IP=${HIRS_ACA_PROVISIONER_TPM2_IP}
          - TPM_ENABLED=${TPM_ENABLED}
          - IMA_ENABLED=${IMA_ENABLED}
          - HIRS_ACA_PORTAL_IP=${HIRS_ACA_PORTAL_IP}
@@ -49,4 +54,4 @@ networks:
       ipam:
          driver: default
          config:
-           - subnet: ${HIRS_SUBNET}
+            - subnet: ${HIRS_SUBNET}

--- a/.ci/system-tests/system_test_core.py
+++ b/.ci/system-tests/system_test_core.py
@@ -307,8 +307,8 @@ class AttestationCAPortal:
                      expected_status_codes=[404, 200], params={'ecValidate': "checked",})
         self.request("post", "portal/policy/update-pc-validation",
                      expected_status_codes=[404, 200], params={'pcValidate': 'checked'})
-        #self.request("post", "portal/policy/update-pc-attribute-validation",
-        #            expected_status_codes=[404, 200], params={'pcAttributeValidate': 'checked'})
+        self.request("post", "portal/policy/update-pc-attribute-validation",
+                    expected_status_codes=[404, 200], params={'pcAttributeValidate': 'checked'})
 
     def enable_ec_validation(self):
         self.request("post", "portal/policy/update-ec-validation",


### PR DESCRIPTION
Code was recently added to update the platform attribute validation.
This ticket provides updates to support the validation:

1. Update the tpm2provisioner Docker image to use latest TPM2 Emulator. 
2. Update the docker-compose-tpm2.yml, so PACCOR can collect device info from within the container.
3. Enable platform attribute validation in **system_test_core.py:enable_supply_chain_validations()**, to be ran during system tests.