### PR TITLE
[#295] Clean up base RIM attributes

### DIFF
--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
@@ -48,7 +48,7 @@ public class SwidTagConstants {
     public static final String EDITION = "edition";
     public static final String PRODUCT = "product";
     public static final String REVISION = "revision";
-    public static final String PAYLOAD_TYPE = "payloadType";
+    public static final String PAYLOAD_TYPE = "PayloadType";
     public static final String HYBRID = "hybrid";
     public static final String PLATFORM_MANUFACTURER_STR = "platformManufacturerStr";
     public static final String PLATFORM_MANUFACTURER_ID = "platformManufacturerId";
@@ -60,7 +60,7 @@ public class SwidTagConstants {
     public static final String FIRMWARE_VERSION = "firmwareVersion";
     public static final String BINDING_SPEC = "bindingSpec";
     public static final String BINDING_SPEC_VERSION = "bindingSpecVersion";
-    public static final String PC_URI_LOCAL = "pcURILocal";
+    public static final String PC_URI_LOCAL = "pcURIlocal";
     public static final String PC_URI_GLOBAL = "pcURIGlobal";
     public static final String RIM_LINK_HASH = "rimLinkHash";
     public static final String SIZE = "size";
@@ -86,7 +86,7 @@ public class SwidTagConstants {
             "revision", "n8060");
     public static final QName _PAYLOAD_TYPE = new QName(
             "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "payloadType", "rim");
+            "PayloadType", "rim");
     public static final QName _PLATFORM_MANUFACTURER_STR = new QName(
             "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
             "platformManufacturerStr", "rim");
@@ -101,22 +101,22 @@ public class SwidTagConstants {
             "platformVersion", "rim");
     public static final QName _FIRMWARE_MANUFACTURER_STR = new QName(
             "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "platformManufacturerStr", "rim");
+            "firmwareManufacturerStr", "rim");
     public static final QName _FIRMWARE_MANUFACTURER_ID = new QName(
             "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "platformManufacturerId", "rim");
+            "firmwareManufacturerId", "rim");
     public static final QName _FIRMWARE_MODEL = new QName(
             "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "platformModel", "rim");
+            "firmwareModel", "rim");
     public static final QName _FIRMWARE_VERSION = new QName(
             "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "platformVersion", "rim");
+            "firmwareVersion", "rim");
     public static final QName _BINDING_SPEC = new QName(
             "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "bindingSpec", "rim");
+            "BindingSpec", "rim");
     public static final QName _BINDING_SPEC_VERSION = new QName(
             "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "bindingSpecVersion", "rim");
+            "BindingSpecVersion", "rim");
     public static final QName _PC_URI_LOCAL = new QName(
             "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
             "pcURILocal", "rim");

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -213,10 +213,7 @@ public class SwidTagGateway {
             swidTag.setTagId(tagId);
         }
         swidTag.setTagVersion(new BigInteger(jsonObject.getString(SwidTagConstants.TAGVERSION, "0")));
-        String version = jsonObject.getString(SwidTagConstants.VERSION, "");
-        if (!version.isEmpty()) {
-            swidTag.setVersion(version);
-        }
+        swidTag.setVersion(jsonObject.getString(SwidTagConstants.VERSION, "0.0"));
         swidTag.setCorpus(jsonObject.getBoolean(SwidTagConstants.CORPUS, false));
         swidTag.setPatch(jsonObject.getBoolean(SwidTagConstants.PATCH, false));
         swidTag.setSupplemental(jsonObject.getBoolean(SwidTagConstants.SUPPLEMENTAL, false));
@@ -312,6 +309,8 @@ public class SwidTagGateway {
         addNonNullAttribute(attributes, SwidTagConstants._BINDING_SPEC_VERSION, jsonObject.getString(SwidTagConstants.BINDING_SPEC_VERSION, ""));
         addNonNullAttribute(attributes, SwidTagConstants._PC_URI_LOCAL, jsonObject.getString(SwidTagConstants.PC_URI_LOCAL, ""));
         addNonNullAttribute(attributes, SwidTagConstants._PC_URI_GLOBAL, jsonObject.getString(SwidTagConstants.PC_URI_GLOBAL, ""));
+        addNonNullAttribute(attributes, SwidTagConstants._SUPPORT_RIM_TYPE, jsonObject.getString(SwidTagConstants.SUPPORT_RIM_TYPE, ""));
+        addNonNullAttribute(attributes, SwidTagConstants._SUPPORT_RIM_FORMAT, jsonObject.getString(SwidTagConstants.SUPPORT_RIM_FORMAT, ""));
         addNonNullAttribute(attributes, SwidTagConstants._RIM_LINK_HASH, jsonObject.getString(SwidTagConstants.RIM_LINK_HASH, ""));
 
         return softwareMeta;
@@ -329,6 +328,7 @@ public class SwidTagGateway {
         addNonNullAttribute(attributes, SwidTagConstants._N8060_ENVVARPREFIX, jsonObject.getString(SwidTagConstants._N8060_ENVVARPREFIX.getLocalPart(), ""));
         addNonNullAttribute(attributes, SwidTagConstants._N8060_ENVVARSUFFIX, jsonObject.getString(SwidTagConstants._N8060_ENVVARSUFFIX.getLocalPart(), ""));
         addNonNullAttribute(attributes, SwidTagConstants._N8060_PATHSEPARATOR, jsonObject.getString(SwidTagConstants._N8060_PATHSEPARATOR.getLocalPart(), ""));
+        addNonNullAttribute(attributes, SwidTagConstants._SUPPORT_RIM_URI_GLOBAL, jsonObject.getString(SwidTagConstants.SUPPORT_RIM_URI_GLOBAL, ""));
 
         return payload;
     }
@@ -342,10 +342,6 @@ public class SwidTagGateway {
     private Directory createDirectory(JsonObject jsonObject) {
         Directory directory = objectFactory.createDirectory();
         directory.setName(jsonObject.getString(SwidTagConstants.NAME, ""));
-        Map<QName, String> attributes = directory.getOtherAttributes();
-        addNonNullAttribute(attributes, SwidTagConstants._SUPPORT_RIM_TYPE, jsonObject.getString(SwidTagConstants.SUPPORT_RIM_TYPE, ""));
-        addNonNullAttribute(attributes, SwidTagConstants._SUPPORT_RIM_FORMAT, jsonObject.getString(SwidTagConstants.SUPPORT_RIM_FORMAT, ""));
-        addNonNullAttribute(attributes, SwidTagConstants._SUPPORT_RIM_URI_GLOBAL, jsonObject.getString(SwidTagConstants.SUPPORT_RIM_URI_GLOBAL, ""));
 
         return directory;
     }

--- a/tools/tcg_rim_tool/src/test/java/hirs/swid/TestSwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/test/java/hirs/swid/TestSwidTagGateway.java
@@ -20,6 +20,7 @@ public class TestSwidTagGateway {
 	private final String DEFAULT_OUTPUT = "generated_swidTag.swidtag";
 	private final String DEFAULT_WITH_CERT = "generated_with_cert.swidtag";
 	private final String DEFAULT_NO_CERT = "generated_no_cert.swidtag";
+	private final String ATTRIBUTES_FILE = TestSwidTagGateway.class.getClassLoader().getResource("rim_fields.json").getPath();
 	private final String SIGNING_CERT_FILE = TestSwidTagGateway.class.getClassLoader().getResource("RimSignCert.pem").getPath();
 	private final String PRIVATE_KEY_FILE = TestSwidTagGateway.class.getClassLoader().getResource("privateRimKey.pem").getPath();
 	private final String SUPPORT_RIM_FILE = TestSwidTagGateway.class.getClassLoader().getResource("TpmLog.bin").getPath();
@@ -29,6 +30,7 @@ public class TestSwidTagGateway {
 	public void setUp() throws Exception {
 		gateway = new SwidTagGateway();
 		gateway.setRimEventLog(SUPPORT_RIM_FILE);
+		gateway.setAttributesFile(ATTRIBUTES_FILE);
 		validator = new SwidTagValidator();
 		validator.setRimEventLog(SUPPORT_RIM_FILE);
 	}

--- a/tools/tcg_rim_tool/src/test/resources/generated_no_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_no_cert.swidtag
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="false" tagId="hirs.swid.SwidTags.example" tagVersion="1" version="0.1" versionScheme="multipartnumeric" xml:lang="en">
-  <Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/>
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+  <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:rimLinkHash="88f21d8e44d4271149297404df91caf207130bfa116582408abd04ede6db7f51"/>
-  <Payload>
-    <Directory name="iotBase">
-      <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="TpmLog.bin" size="7549"/>
+  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:BindingSpec="PC Client RIM" rim:BindingSpecVersion="1.2" rim:PayloadType="direct" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURILocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01" rim:supportRIMFormat="TCG_EventLog_Assertion"/>
+  <Payload xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:supportRIMURIGlobal="https://Example.com/support/ProductA/firmware/rims/">
+    <Directory name="rim">
+      <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.BIOS.01.rimel" size="7549"/>
     </Directory>
   </Payload>
   <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>jpPZu16C8KjtwY2JpJuyR3SBc2XclVEaVsv/DgyZKTM=</DigestValue>
+        <DigestValue>1rf2CJ9y+OSyPzuqgJt9ve3WiaBjya/RylFFZwSpy5Y=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>pWPozFWH2oytfgZse1Ai769c/cBFS/vapKj27asI8XDLdK8FkNs2K/+OTf4lScBiPLTCvWPIihoe
-hielmV8dWZqvR2z09pr+yCF7q/E8sCGhQXSsVlNZjElMXk2Qz2c6C9XtRk4UNmSfTSYsKEm2AST4
-oh6da+x1CeSHipALfuZZrXwa2AMtc9yTNfqaQFBxRqEDeTypLwNQqdr9va2T8C9ZNnEzooTf5FWw
-OUqc+Ewk5V9ZyOJ/0UdUxs40mGPpsIG90ikx59eu1A4qP4BzjHR3vrNbYDA4hBeIpDHC4vzwJrR4
-xqXw1SLqAm8ngL9Haj2Ww+y0PEZfo++JlOMZuQ==</SignatureValue>
+    <SignatureValue>TRqJ4HtAuQRSqL8TnqhpANTRkAPAI1tUft44xSAzqITT9NSetbLd2Te2D5/jg5kNwfpIYKirGKrd
+suTuBID5DsUsuZqExuvfAKPh1AQuSrQDrZReu+Ma1P/IGzZq3hRV1LVinV5NojdQbyB+yUcTp/d0
+gpBr5Y/PfYGLbkHshw2yJuhd6l1a2WPU8AxBQYTGJiFYX3WEkW20EubJ9FoxCVImdkhzbQKP/3lp
+M31jCMKM1DcFuUU3zdonZukWhd4bbqj926Av+r+qH9S1uGmwQEsNT0lfLljGd7Q7MMxuZ+9fbSgo
+D5GuQbkDL+RfEjbseEpOaB0w4f1uqeCoTEuiiA==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
       <KeyValue>

--- a/tools/tcg_rim_tool/src/test/resources/generated_with_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_with_cert.swidtag
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="TCG RIM example" patch="false" supplemental="false" tagId="hirs.swid.SwidTags.example" tagVersion="1" version="0.1" versionScheme="multipartnumeric" xml:lang="en">
-  <Entity name="HIRS" regid="www.example.com" role="softwareCreator tagCreator"/>
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+  <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <Meta xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:bindingSpec="IOT RIM" rim:bindingSpecVersion="1.2" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:rimLinkHash="88f21d8e44d4271149297404df91caf207130bfa116582408abd04ede6db7f51"/>
-  <Payload>
-    <Directory name="iotBase">
-      <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="TpmLog.bin" size="7549"/>
+  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:BindingSpec="PC Client RIM" rim:BindingSpecVersion="1.2" rim:PayloadType="direct" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURILocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01" rim:supportRIMFormat="TCG_EventLog_Assertion"/>
+  <Payload xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" rim:supportRIMURIGlobal="https://Example.com/support/ProductA/firmware/rims/">
+    <Directory name="rim">
+      <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.BIOS.01.rimel" size="7549"/>
     </Directory>
   </Payload>
   <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>jpPZu16C8KjtwY2JpJuyR3SBc2XclVEaVsv/DgyZKTM=</DigestValue>
+        <DigestValue>1rf2CJ9y+OSyPzuqgJt9ve3WiaBjya/RylFFZwSpy5Y=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>pWPozFWH2oytfgZse1Ai769c/cBFS/vapKj27asI8XDLdK8FkNs2K/+OTf4lScBiPLTCvWPIihoe
-hielmV8dWZqvR2z09pr+yCF7q/E8sCGhQXSsVlNZjElMXk2Qz2c6C9XtRk4UNmSfTSYsKEm2AST4
-oh6da+x1CeSHipALfuZZrXwa2AMtc9yTNfqaQFBxRqEDeTypLwNQqdr9va2T8C9ZNnEzooTf5FWw
-OUqc+Ewk5V9ZyOJ/0UdUxs40mGPpsIG90ikx59eu1A4qP4BzjHR3vrNbYDA4hBeIpDHC4vzwJrR4
-xqXw1SLqAm8ngL9Haj2Ww+y0PEZfo++JlOMZuQ==</SignatureValue>
+    <SignatureValue>TRqJ4HtAuQRSqL8TnqhpANTRkAPAI1tUft44xSAzqITT9NSetbLd2Te2D5/jg5kNwfpIYKirGKrd
+suTuBID5DsUsuZqExuvfAKPh1AQuSrQDrZReu+Ma1P/IGzZq3hRV1LVinV5NojdQbyB+yUcTp/d0
+gpBr5Y/PfYGLbkHshw2yJuhd6l1a2WPU8AxBQYTGJiFYX3WEkW20EubJ9FoxCVImdkhzbQKP/3lp
+M31jCMKM1DcFuUU3zdonZukWhd4bbqj926Av+r+qH9S1uGmwQEsNT0lfLljGd7Q7MMxuZ+9fbSgo
+D5GuQbkDL+RfEjbseEpOaB0w4f1uqeCoTEuiiA==</SignatureValue>
     <KeyInfo>
       <X509Data>
         <X509SubjectName>CN=example.RIM.signer,OU=PCClient,O=Example,ST=VA,C=US</X509SubjectName>

--- a/tools/tcg_rim_tool/src/test/resources/rim_fields.json
+++ b/tools/tcg_rim_tool/src/test/resources/rim_fields.json
@@ -1,0 +1,53 @@
+{
+        "SoftwareIdentity": {
+                "name": "Example.com BIOS",
+                "version": "01",
+                "tagId": "94f6b457-9ac9-4d35-9b3f-78804173b65as",
+                "tagVersion": "0",
+                "patch": false,
+                "supplemental": false
+        },
+	"Entity": {
+                "name": "Example Inc",
+                "regid": "http://Example.com",
+                "role": "softwareCreator,tagCreator"
+        },
+	"Link": {
+                "href": "https://Example.com/support/ProductA/firmware/installfiles",
+                "rel": "installationmedia"
+        },
+	"Meta": {
+                "colloquialVersion": "Firmware_2019",
+                "edition": "12",
+                "product": "ProductA",
+                "revision": "r2",
+                "PayloadType": "direct",
+                "platformManufacturerStr": "Example.com",
+                "platformManufacturerId": "00201234",
+                "platformModel": "ProductA",
+                "platformVersion": "01",
+                "firmwareManufacturerStr": "BIOSVendorA",
+                "firmwareManufacturerId": "00213022",
+                "firmwareModel": "A0",
+                "firmwareVersion": "12",
+                "bindingSpec": "PC Client RIM",
+                "bindingSpecVersion": "1.2",
+                "pcURIlocal": "/boot/tcg/manifest/switag/",
+                "pcURIGlobal": "https://Example.com/support/ProductA/",
+                "supportRIMFormat":"TCG_EventLog_Assertion"
+        },
+	"Payload": {
+                "supportRIMURIGlobal": "https://Example.com/support/ProductA/firmware/rims/",
+                "Directory": {
+                        "name": "rim",
+                        "root": "/boot/tcg/manifest/rim/",
+                        "File": {
+                                "version":"01",
+                                "name": "Example.com.BIOS.01.rimel",
+                                "size": "7549",
+                                "hash": "4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848"
+                                }
+                }
+        }
+}
+


### PR DESCRIPTION
1. Firmware attribute QName objects were not spelled correctly
2. Move support RIM attributes under Payload element

Closes #295 