### PR TITLE
[#191]  ACA Processing TPM Quote/PCRs from Certificate Request

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -422,22 +422,6 @@ public abstract class AbstractAttestationCertificateAuthority
     }
 
     /**
-     * yea to process stuff.
-     * @param tpmQuote java stuff.
-     * @return the return.
-     */
-    public byte[] processTpmQuote(final byte[] tpmQuote) {
-        LOG.debug("Got TPM Quote");
-
-        if (ArrayUtils.isEmpty(tpmQuote)) {
-            LOG.error("TPM Quote empty throwing exception.");
-            throw new IllegalArgumentException("");
-        }
-
-        return new byte[]{};
-    }
-
-    /**
      * Performs supply chain validation.
      *
      * @param claim the identity claim

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -491,12 +491,10 @@ public abstract class AbstractAttestationCertificateAuthority
 
         // attempt to retrieve provisioner state based on nonce in request
         TPM2ProvisionerState tpm2ProvisionerState = getTpm2ProvisionerState(request);
-        if (request.getQuote() != null) {
-            LOG.error(request.getQuote());
-        } else if (request.getQuote() == null) {
-            LOG.error("Required TPM Quote was not sent by the host.");
-        } else if (request.getQuote().isEmpty()) {
+        if (request.getQuote().isEmpty()) {
             LOG.error("The required TPM Quote wss sent but is empty.");
+        } else if (request.getQuote() != null) {
+            LOG.error(request.getQuote());
         }
         if (tpm2ProvisionerState != null) {
             // Reparse Identity Claim to gather necessary components

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -472,6 +472,7 @@ public abstract class AbstractAttestationCertificateAuthority
      *                           claim handshake
      * @return a certificateResponse containing the signed certificate
      */
+    @Override
     public byte[] processCertificateRequest(final byte[] certificateRequest) {
         LOG.info("Got certificate request");
 
@@ -494,7 +495,7 @@ public abstract class AbstractAttestationCertificateAuthority
         if (request.getQuote().isEmpty()) {
             LOG.error("The required TPM Quote wss sent but is empty.");
         } else if (request.getQuote() != null) {
-            LOG.error(request.getQuote());
+            LOG.error(request.getQuote().toStringUtf8());
         }
         if (tpm2ProvisionerState != null) {
             // Reparse Identity Claim to gather necessary components

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -497,6 +497,11 @@ public abstract class AbstractAttestationCertificateAuthority
         } else if (request.getQuote() != null) {
             LOG.error(request.getQuote().toStringUtf8());
         }
+        if (request.getPcrslist().isEmpty()) {
+            LOG.error("The required TPM PCRS List was sent but is empty.");
+        } else if (request.getPcrslist() != null) {
+            LOG.error(request.getPcrslist().toStringUtf8());
+        }
         if (tpm2ProvisionerState != null) {
             // Reparse Identity Claim to gather necessary components
             byte[] identityClaim = tpm2ProvisionerState.getIdentityClaim();

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -496,12 +496,6 @@ public abstract class AbstractAttestationCertificateAuthority
 
         // attempt to retrieve provisioner state based on nonce in request
         TPM2ProvisionerState tpm2ProvisionerState = getTpm2ProvisionerState(request);
-        if (request.getQuote().isEmpty()) {
-            LOG.error("The required TPM Quote wss sent but is empty.");
-        }
-        if (request.getPcrslist().isEmpty()) {
-            LOG.error("The required TPM PCRS List was sent but is empty.");
-        }
         if (tpm2ProvisionerState != null) {
             // Reparse Identity Claim to gather necessary components
             byte[] identityClaim = tpm2ProvisionerState.getIdentityClaim();
@@ -521,8 +515,13 @@ public abstract class AbstractAttestationCertificateAuthority
                     endorsementCredential);
 
             // Parse through the Provisioner supplied TPM Quote and pcr values
-            parseTPMQuote(request.getQuote().toStringUtf8());
-            parsePCRValues(request.getPcrslist().toStringUtf8());
+            // these fields are optional
+            if (request.getQuote() != null && !request.getQuote().isEmpty()) {
+                parseTPMQuote(request.getQuote().toStringUtf8());
+            }
+            if (request.getPcrslist() != null && !request.getPcrslist().isEmpty()) {
+                parsePCRValues(request.getPcrslist().toStringUtf8());
+            }
 
             // Get device name and device
             String deviceName = claim.getDv().getNw().getHostname();

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -372,6 +372,7 @@ public abstract class AbstractAttestationCertificateAuthority
      * @param identityClaim the request to process, cannot be null
      * @return an identity claim response for the specified request containing a wrapped blob
      */
+    @Override
     public byte[] processIdentityClaimTpm2(final byte[] identityClaim) {
 
         LOG.debug("Got identity claim");
@@ -414,6 +415,22 @@ public abstract class AbstractAttestationCertificateAuthority
                     + validationResult);
             return new byte[]{};
         }
+    }
+
+    /**
+     * yea to process stuff.
+     * @param tpmQuote java stuff.
+     * @return the return.
+     */
+    public byte[] processTpmQuote(final byte[] tpmQuote) {
+        LOG.debug("Got TPM Quote");
+
+        if (ArrayUtils.isEmpty(tpmQuote)) {
+            LOG.error("TPM Quote empty throwing exception.");
+            throw new IllegalArgumentException("");
+        }
+
+        return new byte[]{};
     }
 
     /**
@@ -474,6 +491,13 @@ public abstract class AbstractAttestationCertificateAuthority
 
         // attempt to retrieve provisioner state based on nonce in request
         TPM2ProvisionerState tpm2ProvisionerState = getTpm2ProvisionerState(request);
+        if (request.getQuote() != null) {
+            LOG.error(request.getQuote());
+        } else if (request.getQuote() == null) {
+            LOG.error("Required TPM Quote was not sent by the host.");
+        } else if (request.getQuote().isEmpty()) {
+            LOG.error("The required TPM Quote wss sent but is empty.");
+        }
         if (tpm2ProvisionerState != null) {
             // Reparse Identity Claim to gather necessary components
             byte[] identityClaim = tpm2ProvisionerState.getIdentityClaim();
@@ -619,6 +643,14 @@ public abstract class AbstractAttestationCertificateAuthority
         LOG.info("Processing Device Info Report");
         // store device and device info report.
         return this.deviceRegister.saveOrUpdateDevice(deviceInfoReport);
+    }
+
+    private void processRimInfo(final ProvisionerTpm2.IdentityClaim claim) {
+        //RimInfoReport rimInfoReport = parseRimInfo(claim);
+
+        LOG.info("Processing RIM Info Report");
+        // store rim and rim info report.
+//        return this.deviceRegister.saveOrUpdateRim(rimInfoReport);
     }
 
     /**

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -120,6 +120,7 @@ public abstract class AbstractAttestationCertificateAuthority
     private static final String AK_NAME_PREFIX = "000b";
     private static final String AK_NAME_HASH_PREFIX =
             "0001000b00050072000000100014000b0800000000000100";
+    private static final String TPM_SIGNATURE_ALG = "sha256";
 
     private static final int MAC_BYTES = 6;
 
@@ -154,6 +155,9 @@ public abstract class AbstractAttestationCertificateAuthority
     private final DeviceRegister deviceRegister;
     private final DeviceManager deviceManager;
     private final DBManager<TPM2ProvisionerState> tpm2ProvisionerStateDBManager;
+    private String[] pcrsList;
+    private String tpmQuoteHash;
+    private String tpmSignatureHash;
 
     /**
      * Constructor.
@@ -494,13 +498,9 @@ public abstract class AbstractAttestationCertificateAuthority
         TPM2ProvisionerState tpm2ProvisionerState = getTpm2ProvisionerState(request);
         if (request.getQuote().isEmpty()) {
             LOG.error("The required TPM Quote wss sent but is empty.");
-        } else if (request.getQuote() != null) {
-            LOG.error(request.getQuote().toStringUtf8());
         }
         if (request.getPcrslist().isEmpty()) {
             LOG.error("The required TPM PCRS List was sent but is empty.");
-        } else if (request.getPcrslist() != null) {
-            LOG.error(request.getPcrslist().toStringUtf8());
         }
         if (tpm2ProvisionerState != null) {
             // Reparse Identity Claim to gather necessary components
@@ -519,6 +519,10 @@ public abstract class AbstractAttestationCertificateAuthority
             // Get Platform Credentials if they exist or were uploaded
             Set<PlatformCredential> platformCredentials = parsePcsFromIdentityClaim(claim,
                     endorsementCredential);
+
+            // Parse through the Provisioner supplied TPM Quote and pcr values
+            parseTPMQuote(request.getQuote().toStringUtf8());
+            parsePCRValues(request.getPcrslist().toStringUtf8());
 
             // Get device name and device
             String deviceName = claim.getDv().getNw().getHostname();
@@ -547,6 +551,44 @@ public abstract class AbstractAttestationCertificateAuthority
                     + request.getNonce().toString());
             throw new CertificateProcessingException("Invalid nonce given in request by client.");
         }
+    }
+
+    /**
+     * This method takes the provided TPM Quote and splits it between the PCR
+     * quote and the signature hash.
+     * @param tpmQuote contains hash values for the quote and the signature
+     */
+    private void parseTPMQuote(final String tpmQuote) {
+        if (tpmQuote != null) {
+            String[] lines = tpmQuote.split(":");
+            if (lines[1].contains("signature")) {
+                this.tpmQuoteHash = lines[1].replace("signature", "").trim();
+            } else {
+                this.tpmQuoteHash = lines[1].trim();
+            }
+            this.tpmSignatureHash = lines[2].trim();
+        }
+    }
+
+    /**
+     * This method splits all hashed pcr values into an array.
+     * @param pcrValues contains the full list of 24 pcr values
+     */
+    private void parsePCRValues(final String pcrValues) {
+        String[] pcrs = null;
+
+        if (pcrValues != null) {
+            int counter = 0;
+            String[] lines = pcrValues.split("\\r?\\n");
+            pcrs = new String[lines.length - 1];
+            for (String line : lines) {
+                if (!line.contains(TPM_SIGNATURE_ALG)) {
+                    pcrs[counter++] = line.split(":")[1].trim();
+                }
+            }
+        }
+
+        this.pcrsList = pcrs;
     }
 
     /**
@@ -647,14 +689,6 @@ public abstract class AbstractAttestationCertificateAuthority
         LOG.info("Processing Device Info Report");
         // store device and device info report.
         return this.deviceRegister.saveOrUpdateDevice(deviceInfoReport);
-    }
-
-    private void processRimInfo(final ProvisionerTpm2.IdentityClaim claim) {
-        //RimInfoReport rimInfoReport = parseRimInfo(claim);
-
-        LOG.info("Processing RIM Info Report");
-        // store rim and rim info report.
-//        return this.deviceRegister.saveOrUpdateRim(rimInfoReport);
     }
 
     /**

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/rest/RestfulAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/rest/RestfulAttestationCertificateAuthority.java
@@ -67,7 +67,8 @@ public class RestfulAttestationCertificateAuthority
      */
     @Override
     @ResponseBody
-    @RequestMapping(value = "/identity-request/process", method = RequestMethod.POST,
+    @RequestMapping(value = "/identity-request/process",
+            method = RequestMethod.POST,
             consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public byte[] processIdentityRequest(@RequestBody final byte[] request) {
         return super.processIdentityRequest(request);
@@ -85,6 +86,20 @@ public class RestfulAttestationCertificateAuthority
             consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public byte[] processIdentityClaimTpm2(@RequestBody final byte[] request) {
         return super.processIdentityClaimTpm2(request);
+    }
+
+    /**
+     * Endpoint for processing TPM quote from the TPM provisioning.
+     * @param request The request object from the provisioner.
+     * @return The response to the provisioner.
+     */
+    @Override
+    @ResponseBody
+    @RequestMapping(value = "/tpm_quote/process",
+            method = RequestMethod.POST,
+            consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
+    public byte[] processTpmQuote(@RequestBody final byte[] request) {
+        return super.processTpmQuote(request);
     }
 
     /**

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/rest/RestfulAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/rest/RestfulAttestationCertificateAuthority.java
@@ -89,20 +89,6 @@ public class RestfulAttestationCertificateAuthority
     }
 
     /**
-     * Endpoint for processing TPM quote from the TPM provisioning.
-     * @param request The request object from the provisioner.
-     * @return The response to the provisioner.
-     */
-    @Override
-    @ResponseBody
-    @RequestMapping(value = "/tpm_quote/process",
-            method = RequestMethod.POST,
-            consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-    public byte[] processTpmQuote(@RequestBody final byte[] request) {
-        return super.processTpmQuote(request);
-    }
-
-    /**
      * Endpoint for processing certificate requests for TPM 2.0 provisioning.
      *
      * @param request The credential request from the client provisioner.

--- a/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
+++ b/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
@@ -68,7 +68,7 @@ message IdentityClaimResponse {
 
 message CertificateRequest {
   required bytes nonce = 1;
-  required string quote = 2;
+  required bytes quote = 2;
 }
 
 message CertificateResponse {

--- a/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
+++ b/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
@@ -69,6 +69,7 @@ message IdentityClaimResponse {
 message CertificateRequest {
   required bytes nonce = 1;
   required bytes quote = 2;
+  required bytes pcrslist = 3;
 }
 
 message CertificateResponse {

--- a/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
+++ b/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
@@ -68,8 +68,8 @@ message IdentityClaimResponse {
 
 message CertificateRequest {
   required bytes nonce = 1;
-  required bytes quote = 2;
-  required bytes pcrslist = 3;
+  optional bytes quote = 2;
+  optional bytes pcrslist = 3;
 }
 
 message CertificateResponse {

--- a/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
+++ b/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
@@ -68,6 +68,7 @@ message IdentityClaimResponse {
 
 message CertificateRequest {
   required bytes nonce = 1;
+  required string quote = 2;
 }
 
 message CertificateResponse {


### PR DESCRIPTION
This pull request closes the update to the restful interface of the ACA allowing for processing of a quote from the provisioner.  The protobuf was updated to reflect optional fields in the certificate request, this attribute allows older provisioner to still communicate with the ACA.  The protobut library crashes the communication if the proto file doesn't match.

Currently the ACA is just process and storing the values provided in variables at this stage.

Closes #191 