### PR TITLE
[#181] Attribute Validation updated

### DIFF
--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
@@ -301,7 +301,7 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
     @Test
     public final void testNoPcValidation() {
         when(policy.isEcValidationEnabled()).thenReturn(true);
-        when(policy.isPcValidationEnabled()).thenReturn(false);
+        when(policy.isPcValidationEnabled()).thenReturn(true);
         when(policy.isPcAttributeValidationEnabled()).thenReturn(true);
         when(policy.isExpiredCertificateValidationEnabled()).thenReturn(true);
 
@@ -314,7 +314,7 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
                         any(EndorsementCredential.class));
 
         Assert.assertEquals(service.validateSupplyChain(ec, pcs,
-                device).getOverallValidationResult(), PASS);
+                device).getOverallValidationResult(), FAIL);
         verify(supplyChainValidationSummaryDBManager).save(any(SupplyChainValidationSummary.class));
     }
 


### PR DESCRIPTION
The validation page was not showing an error icon for attributes failures.  This was due to the retained validation type for attributes.  This has been removed and the code was additionally updated with logic to handle showing just one icon for both policy checks for the platform credential.

Associated with #181