### PR TITLE
[#275] Modify Payload filepath

### DIFF
--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -21,8 +21,12 @@ public class Main {
             if (!commander.getVerifyFile().isEmpty()) {
                 System.out.println(commander.toString());
                 String verifyFile = commander.getVerifyFile();
+                String rimel = commander.getRimEventLog();
                 //String publicCertificate = commander.getPublicCertificate();
                 if (!verifyFile.isEmpty()) {
+                    if (!rimel.isEmpty()) {
+                        gateway.setRimEventLog(rimel);
+                    }
                     try {
                         gateway.validateSwidTag(verifyFile);
                     } catch (IOException e) {

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -117,6 +117,7 @@ public class SwidTagGateway {
             attributesFile = SwidTagConstants.DEFAULT_ATTRIBUTES_FILE;
             defaultCredentials = true;
             pemCertificateFile = "";
+            rimEventLog = "";
         } catch (JAXBException e) {
             System.out.println("Error initializing jaxbcontext: " + e.getMessage());
         }
@@ -188,7 +189,10 @@ public class SwidTagGateway {
                     createSoftwareMeta(configProperties.get(SwidTagConstants.META).asObject()));
             swidTag.getEntityOrEvidenceOrLink().add(meta);
             //File
-            hirs.swid.xjc.File file = createFile();
+            hirs.swid.xjc.File file = createFile(
+                                configProperties.get(SwidTagConstants.PAYLOAD).asObject()
+                                                .get(SwidTagConstants.DIRECTORY).asObject()
+                                                .get(SwidTagConstants.FILE).asObject());
             //Directory
             Directory directory = createDirectory(
                     configProperties.get(SwidTagConstants.PAYLOAD).asObject()
@@ -419,16 +423,23 @@ public class SwidTagGateway {
     }
 
     /**
-     * This method creates a hirs.swid.xjc.File from an indirect payload type by
+     * This method creates a hirs.swid.xjc.File from an indirect payload type
+     * using parameters read in from a properties file and then
      * calculating the hash of a given event log support RIM.
+     *
+     * @param jsonObject the Properties object containing parameters from file
+     * @return File object created from the properties
      */
-    private hirs.swid.xjc.File createFile() {
+    private hirs.swid.xjc.File createFile(JsonObject jsonObject) {
         hirs.swid.xjc.File file = objectFactory.createFile();
-        file.setName(rimEventLog);
+        file.setName(jsonObject.getString(SwidTagConstants.NAME, ""));
         File rimEventLogFile = new File(rimEventLog);
         file.setSize(new BigInteger(Long.toString(rimEventLogFile.length())));
         Map<QName, String> attributes = file.getOtherAttributes();
         addNonNullAttribute(attributes, _SHA256_HASH, HashSwid.get256Hash(rimEventLog));
+        addNonNullAttribute(attributes, SwidTagConstants._SUPPORT_RIM_TYPE, jsonObject.getString(SwidTagConstants.SUPPORT_RIM_TYPE, ""));
+        addNonNullAttribute(attributes, SwidTagConstants._SUPPORT_RIM_FORMAT, jsonObject.getString(SwidTagConstants.SUPPORT_RIM_FORMAT, ""));
+        addNonNullAttribute(attributes, SwidTagConstants._SUPPORT_RIM_URI_GLOBAL, jsonObject.getString(SwidTagConstants.SUPPORT_RIM_URI_GLOBAL, ""));
 
         return file;
     }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -437,7 +437,12 @@ public class SwidTagGateway {
      * This method validates a hirs.swid.xjc.File from an indirect payload
      */
     private boolean validateFile(Element file) {
-        String filepath = file.getAttribute(SwidTagConstants.NAME);
+        String filepath;
+        if (rimEventLog.isEmpty()) {
+            filepath = file.getAttribute(SwidTagConstants.NAME);
+        } else {
+            filepath = rimEventLog;
+        }
         System.out.println("Support rim found at " + filepath);
         if (HashSwid.get256Hash(filepath).equals(file.getAttribute(_SHA256_HASH.getPrefix() + ":" + _SHA256_HASH.getLocalPart()))) {
             System.out.println("Support RIM hash verified!");

--- a/tools/tcg_rim_tool/src/test/resources/generated_no_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_no_cert.swidtag
@@ -5,7 +5,7 @@
   <Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:rimLinkHash="88f21d8e44d4271149297404df91caf207130bfa116582408abd04ede6db7f51"/>
   <Payload>
     <Directory name="iotBase">
-      <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="TpmLog.bin" size="7549"/>
+      <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.iotBase.bin" size="7549"/>
     </Directory>
   </Payload>
   <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>jpPZu16C8KjtwY2JpJuyR3SBc2XclVEaVsv/DgyZKTM=</DigestValue>
+        <DigestValue>HEzVxviL8a3g7VhLtkMDabH2f9n/3mPwEg1NRJBYLA0=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>pWPozFWH2oytfgZse1Ai769c/cBFS/vapKj27asI8XDLdK8FkNs2K/+OTf4lScBiPLTCvWPIihoe
-hielmV8dWZqvR2z09pr+yCF7q/E8sCGhQXSsVlNZjElMXk2Qz2c6C9XtRk4UNmSfTSYsKEm2AST4
-oh6da+x1CeSHipALfuZZrXwa2AMtc9yTNfqaQFBxRqEDeTypLwNQqdr9va2T8C9ZNnEzooTf5FWw
-OUqc+Ewk5V9ZyOJ/0UdUxs40mGPpsIG90ikx59eu1A4qP4BzjHR3vrNbYDA4hBeIpDHC4vzwJrR4
-xqXw1SLqAm8ngL9Haj2Ww+y0PEZfo++JlOMZuQ==</SignatureValue>
+    <SignatureValue>Qjg51EQPVS5paqBbw8e0b8lu4yqzWUEdvE2S64bvt59f6LPaG+1EDgQCimgXMdIg/+tSR4Wou6Hr
+u0ym8K6RqoipWBbF2KNVtR8vCavJblVA+6tCd+iLnFiQ/b2Zud/v/DZq89wQ/hKX0WoskSy/3tiT
+ariMcpP75dYO1b/tYkMshPo0/F0p39VoZxhGDahmYTRT0Wt4KQeIVe/4nDXEu+EbIi18yHVHYFWq
+uO/hC+BoKd/xBKmQnhtGkT4y3vETOoCr0TOHpRUClKC/nL0FhL9hPtpwhPBhakLtbi1WOwBnpxjV
+zFAR1SzeOG87S2Cl8pSDXjwfzHzzcPaJKpXj2g==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
       <KeyValue>

--- a/tools/tcg_rim_tool/src/test/resources/generated_with_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_with_cert.swidtag
@@ -5,7 +5,7 @@
   <Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:rimLinkHash="88f21d8e44d4271149297404df91caf207130bfa116582408abd04ede6db7f51"/>
   <Payload>
     <Directory name="iotBase">
-      <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="TpmLog.bin" size="7549"/>
+      <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.iotBase.bin" size="7549"/>
     </Directory>
   </Payload>
   <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>jpPZu16C8KjtwY2JpJuyR3SBc2XclVEaVsv/DgyZKTM=</DigestValue>
+        <DigestValue>HEzVxviL8a3g7VhLtkMDabH2f9n/3mPwEg1NRJBYLA0=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>pWPozFWH2oytfgZse1Ai769c/cBFS/vapKj27asI8XDLdK8FkNs2K/+OTf4lScBiPLTCvWPIihoe
-hielmV8dWZqvR2z09pr+yCF7q/E8sCGhQXSsVlNZjElMXk2Qz2c6C9XtRk4UNmSfTSYsKEm2AST4
-oh6da+x1CeSHipALfuZZrXwa2AMtc9yTNfqaQFBxRqEDeTypLwNQqdr9va2T8C9ZNnEzooTf5FWw
-OUqc+Ewk5V9ZyOJ/0UdUxs40mGPpsIG90ikx59eu1A4qP4BzjHR3vrNbYDA4hBeIpDHC4vzwJrR4
-xqXw1SLqAm8ngL9Haj2Ww+y0PEZfo++JlOMZuQ==</SignatureValue>
+    <SignatureValue>Qjg51EQPVS5paqBbw8e0b8lu4yqzWUEdvE2S64bvt59f6LPaG+1EDgQCimgXMdIg/+tSR4Wou6Hr
+u0ym8K6RqoipWBbF2KNVtR8vCavJblVA+6tCd+iLnFiQ/b2Zud/v/DZq89wQ/hKX0WoskSy/3tiT
+ariMcpP75dYO1b/tYkMshPo0/F0p39VoZxhGDahmYTRT0Wt4KQeIVe/4nDXEu+EbIi18yHVHYFWq
+uO/hC+BoKd/xBKmQnhtGkT4y3vETOoCr0TOHpRUClKC/nL0FhL9hPtpwhPBhakLtbi1WOwBnpxjV
+zFAR1SzeOG87S2Cl8pSDXjwfzHzzcPaJKpXj2g==</SignatureValue>
     <KeyInfo>
       <X509Data>
         <X509SubjectName>CN=example.RIM.signer,OU=PCClient,O=Example,ST=VA,C=US</X509SubjectName>


### PR DESCRIPTION
1. <File> under <Payload> for a rimel has name read from the attributes json file, while size and hash are calculated from the file given through `-l` command-line parameter.
2. `-v` will verify the <File> hash using what is given in the base RIM; `-v -l <filepath>` will verify the <File> hash using <filepath> instead.

Closes #275 