### PR TITLE
[#254] Modified how TPM2 Provisioner pulls down sub module cpr

### DIFF
--- a/HIRS_ProvisionerTPM2/lib/CPR.CMakeLists.txt.in
+++ b/HIRS_ProvisionerTPM2/lib/CPR.CMakeLists.txt.in
@@ -4,8 +4,8 @@ project(cpr-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(cpr
-        GIT_REPOSITORY    https://github.com/whoshuu/cpr
-        GIT_TAG           1.3.0
+        URL               https://github.com/whoshuu/cpr/archive/1.3.0.zip
+        URL_HASH          SHA1=d669d94b41ffaa2de478923c35a83074e34fdc12
         SOURCE_DIR        "${CMAKE_BINARY_DIR}/lib/cpr-src"
         BINARY_DIR        "${CMAKE_BINARY_DIR}/lib/cpr-build"
         CONFIGURE_COMMAND ""


### PR DESCRIPTION
This issue was resolved by modifying the CPR.CMakeLists.txt.in to no longer use the GIT_REPOSITORY and GIT_TAG.  Instead the URL and URL_HASH are used, pulling down the zip file.

I'm unsure as to what specifically causes this to work and not the repo pull but I am under the assumption that the zip contains everything that is needed whereas the repo and the git commands create the issue that it can't resolve when trying to pull the needed libraries.

Closes #254 