### PR TITLE
[#154] Fix code for Delta Certificate Deletion

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
@@ -261,16 +261,19 @@ public class CertificateRequestPageController extends PageController<NoPageParam
             } else {
                 if (certificateType.equals(PLATFORMCREDENTIAL)) {
                     PlatformCredential platformCertificate = (PlatformCredential) certificate;
-                    List<PlatformCredential> sharedCertificates = getCertificateByBoardSN(
-                            certificateType,
-                            platformCertificate.getPlatformSerial(),
-                            certificateManager);
+                    if (platformCertificate.isBase()) {
+                        // only do this if the base is being deleted.
+                        List<PlatformCredential> sharedCertificates = getCertificateByBoardSN(
+                                certificateType,
+                                platformCertificate.getPlatformSerial(),
+                                certificateManager);
 
-                    if (sharedCertificates != null) {
-                        for (PlatformCredential pc : sharedCertificates) {
-                            if (!pc.isBase()) {
-                                pc.archive();
-                                certificateManager.update(pc);
+                        if (sharedCertificates != null) {
+                            for (PlatformCredential pc : sharedCertificates) {
+                                if (!pc.isBase()) {
+                                    pc.archive();
+                                    certificateManager.update(pc);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Modified the request class that handles uploading, deleting and other associated ACA actions, to only delete multiple associated certificates if the certificate being deleted is a base platform certificate.

Closes #154 