### PR TITLE
[#190] Provision update for quote and pcrs

### DIFF
--- a/HIRS_ProvisionerTPM2/include/CommandTpm2.h
+++ b/HIRS_ProvisionerTPM2/include/CommandTpm2.h
@@ -133,7 +133,7 @@ class CommandTpm2 {
 
     void storeAKCertificate(const std::string& akCertificateByteString);
 
-    std::string getQuote(TPML_PCR_SELECTION* pcr_selection,
+    std::string getQuote(const std::string& pcr_selection,
             const std::string& nonce);
 };
 

--- a/HIRS_ProvisionerTPM2/include/CommandTpm2.h
+++ b/HIRS_ProvisionerTPM2/include/CommandTpm2.h
@@ -133,8 +133,7 @@ class CommandTpm2 {
 
     void storeAKCertificate(const std::string& akCertificateByteString);
 
-    void getQuote(const std::string& akLocation,
-                  TPML_PCR_SELECTION* pcrSelection);
+    void getQuote(TPML_PCR_SELECTION* pcr_selection,const std::string& nonce);
 };
 
 }  // namespace tpm2

--- a/HIRS_ProvisionerTPM2/include/CommandTpm2.h
+++ b/HIRS_ProvisionerTPM2/include/CommandTpm2.h
@@ -62,6 +62,7 @@ class CommandTpm2 {
     static const char* const kTpm2DefaultQuoteFilename;
     static const char* const kTpm2DefaultSigFilename;
     static const char* const kTpm2DefaultSigAlgorithm;
+    static const char* const kTpm2ToolsPcrListCommand;
 
     const hirs::tpm2_tools_utils::Tpm2ToolsVersion version;
 

--- a/HIRS_ProvisionerTPM2/include/CommandTpm2.h
+++ b/HIRS_ProvisionerTPM2/include/CommandTpm2.h
@@ -58,6 +58,7 @@ class CommandTpm2 {
     static const char* const kDefaultAkNameFilename;
     static const char* const kDefaultAkPubFilename;
     static const char* const kDefaultEkPubFilename;
+    static const char* const kTpm2ToolsGetQuoteCommand;
 
     const hirs::tpm2_tools_utils::Tpm2ToolsVersion version;
 

--- a/HIRS_ProvisionerTPM2/include/CommandTpm2.h
+++ b/HIRS_ProvisionerTPM2/include/CommandTpm2.h
@@ -59,6 +59,9 @@ class CommandTpm2 {
     static const char* const kDefaultAkPubFilename;
     static const char* const kDefaultEkPubFilename;
     static const char* const kTpm2ToolsGetQuoteCommand;
+    static const char* const kTpm2DefaultQuoteFilename;
+    static const char* const kTpm2DefaultSigFilename;
+    static const char* const kTpm2DefaultSigAlgorithm;
 
     const hirs::tpm2_tools_utils::Tpm2ToolsVersion version;
 

--- a/HIRS_ProvisionerTPM2/include/CommandTpm2.h
+++ b/HIRS_ProvisionerTPM2/include/CommandTpm2.h
@@ -133,7 +133,7 @@ class CommandTpm2 {
 
     void storeAKCertificate(const std::string& akCertificateByteString);
 
-    std::string getQuote(const std::string& pcr_selection,
+    bytes getQuote(const std::string& pcr_selection,
             const std::string& nonce);
 };
 

--- a/HIRS_ProvisionerTPM2/include/CommandTpm2.h
+++ b/HIRS_ProvisionerTPM2/include/CommandTpm2.h
@@ -133,7 +133,7 @@ class CommandTpm2 {
 
     void storeAKCertificate(const std::string& akCertificateByteString);
 
-    bytes getQuote(const std::string& pcr_selection,
+    std::string getQuote(const std::string& pcr_selection,
             const std::string& nonce);
 };
 

--- a/HIRS_ProvisionerTPM2/include/CommandTpm2.h
+++ b/HIRS_ProvisionerTPM2/include/CommandTpm2.h
@@ -135,6 +135,8 @@ class CommandTpm2 {
 
     std::string getQuote(const std::string& pcr_selection,
             const std::string& nonce);
+
+    std::string getPcrsList();
 };
 
 }  // namespace tpm2

--- a/HIRS_ProvisionerTPM2/include/CommandTpm2.h
+++ b/HIRS_ProvisionerTPM2/include/CommandTpm2.h
@@ -133,7 +133,8 @@ class CommandTpm2 {
 
     void storeAKCertificate(const std::string& akCertificateByteString);
 
-    void getQuote(TPML_PCR_SELECTION* pcr_selection,const std::string& nonce);
+    std::string getQuote(TPML_PCR_SELECTION* pcr_selection,
+            const std::string& nonce);
 };
 
 }  // namespace tpm2

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -524,12 +524,11 @@ string CommandTpm2::createNvWriteCommandArgs(const string& nvIndex,
 string CommandTpm2::getQuote(const string& pcr_selection,
                     const string& nonce) {
     stringstream argsStream;
-    argsStream << kTpm2ToolsGetQuoteCommand
-              << " -k " << kDefaultAkHandle
+    argsStream << " -k " << kDefaultAkHandle
               << " -g " << kTpm2DefaultSigAlgorithm
               << " -m " << kTpm2DefaultQuoteFilename
               << " -s " << kTpm2DefaultSigFilename
-              << " -L " << "0,1,2,3,4,5,6,7"  // needs to be a string
+              << " -l " << pcr_selection  // needs to be a string
               << " -q " << nonce  // this needs to be a hex string
               << endl;
 
@@ -538,7 +537,8 @@ string CommandTpm2::getQuote(const string& pcr_selection,
     runTpm2CommandWithRetry(kTpm2ToolsGetQuoteCommand, argsStream.str(),
                             __LINE__);
     LOGGER.info("TPM Quote successful");
-    return argsStream.str();
+
+    return fileToString(kTpm2DefaultQuoteFilename);
 }
 
 /**

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -523,16 +523,21 @@ string CommandTpm2::createNvWriteCommandArgs(const string& nvIndex,
  */
 string CommandTpm2::getQuote(TPML_PCR_SELECTION* pcr_selection,
                     const string& nonce) {
-    stringstream argStream;
-    argStream << kTpm2ToolsGetQuoteCommand
+    stringstream argsStream;
+    argsStream << kTpm2ToolsGetQuoteCommand
               << " -k" << kDefaultAkHandle
               << " -g" << kTpm2DefaultSigAlgorithm
               << " -m" << kTpm2DefaultQuoteFilename
               << " -s" << kTpm2DefaultSigFilename
-              << " -L" << pcr_selection // needs to be a string
-              << " -q" << nonce // this needs to be a hex string
+              << " -L" << "0,1,2,3,4,5,6,7"  // needs to be a string
+              << " -q" << nonce  // this needs to be a hex string
               << endl;
 
+    LOGGER.info("Running tpm2_quote with arguments: "
+                + argsStream.str());
+    runTpm2CommandWithRetry(kTpm2ToolsGetQuoteCommand, argsStream.str(),
+                            __LINE__);
+    LOGGER.info("TPM Quote successful");
     return argStream.str();
 }
 

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -58,6 +58,7 @@ const char* const CommandTpm2::kTpm2ToolsActivateCredential
     = "tpm2_activatecredential";
 const char* const CommandTpm2::kTpm2ToolsEvictControlCommand
     = "tpm2_evictcontrol";
+const char* const CommandTpm2::kTpm2ToolsGetQuoteCommand = "tpm2_quote";
 
 /**
  * The value for the TPM_RC_RETRY was obtained from Table 16 (pgs. 37-41) of
@@ -320,7 +321,7 @@ void CommandTpm2::createAttestationKey() {
 
     LOGGER.info("Running getpubak with arguments: "
                 + argsStream.str());
-    runTpm2CommandWithRetry(kTpm2ToolsGetPubAkCommand, argsStream.str(),
+    runTpm2CommandWithlRetry(kTpm2ToolsGetPubAkCommand, argsStream.str(),
                             __LINE__);
     LOGGER.info("AK created successfully");
 }
@@ -519,6 +520,11 @@ string CommandTpm2::createNvWriteCommandArgs(const string& nvIndex,
  */
 void CommandTpm2::getQuote(const string& akLocation,
     TPML_PCR_SELECTION* pcrSelection) {
+    stringstream argStream;
+    argStream << " -Q"
+              << " -c" <<
+              << " -l" <<
+              << endl;
 }
 
 /**

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -34,6 +34,7 @@ using std::cout;
 using std::endl;
 using std::string;
 using std::stringstream;
+using std::ifstream;
 using std::this_thread::sleep_for;
 using std::to_string;
 using std::vector;
@@ -521,7 +522,7 @@ string CommandTpm2::createNvWriteCommandArgs(const string& nvIndex,
  * @param akLocation location of an activated AK pair
  * @param pcrSelection selection of pcrs to sign
  */
-string CommandTpm2::getQuote(const string& pcr_selection,
+bytes CommandTpm2::getQuote(const string& pcr_selection,
                     const string& nonce) {
     stringstream argsStream;
     argsStream << " -k " << kDefaultAkHandle
@@ -538,7 +539,20 @@ string CommandTpm2::getQuote(const string& pcr_selection,
                             __LINE__);
     LOGGER.info("TPM Quote successful");
 
-    return fileToString(kTpm2DefaultQuoteFilename);
+    ifstream quoteFile (kTpm2DefaultQuoteFilename, std::ifstream::binary);
+    bytes * buffer = new bytes [0];
+    if (quoteFile) {
+        quoteFile.seekg (0, quoteFile.end);
+        int length = quoteFile.tellg();
+        quoteFile.seekg (0, quoteFile.beg);
+
+        buffer = new bytes [length];
+        quoteFile.read (bufer.length);
+
+        quoteFile.close();
+    }
+
+    return &buffer;
 }
 
 /**

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -538,7 +538,7 @@ string CommandTpm2::getQuote(TPML_PCR_SELECTION* pcr_selection,
     runTpm2CommandWithRetry(kTpm2ToolsGetQuoteCommand, argsStream.str(),
                             __LINE__);
     LOGGER.info("TPM Quote successful");
-    return argStream.str();
+    return argsStream.str();
 }
 
 /**

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -522,7 +522,7 @@ string CommandTpm2::createNvWriteCommandArgs(const string& nvIndex,
  * @param akLocation location of an activated AK pair
  * @param pcrSelection selection of pcrs to sign
  */
-bytes CommandTpm2::getQuote(const string& pcr_selection,
+string CommandTpm2::getQuote(const string& pcr_selection,
                     const string& nonce) {
     stringstream argsStream;
     argsStream << " -k " << kDefaultAkHandle
@@ -539,7 +539,8 @@ bytes CommandTpm2::getQuote(const string& pcr_selection,
                             __LINE__);
     LOGGER.info("TPM Quote successful");
 
-    ifstream quoteFile (kTpm2DefaultQuoteFilename, std::ifstream::binary);
+    return fileToString(kTpm2DefaultQuoteFilename);
+    /**ifstream quoteFile (kTpm2DefaultQuoteFilename, std::ifstream::binary);
     bytes * buffer = new bytes [0];
     if (quoteFile) {
         quoteFile.seekg (0, quoteFile.end);
@@ -552,7 +553,7 @@ bytes CommandTpm2::getQuote(const string& pcr_selection,
         quoteFile.close();
     }
 
-    return &buffer;
+    return &buffer;**/
 }
 
 /**

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -117,6 +117,9 @@ const char* const CommandTpm2::kDefaultIdentityClaimResponseFilename
         = "identityClaimResponse";
 const char* const CommandTpm2::kDefaultActivatedIdentityFilename
         = "activatedIdentity.secret";
+const char* const CommandTpm2::kTpm2DefaultQuoteFilename = "/tmp/quote.bin";
+const char* const CommandTpm2::kTpm2DefaultSigFilename = "/tmp/sig.bin";
+const char* const CommandTpm2::kTpm2DefaultSigAlgorithm = "sha256";
 
 /**
  * Constructor to create an interface to TPM 2.0 devices.
@@ -518,13 +521,19 @@ string CommandTpm2::createNvWriteCommandArgs(const string& nvIndex,
  * @param akLocation location of an activated AK pair
  * @param pcrSelection selection of pcrs to sign
  */
-void CommandTpm2::getQuote(const string& akLocation,
-    TPML_PCR_SELECTION* pcrSelection) {
+string CommandTpm2::getQuote(TPML_PCR_SELECTION* pcr_selection,
+                    const string& nonce) {
     stringstream argStream;
-    /**argStream << " -Q"
-              << " -c" <<
-              << " -l" <<
-              << endl;*/
+    argStream << kTpm2ToolsGetQuoteCommand
+              << " -k" << kDefaultAkHandle
+              << " -g" << kTpm2DefaultSigAlgorithm
+              << " -m" << kTpm2DefaultQuoteFilename
+              << " -s" << kTpm2DefaultSigFilename
+              << " -L" << pcr_selection // needs to be a string
+              << " -q" << nonce // this needs to be a hex string
+              << endl;
+
+    return argStream.str();
 }
 
 /**

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -521,16 +521,16 @@ string CommandTpm2::createNvWriteCommandArgs(const string& nvIndex,
  * @param akLocation location of an activated AK pair
  * @param pcrSelection selection of pcrs to sign
  */
-string CommandTpm2::getQuote(TPML_PCR_SELECTION* pcr_selection,
+string CommandTpm2::getQuote(const string& pcr_selection,
                     const string& nonce) {
     stringstream argsStream;
     argsStream << kTpm2ToolsGetQuoteCommand
-              << " -k" << kDefaultAkHandle
-              << " -g" << kTpm2DefaultSigAlgorithm
-              << " -m" << kTpm2DefaultQuoteFilename
-              << " -s" << kTpm2DefaultSigFilename
-              << " -L" << "0,1,2,3,4,5,6,7"  // needs to be a string
-              << " -q" << nonce  // this needs to be a hex string
+              << " -k " << kDefaultAkHandle
+              << " -g " << kTpm2DefaultSigAlgorithm
+              << " -m " << kTpm2DefaultQuoteFilename
+              << " -s " << kTpm2DefaultSigFilename
+              << " -L " << "0,1,2,3,4,5,6,7"  // needs to be a string
+              << " -q " << nonce  // this needs to be a hex string
               << endl;
 
     LOGGER.info("Running tpm2_quote with arguments: "

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -321,7 +321,7 @@ void CommandTpm2::createAttestationKey() {
 
     LOGGER.info("Running getpubak with arguments: "
                 + argsStream.str());
-    runTpm2CommandWithlRetry(kTpm2ToolsGetPubAkCommand, argsStream.str(),
+    runTpm2CommandWithRetry(kTpm2ToolsGetPubAkCommand, argsStream.str(),
                             __LINE__);
     LOGGER.info("AK created successfully");
 }
@@ -521,10 +521,10 @@ string CommandTpm2::createNvWriteCommandArgs(const string& nvIndex,
 void CommandTpm2::getQuote(const string& akLocation,
     TPML_PCR_SELECTION* pcrSelection) {
     stringstream argStream;
-    argStream << " -Q"
+    /**argStream << " -Q"
               << " -c" <<
               << " -l" <<
-              << endl;
+              << endl;*/
 }
 
 /**

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -524,6 +524,7 @@ string CommandTpm2::createNvWriteCommandArgs(const string& nvIndex,
  */
 string CommandTpm2::getQuote(const string& pcr_selection,
                     const string& nonce) {
+    string quote;
     stringstream argsStream;
     argsStream << " -k " << kDefaultAkHandle
               << " -g " << kTpm2DefaultSigAlgorithm
@@ -539,21 +540,14 @@ string CommandTpm2::getQuote(const string& pcr_selection,
                             __LINE__);
     LOGGER.info("TPM Quote successful");
 
-    return fileToString(kTpm2DefaultQuoteFilename);
-    /**ifstream quoteFile (kTpm2DefaultQuoteFilename, std::ifstream::binary);
-    bytes * buffer = new bytes [0];
-    if (quoteFile) {
-        quoteFile.seekg (0, quoteFile.end);
-        int length = quoteFile.tellg();
-        quoteFile.seekg (0, quoteFile.beg);
+    try {
+        quote = fileToString(kTpm2DefaultQuoteFilename);
+    } catch (HirsRuntimeException& ex) {
+        throw HirsRuntimeException("Unable to open TPM Quote bin file",
+                                       "CommandTpm2::getQuote");
+     }
 
-        buffer = new bytes [length];
-        quoteFile.read (bufer.length);
-
-        quoteFile.close();
-    }
-
-    return &buffer;**/
+    return quote;
 }
 
 /**

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -546,7 +546,8 @@ string CommandTpm2::getQuote(const string& pcr_selection,
               << endl;
 
     LOGGER.info("Running tpm2_quote with arguments: " + argsStream.str());
-    quote = runTpm2CommandWithRetry(kTpm2ToolsGetQuoteCommand, argsStream.str(),
+    quote = runTpm2CommandWithRetry(kTpm2ToolsGetQuoteCommand,
+                            argsStream.str(),
                             __LINE__);
     LOGGER.info("TPM Quote successful");
 
@@ -565,7 +566,8 @@ string CommandTpm2::getPcrsList() {
               << endl;
 
     LOGGER.info("Running tpm2_pcrlist with arguments: " + argsStream.str());
-    pcrslist = runTpm2CommandWithRetry(kTpm2ToolsPcrListCommand, argsStream.str(),
+    pcrslist = runTpm2CommandWithRetry(kTpm2ToolsPcrListCommand,
+                            argsStream.str(),
                             __LINE__);
     LOGGER.info("TPM PCRS List successful");
 

--- a/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
+++ b/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
@@ -79,7 +79,7 @@ message IdentityClaimResponse {
 
 message CertificateRequest {
   required bytes nonce = 1;
-  required string quote = 2;
+  required bytes quote = 2;
 }
 
 message CertificateResponse {

--- a/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
+++ b/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
@@ -44,6 +44,14 @@ message OsInfo {
   required string distributionRelease = 5;
 }
 
+message TpmInfo {
+  required string tpmMake = 1;
+  required string tpmVersionMajor = 2;
+  required string tpmVersionMinor = 3;
+  required string tpmRevMajor = 4;
+  required string tpmRevMinor = 5;
+}
+
 message DeviceInfo {
   required FirmwareInfo fw = 1;
   required HardwareInfo hw = 2;
@@ -59,7 +67,10 @@ message IdentityClaim {
   repeated bytes platform_credential = 5;
   optional string client_version = 6;
   optional string paccorOutput = 7;
+}
 
+message TpmQuote {
+  required string success = 1;
 }
 
 message IdentityClaimResponse {
@@ -68,6 +79,7 @@ message IdentityClaimResponse {
 
 message CertificateRequest {
   required bytes nonce = 1;
+  required string tpmQuote = 2;
 }
 
 message CertificateResponse {

--- a/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
+++ b/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
@@ -80,6 +80,7 @@ message IdentityClaimResponse {
 message CertificateRequest {
   required bytes nonce = 1;
   required bytes quote = 2;
+  required bytes pcrslist = 3;
 }
 
 message CertificateResponse {

--- a/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
+++ b/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
@@ -79,8 +79,8 @@ message IdentityClaimResponse {
 
 message CertificateRequest {
   required bytes nonce = 1;
-  required bytes quote = 2;
-  required bytes pcrslist = 3;
+  optional bytes quote = 2;
+  optional bytes pcrslist = 3;
 }
 
 message CertificateResponse {

--- a/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
+++ b/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
@@ -79,7 +79,7 @@ message IdentityClaimResponse {
 
 message CertificateRequest {
   required bytes nonce = 1;
-  required string tpmQuote = 2;
+  required string quote = 2;
 }
 
 message CertificateResponse {

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -101,7 +101,9 @@ int provision() {
          << "certificate request" << endl;
     hirs::pb::CertificateRequest certificateRequest;
     certificateRequest.set_nonce(decryptedNonce);
-    certificateRequest.set_quote(tpm2.getQuote("nothing", decryptedNonce));
+    certificateRequest.set_quote(tpm2.getQuote(
+                "0,1,2,3,4,5,6,7",
+                decryptedNonce));
     const string& akCertificateByteString
             = provisioner.sendAttestationCertificateRequest(certificateRequest);
 

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -102,8 +102,10 @@ int provision() {
     hirs::pb::CertificateRequest certificateRequest;
     certificateRequest.set_nonce(decryptedNonce);
     certificateRequest.set_quote(tpm2.getQuote(
-                "0,1,2,3,4,5,6,7",
+                "0,1,2,3,4,5,6,7,8,9,10,11,12,13,
+                14,15,16,17,18,19,20,21,22,23",
                 decryptedNonce));
+    certificateRequest.set_pcrslist(tpm2.getPcrsList());
     const string& akCertificateByteString
             = provisioner.sendAttestationCertificateRequest(certificateRequest);
 

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -101,7 +101,7 @@ int provision() {
          << "certificate request" << endl;
     hirs::pb::CertificateRequest certificateRequest;
     certificateRequest.set_nonce(decryptedNonce);
-    certificateRequest.set_quote(CommandTpm2::getQuote(decryptedNonce));
+    certificateRequest.set_quote(CommandTpm2::getQuote("nothing", decryptedNonce));
     const string& akCertificateByteString
             = provisioner.sendAttestationCertificateRequest(certificateRequest);
 

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -102,8 +102,8 @@ int provision() {
     hirs::pb::CertificateRequest certificateRequest;
     certificateRequest.set_nonce(decryptedNonce);
     certificateRequest.set_quote(tpm2.getQuote(
-                "0,1,2,3,4,5,6,7,8,9,10,11,12,13,
-                14,15,16,17,18,19,20,21,22,23",
+                "0,1,2,3,4,5,6,7,8,9,10,11,12,13,"
+                "14,15,16,17,18,19,20,21,22,23",
                 decryptedNonce));
     certificateRequest.set_pcrslist(tpm2.getPcrsList());
     const string& akCertificateByteString

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -101,7 +101,7 @@ int provision() {
          << "certificate request" << endl;
     hirs::pb::CertificateRequest certificateRequest;
     certificateRequest.set_nonce(decryptedNonce);
-    certificateRequest.set_quote("PQC - SUCCESS");
+    //certificateRequest.set_quote(CommandTpm2::getQuote(decryptedNonce));
     const string& akCertificateByteString
             = provisioner.sendAttestationCertificateRequest(certificateRequest);
 

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -101,7 +101,7 @@ int provision() {
          << "certificate request" << endl;
     hirs::pb::CertificateRequest certificateRequest;
     certificateRequest.set_nonce(decryptedNonce);
-    certificateRequest.set_quote(CommandTpm2::getQuote("nothing", decryptedNonce));
+    certificateRequest.set_quote(tpm2.getQuote("nothing", decryptedNonce));
     const string& akCertificateByteString
             = provisioner.sendAttestationCertificateRequest(certificateRequest);
 

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -101,7 +101,7 @@ int provision() {
          << "certificate request" << endl;
     hirs::pb::CertificateRequest certificateRequest;
     certificateRequest.set_nonce(decryptedNonce);
-    certificateRequest.set_tpmQuote("PQC - SUCCESS");
+    certificateRequest.set_quote("PQC - SUCCESS");
     const string& akCertificateByteString
             = provisioner.sendAttestationCertificateRequest(certificateRequest);
 

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -101,6 +101,7 @@ int provision() {
          << "certificate request" << endl;
     hirs::pb::CertificateRequest certificateRequest;
     certificateRequest.set_nonce(decryptedNonce);
+    certificateRequest.set_tpmQuote("PQC - SUCCESS");
     const string& akCertificateByteString
             = provisioner.sendAttestationCertificateRequest(certificateRequest);
 

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -101,7 +101,7 @@ int provision() {
          << "certificate request" << endl;
     hirs::pb::CertificateRequest certificateRequest;
     certificateRequest.set_nonce(decryptedNonce);
-    //certificateRequest.set_quote(CommandTpm2::getQuote(decryptedNonce));
+    certificateRequest.set_quote(CommandTpm2::getQuote(decryptedNonce));
     const string& akCertificateByteString
             = provisioner.sendAttestationCertificateRequest(certificateRequest);
 


### PR DESCRIPTION
The provisioner was updated to include methods to getQuote and getPcrlist by using the tpm2_tools commands.  The output from the commands are kept as strings and this is passed up to the ACA upon certificate request response.  The protobuf file was updated to reflect this and was changed to optional so that previous provisioner versions can still send to the ACA.

Closes #190 