### PR TITLE
[#234] Updated a check on the SERIAL_INDEX in certificate string map builder.

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
@@ -342,9 +342,15 @@ public final class CertificateStringMapBuilder {
             data.put("CPSuri", certificate.getCPSuri());
             //component failure
             StringBuilder savedFailures = new StringBuilder();
+            String[] serialSplit;
             for (String s : certificate.getComponentFailures().split(",")) {
                 if (s.contains("Serial")) {
-                    savedFailures.append(s.split("=")[SERIAL_INDEX]);
+                    serialSplit = s.split("=");
+                    if (serialSplit.length > SERIAL_INDEX) {
+                        savedFailures.append(serialSplit[SERIAL_INDEX]);
+                    } else {
+                        savedFailures.append(s);
+                    }
                 }
             }
             data.put("failures", savedFailures.toString());


### PR DESCRIPTION
A corner case came up in which the serial number didn't contain a value.  This causes an ArrayOutOfBounds exception.  Added an additional check because the serial number isn't required.

Closes #234 