### PR TITLE
[#181] Delta holder validation

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
@@ -12,7 +12,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -262,15 +261,6 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
                         .select(certificateManager)
                         .byBoardSerialNumber(pc.getPlatformSerial())
                         .getCertificates().stream().collect(Collectors.toList());
-                Collections.sort(chainCertificates,
-                        new Comparator<PlatformCredential>() {
-                            @Override
-                            public int compare(final PlatformCredential obj1,
-                                    final PlatformCredential obj2) {
-                                return obj1.getBeginValidity()
-                                .compareTo(obj2.getBeginValidity());
-                            }
-                        });
 
                 SupplyChainValidation deltaScv;
                 KeyStore trustedCa;

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
@@ -698,9 +698,9 @@ public class CertificateRequestPageController extends PageController<NoPageParam
                                 }
                             }
                         }
-                    } else {
+                    } /**else {
                         // this is a delta, check if the holder exists.
-                        PlatformCredential holderPC = PlatformCredential
+                       PlatformCredential holderPC = PlatformCredential
                                 .select(certificateManager)
                                 .bySerialNumber(platformCertificate.getHolderSerialNumber())
                                 .getCertificate();
@@ -716,7 +716,7 @@ public class CertificateRequestPageController extends PageController<NoPageParam
                             LOGGER.error(failMessage);
                             return;
                         }
-                    }
+                    }**/
                 }
 
                 certificateManager.save(certificate);

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
@@ -706,11 +706,12 @@ public class CertificateRequestPageController extends PageController<NoPageParam
                                 .getCertificate();
 
                         if (holderPC == null)  {
-                            final String failMessage = "Storing certificate failed: delta credential"
+                            final String failMessage = "Storing certificate failed: "
+                                    + "delta credential"
                                     + " must have an existing holder stored.  "
                                     + "Credential serial "
                                     + platformCertificate.getHolderSerialNumber()
-                                    + " doesn't exist." ;
+                                    + " doesn't exist.";
                             messages.addError(failMessage);
                             LOGGER.error(failMessage);
                             return;

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
@@ -698,6 +698,23 @@ public class CertificateRequestPageController extends PageController<NoPageParam
                                 }
                             }
                         }
+                    } else {
+                        // this is a delta, check if the holder exists.
+                        PlatformCredential holderPC = PlatformCredential
+                                .select(certificateManager)
+                                .bySerialNumber(platformCertificate.getHolderSerialNumber())
+                                .getCertificate();
+
+                        if (holderPC == null)  {
+                            final String failMessage = "Storing certificate failed: delta credential"
+                                    + " must have an existing holder stored.  "
+                                    + "Credential serial "
+                                    + platformCertificate.getHolderSerialNumber()
+                                    + " doesn't exist." ;
+                            messages.addError(failMessage);
+                            LOGGER.error(failMessage);
+                            return;
+                        }
                     }
                 }
 

--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -59,6 +59,7 @@ import hirs.data.persist.SupplyChainValidation;
 import hirs.data.persist.certificate.Certificate;
 import hirs.data.persist.certificate.attributes.V2.ComponentIdentifierV2;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedList;
 import org.apache.logging.log4j.util.Strings;
 
@@ -559,6 +560,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                 .filter(identifier -> identifier.getComponentManufacturer() != null
                         && identifier.getComponentModel() != null)
                 .collect(Collectors.toList());
+        List<PlatformCredential> chainCertificates = new LinkedList<>(deltaMapping.keySet());
 
         // map the components throughout the chain
         Map<String, ComponentIdentifier> chainCiMapping = new HashMap<>();
@@ -567,18 +569,35 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
             chainCiMapping.put(ci.getComponentSerial().toString(), ci);
         });
 
+        Collections.sort(chainCertificates, new Comparator<PlatformCredential>() {
+            @Override
+            public int compare(final PlatformCredential obj1,
+                               final PlatformCredential obj2) {
+                if (obj1 == null) {
+                    return 0;
+                }
+                if (obj2 == null) {
+                    return 0;
+                }
+                if (obj1.getBeginValidity() == null) {
+                    return 0;
+                }
+                if (obj2.getBeginValidity() == null) {
+                    return 0;
+                }
+                return obj1.getBeginValidity().compareTo(obj2.getBeginValidity());
+            }
+        });
+
         String ciSerial;
         List<Certificate> certificateList = null;
-        PlatformCredential delta = null;
         SupplyChainValidation scv = null;
         resultMessage.append("There are errors with Delta "
                     + "Component Statuses components:\n");
         // go through the leaf and check the changes against the valid components
         // forget modifying validOrigPcComponents
-        for (Map.Entry<PlatformCredential, SupplyChainValidation> deltaEntry
-                : deltaMapping.entrySet()) {
+        for (PlatformCredential delta : chainCertificates) {
             StringBuilder failureMsg = new StringBuilder();
-            delta = deltaEntry.getKey();
             certificateList = new ArrayList<>();
             certificateList.add(delta);
 
@@ -594,7 +613,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                             failureMsg.append(String.format(
                                     "%s attempted MODIFIED with no prior instance.%n",
                                     ciSerial));
-                            scv = deltaEntry.getValue();
+                            scv = deltaMapping.get(delta);
                             if (scv.getResult() != AppraisalStatus.Status.PASS) {
                                 failureMsg.append(scv.getMessage());
                             }
@@ -604,7 +623,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                                     certificateList,
                                     failureMsg.toString()));
                         } else {
-                            chainCiMapping.put(ci.getComponentSerial().toString(), ci);
+                            chainCiMapping.put(ciSerial, ci);
                         }
                     } else if (ciV2.isRemoved()) {
                         if (!chainCiMapping.containsKey(ciSerial)) {
@@ -613,7 +632,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                             failureMsg.append(String.format(
                                     "%s attempted REMOVED with no prior instance.%n",
                                     ciSerial));
-                            scv = deltaEntry.getValue();
+                            scv = deltaMapping.get(delta);
                             if (scv.getResult() != AppraisalStatus.Status.PASS) {
                                 failureMsg.append(scv.getMessage());
                             }
@@ -623,7 +642,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                                     certificateList,
                                     failureMsg.toString()));
                         } else {
-                            chainCiMapping.remove(ci.getComponentSerial().toString());
+                            chainCiMapping.remove(ciSerial);
                         }
                     } else if (ciV2.isAdded()) {
                         // ADDED
@@ -633,7 +652,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                             failureMsg.append(String.format(
                                     "%s was ADDED, the serial already exists.%n",
                                     ciSerial));
-                            scv = deltaEntry.getValue();
+                            scv = deltaMapping.get(delta);
                             if (scv.getResult() != AppraisalStatus.Status.PASS) {
                                 failureMsg.append(scv.getMessage());
                             }

--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -579,10 +579,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                 if (obj2 == null) {
                     return 0;
                 }
-                if (obj1.getBeginValidity() == null) {
-                    return 0;
-                }
-                if (obj2.getBeginValidity() == null) {
+                if (obj1.getBeginValidity() == null || obj2.getBeginValidity() == null) {
                     return 0;
                 }
                 return obj1.getBeginValidity().compareTo(obj2.getBeginValidity());


### PR DESCRIPTION
Through further testing with delta certificates that had differing begin validity dates, the code to test the sorting failed. This push includes a fix that places the deltas in the proper order.

In addition, this code includes a placeholder for deltas that don't have an existing holder certificate in the database.

Closes #181