### PR TITLE
[#133] Multiple base restriction

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
@@ -38,6 +38,8 @@ import hirs.persist.CriteriaModifier;
 import hirs.persist.CrudManager;
 import hirs.persist.DBManagerException;
 import hirs.persist.OrderedListQuerier;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -528,6 +530,30 @@ public class CertificateRequestPageController extends PageController<NoPageParam
     }
 
     /**
+     * Gets the certificate by the platform serial number.
+     *
+     * @param certificateType String containing the certificate type
+     * @param serialNumber the platform serial number
+     * @param certificateManager the certificate manager to query
+     * @return the certificate or null if none is found
+     */
+    private List<PlatformCredential> getCertificateByBoardSN(
+            final String certificateType,
+            final String serialNumber,
+            final CertificateManager certificateManager) {
+
+        switch (certificateType) {
+            case PLATFORMCREDENTIAL:
+                return PlatformCredential
+                        .select(certificateManager)
+                        .byBoardSerialNumber(serialNumber)
+                        .getCertificates().stream().collect(Collectors.toList());
+            default:
+                return null;
+        }
+    }
+
+    /**
      * Parses an uploaded file into a certificate and populates the given model
      * with error messages if parsing fails.
      *
@@ -626,6 +652,27 @@ public class CertificateRequestPageController extends PageController<NoPageParam
         try {
             // save the new certificate if no match is found
             if (existingCertificate == null) {
+                if (certificateType.equals(PLATFORMCREDENTIAL)) {
+                    PlatformCredential platformCertificate = (PlatformCredential) certificate;
+                    List<PlatformCredential> sharedCertificates = getCertificateByBoardSN(
+                            certificateType,
+                            platformCertificate.getPlatformSerial(),
+                            certificateManager);
+
+                    for (PlatformCredential pc : sharedCertificates) {
+                        if (pc.isBase()) {
+                            final String failMessage = "Storing certificate failed: "
+                                    + "platform credential "
+                                    + "chain (" + pc.getPlatformSerial()
+                                    + ") base already exists in this chain ("
+                                    + fileName + ")";
+                            messages.addError(failMessage);
+                            LOGGER.error(failMessage);
+                            return;
+                        }
+                    }
+                }
+
                 certificateManager.save(certificate);
 
                 final String successMsg = "New certificate successfully uploaded ("

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
@@ -370,7 +370,7 @@ public class CertificateRequestPageController extends PageController<NoPageParam
         Map<String, Object> model = new HashMap<>();
         PageMessages messages = new PageMessages();
 
-        for (MultipartFile file :files) {
+        for (MultipartFile file : files) {
             //Parse certificate
             Certificate certificate = parseCertificate(certificateType, file, messages);
 
@@ -542,6 +542,10 @@ public class CertificateRequestPageController extends PageController<NoPageParam
             final String serialNumber,
             final CertificateManager certificateManager) {
 
+        if (serialNumber == null) {
+            return null;
+        }
+
         switch (certificateType) {
             case PLATFORMCREDENTIAL:
                 return PlatformCredential
@@ -659,16 +663,18 @@ public class CertificateRequestPageController extends PageController<NoPageParam
                             platformCertificate.getPlatformSerial(),
                             certificateManager);
 
-                    for (PlatformCredential pc : sharedCertificates) {
-                        if (pc.isBase()) {
-                            final String failMessage = "Storing certificate failed: "
-                                    + "platform credential "
-                                    + "chain (" + pc.getPlatformSerial()
-                                    + ") base already exists in this chain ("
-                                    + fileName + ")";
-                            messages.addError(failMessage);
-                            LOGGER.error(failMessage);
-                            return;
+                    if (sharedCertificates != null) {
+                        for (PlatformCredential pc : sharedCertificates) {
+                            if (pc.isBase()) {
+                                final String failMessage = "Storing certificate failed: "
+                                        + "platform credential "
+                                        + "chain (" + pc.getPlatformSerial()
+                                        + ") base already exists in this chain ("
+                                        + fileName + ")";
+                                messages.addError(failMessage);
+                                LOGGER.error(failMessage);
+                                return;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Updated the controller for the upload feature of the ACA for certificates and modified the platform certificate portion to restrict the upload if a base exists in that associated certificate chain associated with the same platform serial number.

Added code that deletes the entire chain if the base is deleted.

Closes #133 & #134