### PR TITLE
Clean up

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -367,7 +367,7 @@ public abstract class AbstractAttestationCertificateAuthority
     /**
      * Basic implementation of the ACA processIdentityClaimTpm2 method. Parses the claim,
      * stores the device info, performs supply chain validation, generates a nonce,
-     * and wraps that nonce with the makecredential process before returning it to the client.
+     * and wraps that nonce with the make credential process before returning it to the client.
      *
      * @param identityClaim the request to process, cannot be null
      * @return an identity claim response for the specified request containing a wrapped blob

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/CredentialManagementHelper.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/CredentialManagementHelper.java
@@ -7,6 +7,9 @@ import hirs.data.persist.certificate.PlatformCredential;
 import hirs.persist.CertificateManager;
 import hirs.persist.DBManagerException;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 
 /**
  * Utility class which includes credential management functions used by the ACA.
@@ -30,11 +33,11 @@ public final class CredentialManagementHelper {
             final CertificateManager certificateManager,
             final byte[] endorsementBytes) throws IllegalArgumentException {
 
-        if (null == certificateManager) {
+        if (certificateManager == null) {
             throw new IllegalArgumentException("null certificate manager");
         }
 
-        if (null == endorsementBytes) {
+        if (endorsementBytes == null) {
             throw new IllegalArgumentException("null endorsement credential bytes");
         }
 
@@ -59,7 +62,7 @@ public final class CredentialManagementHelper {
         EndorsementCredential existingCredential =
                 EndorsementCredential.select(certificateManager).includeArchived()
                         .byHashCode(certificateHash).getCertificate();
-        if (null == existingCredential) {
+        if (existingCredential == null) {
             LOG.info("No Endorsement Credential found with hash: " + certificateHash);
             return (EndorsementCredential) certificateManager.save(endorsementCredential);
         } else if (existingCredential.isArchived()) {
@@ -83,11 +86,11 @@ public final class CredentialManagementHelper {
             final CertificateManager certificateManager,
             final byte[] platformBytes) {
 
-        if (null == certificateManager) {
+        if (certificateManager == null) {
             throw new IllegalArgumentException("null certificate manager");
         }
 
-        if (null == platformBytes) {
+        if (platformBytes == null) {
             throw new IllegalArgumentException("null platform credential bytes");
         }
 
@@ -101,13 +104,30 @@ public final class CredentialManagementHelper {
         try {
             PlatformCredential platformCredential =
                     PlatformCredential.parseWithPossibleHeader(platformBytes);
-            if (null == platformCredential) {
+            if (platformCredential == null) {
                 return null;
             }
             PlatformCredential existingCredential =
                     PlatformCredential.select(certificateManager)
                 .byHashCode(platformCredential.getCertificateHash()).getCertificate();
-            if (null == existingCredential) {
+            if (existingCredential == null) {
+                List<PlatformCredential> certificates = PlatformCredential
+                        .select(certificateManager)
+                        .byBoardSerialNumber(platformCredential.getPlatformSerial())
+                        .getCertificates().stream().collect(Collectors.toList());
+                if (!certificates.isEmpty()) {
+                    // found associated certificates
+                    for (PlatformCredential pc : certificates) {
+                        if (pc.isBase()) {
+                            // found a base in the database associated with
+                            // parsed certificate
+                            LOG.error(String.format("Base certificate stored"
+                                    + " in database with same platform serial number. (%s)",
+                                    platformCredential.getPlatformSerial()));
+                            return null;
+                        }
+                    }
+                }
                 return (PlatformCredential) certificateManager.save(platformCredential);
             } else if (existingCredential.isArchived()) {
                 // if the PC is stored in the DB and it's archived, unarchive.

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/CredentialManagementHelper.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/CredentialManagementHelper.java
@@ -111,20 +111,22 @@ public final class CredentialManagementHelper {
                     PlatformCredential.select(certificateManager)
                 .byHashCode(platformCredential.getCertificateHash()).getCertificate();
             if (existingCredential == null) {
-                List<PlatformCredential> certificates = PlatformCredential
-                        .select(certificateManager)
-                        .byBoardSerialNumber(platformCredential.getPlatformSerial())
-                        .getCertificates().stream().collect(Collectors.toList());
-                if (!certificates.isEmpty()) {
-                    // found associated certificates
-                    for (PlatformCredential pc : certificates) {
-                        if (pc.isBase()) {
-                            // found a base in the database associated with
-                            // parsed certificate
-                            LOG.error(String.format("Base certificate stored"
-                                    + " in database with same platform serial number. (%s)",
-                                    platformCredential.getPlatformSerial()));
-                            return null;
+                if (platformCredential.getPlatformSerial() != null) {
+                    List<PlatformCredential> certificates = PlatformCredential
+                            .select(certificateManager)
+                            .byBoardSerialNumber(platformCredential.getPlatformSerial())
+                            .getCertificates().stream().collect(Collectors.toList());
+                    if (!certificates.isEmpty()) {
+                        // found associated certificates
+                        for (PlatformCredential pc : certificates) {
+                            if (pc.isBase()) {
+                                // found a base in the database associated with
+                                // parsed certificate
+                                LOG.error(String.format("Base certificate stored"
+                                                + " in database with same platform serial number. (%s)",
+                                        platformCredential.getPlatformSerial()));
+                                return null;
+                            }
                         }
                     }
                 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/CredentialManagementHelper.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/CredentialManagementHelper.java
@@ -123,7 +123,8 @@ public final class CredentialManagementHelper {
                                 // found a base in the database associated with
                                 // parsed certificate
                                 LOG.error(String.format("Base certificate stored"
-                                                + " in database with same platform serial number. (%s)",
+                                                + " in database with same platform"
+                                                + "serial number. (%s)",
                                         platformCredential.getPlatformSerial()));
                                 return null;
                             }

--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -573,6 +573,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
             final List<ComponentIdentifier> origPcComponents) {
         boolean fieldValidation = true;
         StringBuilder resultMessage = new StringBuilder();
+        StringBuilder deltaMessage = new StringBuilder();
         List<ComponentIdentifier> validOrigPcComponents = origPcComponents.stream()
                 .filter(identifier -> identifier.getComponentManufacturer() != null
                         && identifier.getComponentModel() != null)
@@ -598,7 +599,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                         // check it is there
                         if (!chainCiMapping.containsKey(ciSerial)) {
                             fieldValidation = false;
-                            resultMessage.append(String.format(
+                            deltaMessage.append(String.format(
                                     "%s attempted MODIFIED with no prior instance.%n",
                                     ciSerial));
                         } else {
@@ -608,7 +609,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                         if (!chainCiMapping.containsKey(ciSerial)) {
                             // error thrown, can't remove if it doesn't exist
                             fieldValidation = false;
-                            resultMessage.append(String.format(
+                            deltaMessage.append(String.format(
                                     "%s attempted REMOVED with no prior instance.%n",
                                     ciSerial));
                         } else {
@@ -619,11 +620,11 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                         if (chainCiMapping.containsKey(ciSerial)) {
                             // error, shouldn't exist
                             fieldValidation = false;
-                            resultMessage.append(String.format(
+                            deltaMessage.append(String.format(
                                     "%s was ADDED, the serial already exists.%n",
                                     ciSerial));
                         } else {
-                            // have to add incase later it is removed
+                            // have to add in case later it is removed
                             chainCiMapping.put(ciSerial, ci);
                         }
                     }
@@ -632,9 +633,8 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
         }
 
         if (!fieldValidation) {
-            resultMessage.append("There are errors with Delta "
-                    + "Component Statuses components:\n");
-
+            resultMessage.append("There are errors with Delta Component Statuses components:\n");
+            resultMessage.append(deltaMessage.toString());
             return new AppraisalStatus(FAIL, resultMessage.toString());
         }
 


### PR DESCRIPTION
The credential management helper was updated to notice and then not save a duplicate base certificate.  This mainly affects the emulator.

Closes #171 