### PR TITLE
[#142] Make sure Tomcat stops completely in Docker containers before restarting it

### DIFF
--- a/package/scripts/aca/certificate_generate.sh
+++ b/package/scripts/aca/certificate_generate.sh
@@ -75,6 +75,10 @@ if [ $DOCKER_CONTAINER = true ]; then
     if [[ $(ss -t -l -n | grep -q LISTEN.*:::8009) -eq 0 ]]; then
         echo "Tomcat is running, so we restart it."
         /usr/libexec/tomcat/server stop
+        # Wait for Tomcat to stop completely and prevent port bind collisions
+        while [ -z $(tail -n 1 /var/log/tomcat/catalina.$(date +"%Y-%m-%d").log | grep "Destroying ProtocolHandler \[\"http-bio-8443\"\]") ]; do
+            :
+        done
         (/usr/libexec/tomcat/server start) &
         # Wait for Tomcat to boot completely
         until [ "`curl --silent --connect-timeout 1 -I http://localhost:8080 | grep 'Coyote'`" != "" ]; do

--- a/package/scripts/aca/certificate_generate.sh
+++ b/package/scripts/aca/certificate_generate.sh
@@ -76,7 +76,7 @@ if [ $DOCKER_CONTAINER = true ]; then
         echo "Tomcat is running, so we restart it."
         /usr/libexec/tomcat/server stop
         # Wait for Tomcat to stop completely and prevent port bind collisions
-        while [ -z $(tail -n 1 /var/log/tomcat/catalina.$(date +"%Y-%m-%d").log | grep "Destroying ProtocolHandler \[\"http-bio-8443\"\]") ]; do
+        while [ -z "$(tail -n 1 /var/log/tomcat/catalina.$(date +"%Y-%m-%d").log | grep "Destroying ProtocolHandler \[\"http-bio-8443\"\]")" ]; do
             :
         done
         (/usr/libexec/tomcat/server start) &

--- a/package/scripts/common/db_create.sh
+++ b/package/scripts/common/db_create.sh
@@ -24,9 +24,9 @@ else
 fi
 
 if [[ -f /etc/redhat-release ]] ; then
-CENTOS_VER=`/opt/hirs/scripts/common/get_centos_major_version.sh`
+    CENTOS_VER=`/opt/hirs/scripts/common/get_centos_major_version.sh`
 elif [[ -f /etc/os-release ]] ; then
-AMAZON_VER=`/opt/hirs/scripts/common/get_amazon_linux_major_version.sh`
+    AMAZON_VER=`/opt/hirs/scripts/common/get_amazon_linux_major_version.sh`
 fi
 if [ $CENTOS_VER -eq "6" ] ; then
     DB_CREATE_SCRIPT=/opt/hirs/scripts/common/db_create.sql.el6


### PR DESCRIPTION
This is a small MR that does as advertised. We want to avoid port collisions when the ACA is run parallel with other webapps in a Tomcat deployment in Docker containers.

Closes #142 