### PR TITLE
HexUtils Refactor

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -35,7 +35,6 @@ import hirs.structs.elements.tpm.IdentityProof;
 import hirs.structs.elements.tpm.IdentityRequest;
 import hirs.structs.elements.tpm.SymmetricKey;
 import hirs.structs.elements.tpm.SymmetricKeyParams;
-import hirs.utils.HexUtils;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.ArrayUtils;
@@ -51,7 +50,6 @@ import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.springframework.util.SerializationUtils;
-import sun.rmi.runtime.Log;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
@@ -602,9 +600,7 @@ public abstract class AbstractAttestationCertificateAuthority
         }
         // public data ends with 256 byte modulus
         byte[] modulus = Arrays.copyOfRange(publicArea, pubLen - RSA_MODULUS_LENGTH,
-                pubLen);//HexUtils.subarray(publicArea,
-                //pubLen - RSA_MODULUS_LENGTH,
-                //pubLen - 1);
+                pubLen);
         RSAPublicKey pub = (RSAPublicKey) assemblePublicKey(modulus);
         return pub;
     }
@@ -1105,6 +1101,7 @@ public abstract class AbstractAttestationCertificateAuthority
      * @param ak attestation key in the identity claim
      * @param secret a nonce
      * @return the encrypted blob forming the identity claim challenge
+     * @throws DecoderException error on Hex array being decoded.
      */
     protected ByteString tpm20MakeCredential(final RSAPublicKey ek, final RSAPublicKey ak,
                                              final byte[] secret) throws DecoderException {
@@ -1219,8 +1216,10 @@ public abstract class AbstractAttestationCertificateAuthority
      * @param akModulus modulus of an attestation key
      * @return the ak name byte array
      * @throws NoSuchAlgorithmException Underlying SHA256 method used a bad algorithm
+     * @throws DecoderException error on Hex array being decoded.
      */
-    byte[] generateAkName(final byte[] akModulus) throws NoSuchAlgorithmException, DecoderException {
+    byte[] generateAkName(final byte[] akModulus) throws NoSuchAlgorithmException,
+            DecoderException {
         byte[] namePrefix = Hex.decodeHex(AK_NAME_PREFIX.toCharArray());
         byte[] hashPrefix = Hex.decodeHex(AK_NAME_HASH_PREFIX.toCharArray());
         byte[] toHash = new byte[hashPrefix.length + akModulus.length];

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/AbstractAttestationCertificateAuthorityTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/AbstractAttestationCertificateAuthorityTest.java
@@ -2,6 +2,7 @@ package hirs.attestationca;
 
 import com.google.protobuf.ByteString;
 import hirs.utils.HexUtils;
+import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.ArrayUtils;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -708,7 +709,7 @@ public class AbstractAttestationCertificateAuthorityTest {
             System.arraycopy(mod, 1, tmp, 0, mod.length - 1);
             mod = tmp;
         }
-        String hex = HexUtils.byteArrayToHexString(mod);
+        String hex = Hex.encodeHexString(mod);
         String realMod = EK_MODULUS_HEX.replaceAll("\\s+", "");
         assertEquals(hex, realMod);
     }
@@ -735,7 +736,7 @@ public class AbstractAttestationCertificateAuthorityTest {
             System.arraycopy(mod, 1, tmp, 0, mod.length - 1);
             mod = tmp;
         }
-        String hex = HexUtils.byteArrayToHexString(mod);
+        String hex = Hex.encodeHexString(mod);
         String realMod = AK_MODULUS_HEX.replaceAll("\\s+", "");
         assertEquals(hex, realMod);
     }
@@ -748,7 +749,7 @@ public class AbstractAttestationCertificateAuthorityTest {
      */
     @Test
     public void testGenerateAkName() throws URISyntaxException, IOException,
-            NoSuchAlgorithmException {
+            NoSuchAlgorithmException, DecoderException {
         Path akNamePath = Paths.get(getClass().getResource(
                 AK_NAME_PATH).toURI());
 
@@ -756,9 +757,9 @@ public class AbstractAttestationCertificateAuthorityTest {
         String realHex = HexUtils.byteArrayToHexString(akNameFileBytes);
 
         String realMod = AK_MODULUS_HEX.replaceAll("\\s+", "");
-        byte[] akName = aca.generateAkName(HexUtils.hexStringToByteArray(realMod));
+        byte[] akName = aca.generateAkName(Hex.decodeHex(realMod.toCharArray()));
 
-        String hex = HexUtils.byteArrayToHexString(akName);
+        String hex = Hex.encodeHexString(akName);
         String realName = AK_NAME_HEX.replaceAll("\\s+", "");
         assertEquals(hex, realName);
         assertEquals(hex, realHex);
@@ -776,7 +777,7 @@ public class AbstractAttestationCertificateAuthorityTest {
      * @throws IOException unable to read file
      */
     @Test(enabled = false)
-    public void testMakeCredential() throws URISyntaxException, IOException {
+    public void testMakeCredential() throws URISyntaxException, IOException, DecoderException {
         Path akPubPath = Paths.get(getClass().getResource(
                 AK_PUBLIC_PATH).toURI());
         Path ekPubPath = Paths.get(getClass().getResource(

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/AbstractAttestationCertificateAuthorityTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/AbstractAttestationCertificateAuthorityTest.java
@@ -1,7 +1,6 @@
 package hirs.attestationca;
 
 import com.google.protobuf.ByteString;
-import hirs.utils.HexUtils;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.ArrayUtils;
@@ -746,6 +745,7 @@ public class AbstractAttestationCertificateAuthorityTest {
      * @throws URISyntaxException incorrect resource path
      * @throws IOException unable to read from file
      * @throws NoSuchAlgorithmException inavlid algorithm
+     * @throws DecoderException error on Hex array being decoded.
      */
     @Test
     public void testGenerateAkName() throws URISyntaxException, IOException,
@@ -754,7 +754,7 @@ public class AbstractAttestationCertificateAuthorityTest {
                 AK_NAME_PATH).toURI());
 
         byte[] akNameFileBytes = Files.readAllBytes(akNamePath);
-        String realHex = HexUtils.byteArrayToHexString(akNameFileBytes);
+        String realHex = Hex.encodeHexString(akNameFileBytes);
 
         String realMod = AK_MODULUS_HEX.replaceAll("\\s+", "");
         byte[] akName = aca.generateAkName(Hex.decodeHex(realMod.toCharArray()));
@@ -775,6 +775,7 @@ public class AbstractAttestationCertificateAuthorityTest {
      * output as HIRS_AttestationCA/src/test/resources/tpm2/test/secret.blob
      * @throws URISyntaxException invalid file path
      * @throws IOException unable to read file
+     * @throws DecoderException error on Hex array being decoded.
      */
     @Test(enabled = false)
     public void testMakeCredential() throws URISyntaxException, IOException, DecoderException {

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -3,7 +3,6 @@ package hirs.data.persist.certificate;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import hirs.data.persist.ArchivableEntity;
-import hirs.utils.HexUtils;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/Certificate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import hirs.data.persist.ArchivableEntity;
 import hirs.utils.HexUtils;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.asn1.ASN1BitString;
@@ -639,7 +640,7 @@ public abstract class Certificate extends ArchivableEntity {
         if (aki != null) {
             byte[] keyArray = aki.getKeyIdentifier();
             if (keyArray != null) {
-                retValue = HexUtils.byteArrayToHexString(keyArray);
+                retValue = Hex.encodeHexString(keyArray);
             }
         }
 

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TCGEventLog.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TCGEventLog.java
@@ -1,6 +1,5 @@
 package hirs.tpm.eventlog;
 
-import hirs.utils.HexUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.MessageDigest;

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TCGEventLogProcessor.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TCGEventLogProcessor.java
@@ -8,7 +8,9 @@ import hirs.data.persist.TPMMeasurementRecord;
 import hirs.data.persist.TpmWhiteListBaseline;
 import hirs.utils.HexUtils;
 import hirs.data.persist.Digest;
-import hirs.data.persist.DigestAlgorithm;;
+import hirs.data.persist.DigestAlgorithm;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;;
 
 /**
  * Class for parsing a TCG EventLogs (both SHA1 and Crypto Agile Formats).
@@ -100,19 +102,19 @@ public class TCGEventLogProcessor {
      * @param name name to call the TPM Baseline
      * @return whitelist baseline
      */
-    public TpmWhiteListBaseline createTPMBaseline(final String name) {
+    public TpmWhiteListBaseline createTPMBaseline(final String name) throws DecoderException {
         TpmWhiteListBaseline baseline = new TpmWhiteListBaseline(name);
         TPMMeasurementRecord record;
         String pcrValue;
         for (int i = 0; i < TpmPcrEvent.PCR_COUNT; i++) {
             if (algorithm.compareToIgnoreCase("TPM_ALG_SHA1") == 0) { // Log Was SHA1 Format
                 pcrValue = tcgLog.getExpectedPCRValue(i);
-                byte[] hexValue = HexUtils.hexStringToByteArray(pcrValue);
+                byte[] hexValue = Hex.decodeHex(pcrValue.toCharArray());
                 final Digest hash = new Digest(DigestAlgorithm.SHA1, hexValue);
                 record = new TPMMeasurementRecord(i, hash);
             } else {  // Log was Crypto Agile, currently assumes SHA256
                 pcrValue = tcgLog.getExpectedPCRValue(i);
-                byte[] hexValue = HexUtils.hexStringToByteArray(pcrValue);
+                byte[] hexValue = Hex.decodeHex(pcrValue.toCharArray());
                 final Digest hash = new Digest(DigestAlgorithm.SHA256, hexValue);
                 record = new TPMMeasurementRecord(i, hash);
             }

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TCGEventLogProcessor.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TCGEventLogProcessor.java
@@ -101,6 +101,7 @@ public class TCGEventLogProcessor {
      *
      * @param name name to call the TPM Baseline
      * @return whitelist baseline
+     * @throws DecoderException error on Hex array being decoded.
      */
     public TpmWhiteListBaseline createTPMBaseline(final String name) throws DecoderException {
         TpmWhiteListBaseline baseline = new TpmWhiteListBaseline(name);

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TcgTpmtHa.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TcgTpmtHa.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 
 import hirs.utils.HexUtils;
+import org.apache.commons.codec.binary.Hex;
 
 /**
  * Class to for the TCG defined TPMT_HA structure used to support the Crypto Agile Log format.
@@ -130,7 +131,7 @@ public class TcgTpmtHa {
      */
     @Override
     public String toString() {
-        return String.format("%s hash = %s", hashName, HexUtils.byteArrayToHexString(digest));
+        return String.format("%s hash = %s", hashName, Hex.encodeHexString(digest));
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/HexUtils.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/HexUtils.java
@@ -1,41 +1,27 @@
 package hirs.utils;
 
-import java.io.ByteArrayInputStream;
+import org.bouncycastle.util.Arrays;
+
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 
 /**
  * Utilities for working with hex strings and byte arrays.
  */
 public final class HexUtils {
 
-    /**
-     * The mathematical base for the hexadecimal representation.
-     */
-    public static final int HEX_BASIS = 16;
-
-    /**
-     * An integer representation of the byte 0xff or 255.
-     */
-    public static final int FF_BYTE = 0xff;
-
     private HexUtils() { }
 
     /**
-     * Takes in a byte array and reverses the order.
+     * Needs to be removed.
      * @param in  byte array to reverse
      * @return reversed byte array
      */
    public static byte[] leReverseByte(final byte[] in) {
-        byte[] finished = new byte[in.length];
-          for (int i = 0; i < finished.length; i++) {
-             finished[i] = in[(in.length - 1) - i];
-         }
-      return finished;
+        return Arrays.reverse(in);
     }
 
     /**
-     * Takes in a byte array and reverses the order then converts to an int.
+     * Needs to be removed.
      * @param in  byte array to reverse
      * @return integer that represents the reversed byte array
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/HexUtils.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/HexUtils.java
@@ -1,6 +1,8 @@
 package hirs.utils;
 
+import java.io.ByteArrayInputStream;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
 
 /**
  * Utilities for working with hex strings and byte arrays.
@@ -18,64 +20,6 @@ public final class HexUtils {
     public static final int FF_BYTE = 0xff;
 
     private HexUtils() { }
-
-    /**
-     * Converts a binary hex string to a byte array.
-     * @param s string to convert
-     * @return byte array representation of s
-     */
-    public static byte[] hexStringToByteArray(final String s) {
-        int sizeInt = s.length() / 2;
-        byte[] returnArray = new byte[sizeInt];
-        String byteVal;
-        for (int i = 0; i < sizeInt; i++) {
-            int index = 2 * i;
-            byteVal = s.substring(index, index + 2);
-            returnArray[i] = (byte) (Integer.parseInt(byteVal, HEX_BASIS));
-        }
-        return returnArray;
-    }
-
-    /**
-     * Converts a byte array to a hex represented binary string.
-     * @param b byte array to convert
-     * @return hex string representation of array
-     */
-    public static String byteArrayToHexString(final byte[] b) {
-        StringBuilder sb = new StringBuilder();
-        String returnStr = "";
-        for (int i = 0; i < b.length; i++) {
-            String singleByte = Integer.toHexString(b[i] & FF_BYTE);
-            if (singleByte.length() != 2) {
-                singleByte = "0" + singleByte;
-            }
-            returnStr = sb.append(singleByte).toString();
-        }
-        return returnStr;
-    }
-
-    /**
-     * Converts an individual hex string to an integer.
-     * @param s an individual hex string
-     * @return an integer representation of a hex string
-     */
-    public static Integer hexToInt(final String s) {
-        Integer i = Integer.parseInt(s, HEX_BASIS);
-        return i;
-    }
-
-    /**
-     * Takes a byte array returns a subset of the array.
-     * @param b the array to take a subset of
-     * @param start the first index to copy
-     * @param end the last index to copy (inclusive)
-     * @return a new array of bytes from start to end
-     */
-    public static byte[] subarray(final byte[] b, final int start, final int end) {
-        byte[] copy = new byte[end - start + 1];
-        System.arraycopy(b, start, copy, 0, end - start + 1);
-        return copy;
-    }
 
     /**
      * Takes in a byte array and reverses the order.
@@ -98,16 +42,5 @@ public final class HexUtils {
     public static int leReverseInt(final byte[] in) {
         byte[] finished = leReverseByte(in);
         return new BigInteger(finished).intValue();
-    }
-
-    /**
-     * Takes in a byte array of 4 bytes and returns a long.
-     * @param bytes  byte array to convert
-     * @return long representation of the bytes
-     */
-    public static long bytesToLong(final byte[] bytes) {
-      BigInteger lValue = new BigInteger(bytes);
-
-      return  lValue.abs().longValue();
     }
 }

--- a/HIRS_Utils/src/test/java/hirs/tpm/eventlog/TCGEventLogProcessorTest.java
+++ b/HIRS_Utils/src/test/java/hirs/tpm/eventlog/TCGEventLogProcessorTest.java
@@ -6,6 +6,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.IOUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -153,7 +155,7 @@ public class TCGEventLogProcessorTest extends SpringPersistenceTest {
      * @throws IOException when processing the test fails
      */
     @Test
-    public final void testTPMBaselineCreate() throws IOException {
+    public final void testTPMBaselineCreate() throws IOException, DecoderException {
         LOGGER.debug("Create and save TPM baseline from TCG Event Log test started");
         InputStream log;
         boolean testPass = true;
@@ -172,7 +174,7 @@ public class TCGEventLogProcessorTest extends SpringPersistenceTest {
         for (int i = 0; i < 24; i++) {
             Set<Digest> records = b.getPCRHashes(i);
             for (Digest digest:records) {
-                String pcrValue = HexUtils.byteArrayToHexString(digest.getDigest());
+                String pcrValue = Hex.encodeHexString(digest.getDigest());
                 if (pcrFromLog[i].compareToIgnoreCase(pcrValue) != 0) {
                     testPass = false;
                     LOGGER.error("\testTPMBaselineCreate error with PCR " + i);

--- a/HIRS_Utils/src/test/java/hirs/tpm/eventlog/TCGEventLogProcessorTest.java
+++ b/HIRS_Utils/src/test/java/hirs/tpm/eventlog/TCGEventLogProcessorTest.java
@@ -30,7 +30,6 @@ import hirs.data.persist.Baseline;
 import hirs.data.persist.Digest;
 import hirs.data.persist.SpringPersistenceTest;
 import hirs.data.persist.TpmWhiteListBaseline;
-import hirs.utils.HexUtils;
 
 /**
  *  Class for testing TCG Event Log processing.
@@ -153,6 +152,7 @@ public class TCGEventLogProcessorTest extends SpringPersistenceTest {
     /**
      * Tests TPM Baseline creation from a EventLog.
      * @throws IOException when processing the test fails
+     * @throws DecoderException error on Hex array being decoded.
      */
     @Test
     public final void testTPMBaselineCreate() throws IOException, DecoderException {

--- a/HIRS_Utils/src/test/java/hirs/utils/HexUtilsTest.java
+++ b/HIRS_Utils/src/test/java/hirs/utils/HexUtilsTest.java
@@ -1,13 +1,5 @@
 package hirs.utils;
 
-import org.apache.commons.codec.DecoderException;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
-import org.apache.commons.codec.binary.Hex;
-
-import java.util.Arrays;
-
 /**
  * Class for testing the HexUtils class.
  */

--- a/HIRS_Utils/src/test/java/hirs/utils/HexUtilsTest.java
+++ b/HIRS_Utils/src/test/java/hirs/utils/HexUtilsTest.java
@@ -1,72 +1,17 @@
 package hirs.utils;
 
+import org.apache.commons.codec.DecoderException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import org.apache.commons.codec.binary.Hex;
+
+import java.util.Arrays;
 
 /**
  * Class for testing the HexUtils class.
  */
 public class HexUtilsTest {
-
-    /**
-     * Tests that we can convert a hex string to a byte array.
-     */
-    @Test
-    public void testHexStringToByteArray() {
-        String s = "abcd1234";
-        byte[] target = {-85, -51, 18, 52};
-
-        byte[] b = HexUtils.hexStringToByteArray(s);
-        Assert.assertEquals(b, target);
-    }
-
-    /**
-     * Tests that we can convert a hex string to a byte array.
-     */
-    @Test
-    public void testByteArrayToHexString() {
-        String target = "abcd1234";
-        byte[] b = {-85, -51, 18, 52};
-
-        String s = HexUtils.byteArrayToHexString(b);
-        Assert.assertEquals(s, target);
-    }
-
-    /**
-     * Tests that we can convert a hex string to a byte array.
-     */
-    @Test
-    public void testByteArrayToHexStringConditional() {
-        String target = "abcd0100";
-        byte[] b = {-85, -51, 1, 0};
-
-        String s = HexUtils.byteArrayToHexString(b);
-        Assert.assertEquals(s, target);
-    }
-
-    /**
-     * Tests that a hex string can be converted to an integer.
-     */
-    @Test
-    public void testHexToInt() {
-        String s = "ff";
-        Integer i = HexUtils.hexToInt(s);
-        Assert.assertEquals((int) i, HexUtils.FF_BYTE);
-    }
-
-    /**
-     * Tests the subarray utility method.
-     */
-    @Test
-    public void testSubarray() {
-        byte[] b = {-85, -51, 18, 52};
-        byte[] target = {-51, 18};
-
-        byte[] sub = HexUtils.subarray(b, 1, 2);
-
-        Assert.assertEquals(sub, target);
-    }
-
 
 
 }


### PR DESCRIPTION
The HexUtils class has a lot of code that is unnecessary.  The functionality can be done by built in Java classes, already loaded, that can be used to do the operations HexUtils handles.