### PR TITLE
[#166] Validation icon swap

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
@@ -94,7 +94,6 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
      * @return A summary of the validation results.
      */
     @Override
-    @SuppressWarnings("methodlength")
     public SupplyChainValidationSummary validateSupplyChain(final EndorsementCredential ec,
         final Set<PlatformCredential> pcs,
         final Device device) {
@@ -169,12 +168,11 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
                     if (baseCredential == null || pc == baseCredential && !pc.isDeltaChain()) {
                         attributeScv = validatePlatformCredentialAttributes(
                             pc, device.getDeviceInfo(), ec);
+                        validations.add(attributeScv);
                     } else {
-
-                        attributeScv = validateDeltaPlatformCredentialAttributes(
+                        validateDeltaPlatformCredentialAttributes(
                             pc, device.getDeviceInfo(), baseCredential, deltaMapping);
                     }
-
 
                     if (pc != null) {
                         pc.setDevice(device);
@@ -184,10 +182,9 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
             }
         }
 
-
-                    if (!deltaMapping.isEmpty()) {
-                        validations.addAll(deltaMapping.values());
-                    }
+        if (!deltaMapping.isEmpty()) {
+            validations.addAll(deltaMapping.values());
+        }
 
         // Generate validation summary, save it, and return it.
         SupplyChainValidationSummary summary =

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -252,6 +253,15 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
                     .select(certificateManager)
                     .byBoardSerialNumber(pc.getPlatformSerial())
                     .getCertificates().stream().collect(Collectors.toList());
+            Collections.sort(chainCertificates,
+                    new Comparator<PlatformCredential>() {
+                @Override
+                public int compare(final PlatformCredential obj1,
+                                   final PlatformCredential obj2) {
+                    return obj1.getBeginValidity()
+                            .compareTo(obj2.getBeginValidity());
+                }
+            });
 
             SupplyChainValidation deltaScv;
             KeyStore trustedCa;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
@@ -112,7 +112,6 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
         if (policy.isEcValidationEnabled()) {
             validationTypeMap.put(SupplyChainValidation.ValidationType.ENDORSEMENT_CREDENTIAL,
                     validateEndorsementCredential(ec, acceptExpiredCerts));
-//            validations.add(validateEndorsementCredential(ec, acceptExpiredCerts));
             // store the device with the credential
             if (null != ec) {
                 ec.setDevice(device);
@@ -148,7 +147,6 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
                         validationTypeMap.put(SupplyChainValidation
                                 .ValidationType.PLATFORM_CREDENTIAL,
                                 platformScv);
-//                        validations.add(platformScv);
                         pc.setDevice(device);
                         this.certificateManager.update(pc);
                         if (pc.isBase()) {
@@ -183,7 +181,6 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
                         validationTypeMap.put(SupplyChainValidation
                                 .ValidationType.PLATFORM_CREDENTIAL,
                                 attributeScv);
-//                        validations.add(attributeScv);
                     }
 
                     if (pc != null && pc.isDeltaChain()) {

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
@@ -241,7 +241,7 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
                 validateEndorsementCredential(eq(ec), any(KeyStore.class), eq(true));
         doReturn(new AppraisalStatus(FAIL, "")).when(supplyChainCredentialValidator).
                 validatePlatformCredential(eq(pc), any(KeyStore.class), eq(true));
-        doReturn(new AppraisalStatus(PASS, "")).when(supplyChainCredentialValidator)
+        doReturn(new AppraisalStatus(FAIL, "")).when(supplyChainCredentialValidator)
                 .validatePlatformCredentialAttributes(eq(pc), any(DeviceInfoReport.class),
                         any(EndorsementCredential.class));
         Assert.assertEquals(service.validateSupplyChain(ec, pcs,

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
@@ -144,7 +144,6 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
         //when(delta.getSerialNumber()).thenReturn(BigInteger.ONE);
         when(delta.getIssuerOrganization()).thenReturn("STMicroelectronics NV");
         when(delta.getSubjectOrganization()).thenReturn("STMicroelectronics NV");
-        //pcs.add(delta);
 
         Set<Certificate> resultPcs = new HashSet<>();
         resultPcs.add(pc);
@@ -260,6 +259,7 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
         when(policy.isPcAttributeValidationEnabled()).thenReturn(true);
         when(policy.isExpiredCertificateValidationEnabled()).thenReturn(true);
 
+        pcs.add(delta);
         doReturn(new AppraisalStatus(PASS, "")).when(supplyChainCredentialValidator).
                 validateEndorsementCredential(eq(ec), any(KeyStore.class), eq(true));
         doReturn(new AppraisalStatus(PASS, "")).when(supplyChainCredentialValidator).
@@ -271,6 +271,7 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
         Assert.assertEquals(service.validateSupplyChain(ec, pcs,
                 device).getOverallValidationResult(), FAIL);
         verify(supplyChainValidationSummaryDBManager).save(any(SupplyChainValidationSummary.class));
+        pcs.remove(delta);
     }
 
     /**

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
@@ -259,7 +259,6 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
         when(policy.isPcAttributeValidationEnabled()).thenReturn(true);
         when(policy.isExpiredCertificateValidationEnabled()).thenReturn(true);
 
-        pcs.add(delta);
         doReturn(new AppraisalStatus(PASS, "")).when(supplyChainCredentialValidator).
                 validateEndorsementCredential(eq(ec), any(KeyStore.class), eq(true));
         doReturn(new AppraisalStatus(PASS, "")).when(supplyChainCredentialValidator).
@@ -271,7 +270,6 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
         Assert.assertEquals(service.validateSupplyChain(ec, pcs,
                 device).getOverallValidationResult(), FAIL);
         verify(supplyChainValidationSummaryDBManager).save(any(SupplyChainValidationSummary.class));
-        pcs.remove(delta);
     }
 
     /**

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
@@ -616,12 +616,12 @@
                                                             <div class="panel panel-default">
                                                                 <div class="panel-heading">
                                                                     <c:choose>
-                                                                       <c:when test="${component.isVersion2()=='TRUE'}">
-                                                                           <span data-toggle="tooltip" data-placement="top" title="Component Class">${component.getComponentClass()}</span>
-                                                                       </c:when>
-                                                                       <c:otherwise>
-                                                                           <span data-toggle="tooltip" data-placement="top" title="Component Class">Platform Components</span>
-                                                                       </c:otherwise>
+                                                                        <c:when test="${component.isVersion2()=='TRUE'}">
+                                                                            <span data-toggle="tooltip" data-placement="top" title="Component Class">${component.getComponentClass()}</span>
+                                                                        </c:when>
+                                                                        <c:otherwise>
+                                                                            <span data-toggle="tooltip" data-placement="top" title="Component Class">Platform Components</span>
+                                                                        </c:otherwise>
                                                                     </c:choose>
                                                                 </div>
                                                                 <div class="panel-body">
@@ -649,22 +649,22 @@
                                                                             <span class="label label-danger">Irreplaceable</span><br/>
                                                                         </c:otherwise>
                                                                     </c:choose>
-                                                                        <c:if test="${component.isVersion2()}">
-                                                                            <c:if test="${not empty component.getCertificateIdentifier()}">
-                                                                                <span class="fieldHeader">Platform Certificate Issuer:</span>
-                                                                                <span class="fieldValue">${component.getCertificateIdentifier().getIssuerDN()}</span><br />
-                                                                                <span class="fieldHeader">Platform Certificate Serial Number:</span>
-                                                                                <span class="fieldValue">${component.getCertificateIdentifier().getCertificateSerialNumber()}</span><br />
-                                                                                <span class="fieldHeader">Platform Certificate URI:</span>  
-                                                                            </c:if>
-                                                                            <span class="fieldValue">
-                                                                                <a href="${component.getComponentPlatformUri().getUniformResourceIdentifier()}">
-                                                                                    ${component.getComponentPlatformUri().getUniformResourceIdentifier()}
-                                                                                </a>
-                                                                            </span><br />
-                                                                            <span class="fieldHeader">Status:</span>
-                                                                            <span class="fieldValue">${component.getAttributeStatus()}</span><br/>
+                                                                    <c:if test="${component.isVersion2()}">
+                                                                        <c:if test="${not empty component.getCertificateIdentifier()}">
+                                                                            <span class="fieldHeader">Platform Certificate Issuer:</span>
+                                                                            <span class="fieldValue">${component.getCertificateIdentifier().getIssuerDN()}</span><br />
+                                                                            <span class="fieldHeader">Platform Certificate Serial Number:</span>
+                                                                            <span class="fieldValue">${component.getCertificateIdentifier().getCertificateSerialNumber()}</span><br />
+                                                                            <span class="fieldHeader">Platform Certificate URI:</span>  
                                                                         </c:if>
+                                                                        <span class="fieldValue">
+                                                                            <a href="${component.getComponentPlatformUri().getUniformResourceIdentifier()}">
+                                                                                ${component.getComponentPlatformUri().getUniformResourceIdentifier()}
+                                                                            </a>
+                                                                        </span><br />
+                                                                        <span class="fieldHeader">Status:</span>
+                                                                        <span class="fieldValue">${component.getAttributeStatus()}</span><br/>
+                                                                    </c:if>
                                                                 </div>
                                                             </div>
                                                         </div>
@@ -825,11 +825,11 @@
                 $("#authorityKeyIdentifier").html("Not Specified");
                 </c:otherwise>
             </c:choose>
-                
-                <c:if test="${not empty initialData.authSerialNumber}">
-                    //Convert string to serial String
-                    $("#authSerialNumber").html(parseSerialNumber(authoritySerialNumber));
-                </c:if>
+
+            <c:if test="${not empty initialData.authSerialNumber}">
+                //Convert string to serial String
+                $("#authSerialNumber").html(parseSerialNumber(authoritySerialNumber));
+            </c:if>
             <c:choose>
                 <c:when test="${not empty initialData.publicKeyValue}">
                 var publicKey = '${initialData.publicKeyValue}';

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/validation-reports.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/validation-reports.jsp
@@ -32,12 +32,12 @@
                         <th rowspan="2">Result</th>
                         <th rowspan="2">Timestamp</th>
                         <th rowspan="2">Device</th>
-                        <th colspan="3">Credential Validations</th>
+                        <th colspan="2">Credential Validations</th>
                     </tr>
                     <tr>
-                        <th>Endorsement</th>
-                        <th>Platform</th>
-                        <th>Platform Attributes</th>
+                        <th style="text-align:center">Endorsement</th>
+                        <th style="text-align:center">Platform</th>
+                        <th></th>
                     </tr>
                 </thead>
             </table>
@@ -55,16 +55,17 @@
 
                                 // create status icon
                                 var result = full.overallValidationResult;
+                                var ovallMessage = full.message;
                                 if (result) {
                                     switch (result) {
                                         case "PASS":
                                             html += '<img src="${passIcon}" title="${passText}"/>';
                                             break;
                                         case "FAIL":
-                                            html += '<img src="${failIcon}" title="${failText}"/>';
+                                            html += '<img src="${failIcon}" title="' + ovallMessage + '"/>';
                                             break;
                                         case "ERROR":
-                                            html += '<img src="${errorIcon}" title="${errorText}"/>';
+                                            html += '<img src="${errorIcon}" title="' + ovallMessage + '"/>';
                                             break;
                                         default:
                                             html += unknownStatus;
@@ -161,7 +162,7 @@
 
                                html += '<a href="${portal}/certificate-details?id='
                                    + curValidation.certificatesUsed[0].id
-                                   + '&type=' + certType + '">'
+                                   + '&type=' + certType + '">';
                            }
 
                            switch (curResult) {

--- a/HIRS_Utils/src/main/java/hirs/data/persist/AbstractEntity.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/AbstractEntity.java
@@ -15,6 +15,13 @@ import org.hibernate.annotations.Type;
  */
 @MappedSuperclass
 public abstract class AbstractEntity {
+
+    /**
+     * static value for the length of a status message for objects that
+     * can have extremely long values, potentially.
+     */
+    protected static final int RESULT_MESSAGE_LENGTH = 1000000;
+
     @Id
     @Column(name = "id")
     @GeneratedValue(generator = "uuid2")

--- a/HIRS_Utils/src/main/java/hirs/data/persist/AppraisalResult.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/AppraisalResult.java
@@ -29,8 +29,6 @@ import javax.xml.bind.annotation.XmlTransient;
 @JsonSerialize(using = AppraisalResultSerializer.class)
 public class AppraisalResult extends AbstractEntity {
 
-    private static final int RESULT_MESSAGE_LENGTH = 1000000;
-
     /**
      * Corresponding <code>Appraiser</code>. Can be NULL.
      */

--- a/HIRS_Utils/src/main/java/hirs/data/persist/NetworkInfo.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/NetworkInfo.java
@@ -22,22 +22,24 @@ public class NetworkInfo implements Serializable {
     private static final Logger LOGGER = LogManager
             .getLogger(NetworkInfo.class);
 
+    private static final int LONG_STRING_LENGTH = 255;
+    private static final int SHORT_STRING_LENGTH = 32;
     private static final int NUM_MAC_ADDRESS_BYTES = 6;
 
     @XmlElement
-    @Column(length = 255, nullable = true)
+    @Column(length = LONG_STRING_LENGTH, nullable = true)
     @SuppressWarnings("checkstyle:magicnumber")
     private String hostname;
 
     @XmlElement
     @XmlJavaTypeAdapter(value = InetAddressXmlAdapter.class)
     @SuppressWarnings("checkstyle:magicnumber")
-    @Column(length = 32, nullable = true)
+    @Column(length = SHORT_STRING_LENGTH, nullable = true)
     @Type(type = "hirs.data.persist.type.InetAddressType")
     private InetAddress ipAddress;
 
     @XmlElement
-    @Column(length = 6, nullable = true)
+    @Column(length = NUM_MAC_ADDRESS_BYTES, nullable = true)
     @SuppressWarnings("checkstyle:magicnumber")
     private byte[] macAddress;
 

--- a/HIRS_Utils/src/main/java/hirs/validation/CredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/CredentialValidator.java
@@ -2,11 +2,12 @@ package hirs.validation;
 
 import hirs.data.persist.AppraisalStatus;
 import hirs.data.persist.DeviceInfoReport;
+import hirs.data.persist.SupplyChainValidation;
 import hirs.data.persist.certificate.EndorsementCredential;
 import hirs.data.persist.certificate.PlatformCredential;
 
 import java.security.KeyStore;
-import java.util.List;
+import java.util.Map;
 
 /**
  * A class used to support supply chain validation by performing the actual
@@ -44,14 +45,15 @@ public interface CredentialValidator {
      *                         serial number of the platform to be validated.
      * @param base the base credential from the same identity request
      *                              as the delta credential.
-     * @param chainCertificates base and delta certificates associated with the
-     *                          delta being validated.
+     * @param deltaMapping delta certificates associated with the
+     *                          delta supply validation.
      * @return the result of the validation.
      */
     AppraisalStatus validateDeltaPlatformCredentialAttributes(PlatformCredential delta,
                                                         DeviceInfoReport deviceInfoReport,
                                                         PlatformCredential base,
-                                                        List<PlatformCredential> chainCertificates);
+                                                        Map<PlatformCredential,
+                                                        SupplyChainValidation> deltaMapping);
     /**
      * Checks if the endorsement credential is valid.
      *

--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -139,7 +139,6 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
             return node.findValue(fieldName).asText();
         }
         return null;
-
     }
 
     /**
@@ -166,7 +165,6 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                 message = baseErrorMessage + "a trust store\n";
                 LOGGER.error(message);
                 return new AppraisalStatus(FAIL, message);
-
             }
         } catch (KeyStoreException e) {
             message = baseErrorMessage + "an intitialized trust store";
@@ -1431,8 +1429,9 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
     }
 
     /**
-     * vavusit.
-     * @return aidfaf
+     * Getter for the collection of delta certificates that have failed and the
+     * associated message.
+     * @return unmodifiable list of failed certificates
      */
     public Map<PlatformCredential, StringBuilder> getDeltaFailures() {
         return Collections.unmodifiableMap(DELTA_FAILURES);

--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -304,7 +304,6 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
         // parse out the provided delta and its specific chain.
         Collections.reverse(chainCertificates);
         List<PlatformCredential> leafChain = new LinkedList<>();
-        PlatformCredential dc;
         List<ComponentIdentifier> origPcComponents = new LinkedList<>();
 
         for (PlatformCredential pc : chainCertificates) {
@@ -315,8 +314,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                     origPcComponents.addAll(pc.getComponentIdentifiers());
                 }
             } else {
-                dc = pc;
-                leafChain.add(dc);
+                leafChain.add(pc);
             }
         }
 
@@ -325,24 +323,6 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
         leafChain.stream().forEach((delta) -> {
             leafMap.put(delta.getHolderSerialNumber().toString(), delta);
         });
-
-        leafChain.clear();
-        String serialNumber = basePlatformCredential.getSerialNumber().toString();
-        PlatformCredential tempCred;
-
-        // Start with the base serial number, find the delta pointing to it
-        // and put that first in the list
-        for (int i = 0; i < leafMap.size(); i++) {
-            tempCred = leafMap.get(serialNumber);
-            // this should never be null
-            if (tempCred != null) {
-                leafChain.add(i, tempCred);
-                serialNumber = tempCred.getSerialNumber().toString();
-            } else {
-                return new AppraisalStatus(ERROR, String.format("Delta platform search "
-                        + "for mapping returned null for %s", serialNumber));
-            }
-        }
 
         return validateDeltaAttributesChainV2p0(deviceInfoReport,
                 leafChain, origPcComponents);
@@ -613,7 +593,6 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                 if (ci.isVersion2()) {
                     ciSerial = ci.getComponentSerial().toString();
                     ComponentIdentifierV2 ciV2 = (ComponentIdentifierV2) ci;
-
                     if (ciV2.isModified())  {
                         // this won't match
                         // check it is there

--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -592,11 +592,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                         // check it is there
                         if (!chainCiMapping.containsKey(ciSerial)) {
                             fieldValidation = false;
-<<<<<<< HEAD
                             failureMsg.append(String.format(
-=======
-                            deltaMessage.append(String.format(
->>>>>>> master
                                     "%s attempted MODIFIED with no prior instance.%n",
                                     ciSerial));
                             scv = deltaEntry.getValue();
@@ -615,11 +611,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                         if (!chainCiMapping.containsKey(ciSerial)) {
                             // error thrown, can't remove if it doesn't exist
                             fieldValidation = false;
-<<<<<<< HEAD
                             failureMsg.append(String.format(
-=======
-                            deltaMessage.append(String.format(
->>>>>>> master
                                     "%s attempted REMOVED with no prior instance.%n",
                                     ciSerial));
                             scv = deltaEntry.getValue();
@@ -639,11 +631,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                         if (chainCiMapping.containsKey(ciSerial)) {
                             // error, shouldn't exist
                             fieldValidation = false;
-<<<<<<< HEAD
                             failureMsg.append(String.format(
-=======
-                            deltaMessage.append(String.format(
->>>>>>> master
                                     "%s was ADDED, the serial already exists.%n",
                                     ciSerial));
                             scv = deltaEntry.getValue();
@@ -667,11 +655,6 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
         }
 
         if (!fieldValidation) {
-<<<<<<< HEAD
-=======
-            resultMessage.append("There are errors with Delta Component Statuses components:\n");
-            resultMessage.append(deltaMessage.toString());
->>>>>>> master
             return new AppraisalStatus(FAIL, resultMessage.toString());
         }
 

--- a/HIRS_Utils/src/test/java/hirs/validation/SupplyChainCredentialValidatorTest.java
+++ b/HIRS_Utils/src/test/java/hirs/validation/SupplyChainCredentialValidatorTest.java
@@ -1161,7 +1161,8 @@ public class SupplyChainCredentialValidatorTest {
      */
     @Test
     public final void verifyPlatformCredentialNullCredentialPath() {
-        String expectedMessage = "Can't validate platform credential without a platform credential";
+        String expectedMessage = "Can't validate platform credential without "
+                + "a platform credential\n";
 
         AppraisalStatus result = supplyChainCredentialValidator.validatePlatformCredential(
                 null, keyStore, true);
@@ -1185,7 +1186,7 @@ public class SupplyChainCredentialValidatorTest {
         PlatformCredential pc = new PlatformCredential(certBytes);
 
         String expectedMessage = "Can't validate platform credential without a "
-                + "trust store";
+                + "trust store\n";
 
         AppraisalStatus result = supplyChainCredentialValidator.validatePlatformCredential(pc, null,
                 true);

--- a/HIRS_Utils/src/test/java/hirs/validation/SupplyChainCredentialValidatorTest.java
+++ b/HIRS_Utils/src/test/java/hirs/validation/SupplyChainCredentialValidatorTest.java
@@ -9,6 +9,7 @@ import hirs.data.persist.HardwareInfo;
 import hirs.data.persist.NICComponentInfo;
 import hirs.data.persist.NetworkInfo;
 import hirs.data.persist.OSInfo;
+import hirs.data.persist.SupplyChainValidation;
 import hirs.data.persist.TPMInfo;
 import hirs.data.persist.certificate.Certificate;
 import hirs.data.persist.certificate.CertificateAuthorityCredential;
@@ -79,8 +80,10 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -2092,10 +2095,22 @@ public class SupplyChainCredentialValidatorTest {
         when(delta1.getComponentIdentifiers()).thenReturn(delta1List);
         when(delta2.getComponentIdentifiers()).thenReturn(delta2List);
 
-        List<PlatformCredential> chainCredentials = new ArrayList<>(0);
-        chainCredentials.add(base);
-        chainCredentials.add(delta1);
-        chainCredentials.add(delta2);
+        Map<PlatformCredential, SupplyChainValidation> chainCredentials = new HashMap<>(0);
+        List<Certificate> certsUsed = new ArrayList<>();
+        certsUsed.add(base);
+        chainCredentials.put(base, new SupplyChainValidation(
+                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
+                AppraisalStatus.Status.PASS, certsUsed, ""));
+        certsUsed.clear();
+        certsUsed.add(delta1);
+        chainCredentials.put(delta1, new SupplyChainValidation(
+                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
+                AppraisalStatus.Status.PASS, certsUsed, ""));
+        certsUsed.clear();
+        certsUsed.add(delta2);
+        chainCredentials.put(delta2, new SupplyChainValidation(
+                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
+                AppraisalStatus.Status.PASS, certsUsed, ""));
 
         AppraisalStatus result = supplyChainCredentialValidator
                 .validateDeltaPlatformCredentialAttributes(delta2,
@@ -2185,9 +2200,17 @@ public class SupplyChainCredentialValidatorTest {
         when(base.getComponentIdentifiers()).thenReturn(compList);
         when(delta1.getComponentIdentifiers()).thenReturn(delta1List);
 
-        List<PlatformCredential> chainCredentials = new ArrayList<>(0);
-        chainCredentials.add(base);
-        chainCredentials.add(delta1);
+        Map<PlatformCredential, SupplyChainValidation> chainCredentials = new HashMap<>(0);
+        List<Certificate> certsUsed = new ArrayList<>();
+        certsUsed.add(base);
+        chainCredentials.put(base, new SupplyChainValidation(
+                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
+                AppraisalStatus.Status.PASS, certsUsed, ""));
+        certsUsed.clear();
+        certsUsed.add(delta1);
+        chainCredentials.put(delta1, new SupplyChainValidation(
+                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
+                AppraisalStatus.Status.PASS, certsUsed, ""));
 
         AppraisalStatus result = supplyChainCredentialValidator
                 .validateDeltaPlatformCredentialAttributes(delta1,


### PR DESCRIPTION
This pull request contains 2 main changes, the first is transferring the status text from the attributes failure to the icon specifically for platform trust chain validation. Then this removes the third column on the validation page that singles out the icons for the attribute status. 

In addition, this status is also rolled up to the summary status icon and displays the text there as well for all that have failed.  This will modify the database.  The SupplyChainValidationSummary was updated to increase the message fields length to accommodate the underlying errors rolling up into this field.

Closes #166 