### PR TITLE
[#202] Certificate fail to save upon deletion during provisioning FIXED

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -1466,9 +1466,6 @@ public abstract class AbstractAttestationCertificateAuthority
             // save issued certificate
             IssuedAttestationCertificate attCert = new IssuedAttestationCertificate(
                     derEncodedAttestationCertificate, endorsementCredential, platformCredentials);
-            for (PlatformCredential pc : platformCredentials) {
-                LOG.error("Another TDM -> " + pc.toString());
-            }
             attCert.setDevice(device);
             certificateManager.save(attCert);
         } catch (Exception e) {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -1466,6 +1466,9 @@ public abstract class AbstractAttestationCertificateAuthority
             // save issued certificate
             IssuedAttestationCertificate attCert = new IssuedAttestationCertificate(
                     derEncodedAttestationCertificate, endorsementCredential, platformCredentials);
+            for (PlatformCredential pc : platformCredentials) {
+                LOG.error("Another TDM -> " + pc.toString());
+            }
             attCert.setDevice(device);
             certificateManager.save(attCert);
         } catch (Exception e) {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/CredentialManagementHelper.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/CredentialManagementHelper.java
@@ -109,7 +109,10 @@ public final class CredentialManagementHelper {
             }
             PlatformCredential existingCredential =
                     PlatformCredential.select(certificateManager)
-                .byHashCode(platformCredential.getCertificateHash()).getCertificate();
+                            .includeArchived()
+                            .byHashCode(platformCredential
+                                    .getCertificateHash())
+                            .getCertificate();
             if (existingCredential == null) {
                 if (platformCredential.getPlatformSerial() != null) {
                     List<PlatformCredential> certificates = PlatformCredential

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateRequestPageController.java
@@ -739,7 +739,6 @@ public class CertificateRequestPageController extends PageController<NoPageParam
             // if an identical certificate is archived, update the existing certificate to
             // unarchive it and change the creation date
             if (existingCertificate.isArchived()) {
-
                 existingCertificate.restore();
                 existingCertificate.resetCreateTime();
                 certificateManager.update(existingCertificate);

--- a/HIRS_Utils/src/main/java/hirs/data/persist/AbstractEntity.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/AbstractEntity.java
@@ -86,4 +86,14 @@ public abstract class AbstractEntity {
         }
         return this.hashCode() == obj.hashCode();
     }
+
+    @Override
+    public String toString() {
+        try {
+            return String.format("UUID=%s, createTime=%s",
+                getId(), getCreateTime().toString());
+        } catch (NullPointerException npEx) {
+            return "";
+        }
+    }
 }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/ArchivableEntity.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/ArchivableEntity.java
@@ -107,4 +107,16 @@ public abstract class ArchivableEntity extends AbstractEntity {
     public final String getArchivedDescription() {
         return this.archivedDescription;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(super.toString());
+        if (archivedTime != null) {
+            sb.append(String.format(", archivedTime=%s, archiveDescription=%s",
+                archivedTime.toString(), archivedDescription));
+        }
+
+        return sb.toString();
+    }
 }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/Device.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/Device.java
@@ -394,4 +394,9 @@ public class Device extends AbstractEntity {
         return this.name.equals(other.name);
     }
 
+    @Override
+    public String toString() {
+        return String.format("Device{name=%s, status=%s}",
+                name, supplyChainValidationStatus);
+    }
 }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -1083,10 +1083,12 @@ public abstract class Certificate extends ArchivableEntity {
 
     @Override
     public String toString() {
-        return "Certificate{"
-                + ", serialNumber=" + serialNumber
-                + ", issuer='" + issuer + '\''
-                + '}';
+        return String.format("Certificate{%s, AuthID=%s, serialNumber=%s, "
+                + "issuer=%s, AuthSerialNumber=%s, publicKeySize=%d, "
+                + "signatureAlg=%s, Hash=%d}", super.toString(),
+                authorityKeyIdentifier, serialNumber.toString(),
+                issuer, authoritySerialNumber.toString(), publicKeySize,
+                signatureAlgorithm, certificateHash);
     }
 
     @Override

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/DeviceAssociatedCertificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/DeviceAssociatedCertificate.java
@@ -70,4 +70,15 @@ public abstract class DeviceAssociatedCertificate extends Certificate {
     public void setDevice(final Device device) {
         this.device = device;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(super.toString());
+        if (device != null) {
+            sb.append(String.format("%nDevice -> %s", getDevice().toString()));
+        }
+
+        return sb.toString();
+    }
 }


### PR DESCRIPTION
This pull requests fixes an error produced when provisioning when the certificate from a previous provision is deleted from the ACA.  The error involves doing a look up for an existing certificate and getting nothing however this is due to not using the 'includeArchived' attribute for the Certificate Selector.  Include Archived is used when manually uploading a certificate.

In addition, some toString methods were added/updated to provide more information for future debug purposes.

Closes #202