### PR TITLE
[#236] TPM Quote validation update

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -515,9 +515,9 @@ public abstract class AbstractAttestationCertificateAuthority
             if (request.getQuote() != null && !request.getQuote().isEmpty()) {
                 parseTPMQuote(request.getQuote().toStringUtf8());
             }
-            if (request.getPcrslist() != null && !request.getPcrslist().isEmpty()) {
-                this.pcrValues = request.getPcrslist().toStringUtf8();
-            }
+//            if (request.getPcrslist() != null && !request.getPcrslist().isEmpty()) {
+//                this.pcrValues = request.getPcrslist().toStringUtf8();
+//            }
 
             // Get device name and device
             String deviceName = claim.getDv().getNw().getHostname();
@@ -1477,7 +1477,6 @@ public abstract class AbstractAttestationCertificateAuthority
             IssuedAttestationCertificate attCert = new IssuedAttestationCertificate(
                     derEncodedAttestationCertificate, endorsementCredential, platformCredentials);
             attCert.setDevice(device);
-            attCert.setPcrValues(savePcrValues(pcrValues, device.getName()));
             certificateManager.save(attCert);
         } catch (Exception e) {
             LOG.error("Error saving generated Attestation Certificate to database.", e);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -166,7 +166,6 @@ public abstract class AbstractAttestationCertificateAuthority
     private String tpmQuoteHash = "";
     private String tpmQuoteSignature = "";
     private String pcrValues;
-    private SupplyChainValidationSummary savedSummary;
 
     /**
      * Constructor.
@@ -453,7 +452,6 @@ public abstract class AbstractAttestationCertificateAuthority
         // perform supply chain validation
         SupplyChainValidationSummary summary = supplyChainValidationService.validateSupplyChain(
                 endorsementCredential, platformCredentials, device);
-        savedSummary = summary;
         // update the validation result in the device
         AppraisalStatus.Status validationResult = summary.getOverallValidationResult();
         device.setSupplyChainStatus(validationResult);
@@ -471,7 +469,7 @@ public abstract class AbstractAttestationCertificateAuthority
     private AppraisalStatus.Status doQuoteValidation(final Device device) {
         // perform supply chain validation
         SupplyChainValidationSummary scvs = supplyChainValidationService.validateQuote(
-                device, savedSummary);
+                device);
         AppraisalStatus.Status validationResult;
 
         // either validation wasn't enabled or device already failed

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -302,7 +302,7 @@ public abstract class AbstractAttestationCertificateAuthority
         // update the validation result in the device
         device.setSupplyChainStatus(summary.getOverallValidationResult());
         deviceManager.updateDevice(device);
-
+        LOG.error("This is the device id? {} ", device.getId());
         // check if supply chain validation succeeded.
         // If it did not, do not provide the IdentityResponseEnvelope
         if (summary.getOverallValidationResult() == AppraisalStatus.Status.PASS) {
@@ -452,6 +452,7 @@ public abstract class AbstractAttestationCertificateAuthority
         // perform supply chain validation
         SupplyChainValidationSummary summary = supplyChainValidationService.validateSupplyChain(
                 endorsementCredential, platformCredentials, device);
+        device.setSummaryId(summary.getId().toString());
         // update the validation result in the device
         AppraisalStatus.Status validationResult = summary.getOverallValidationResult();
         device.setSupplyChainStatus(validationResult);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -62,14 +62,11 @@ import javax.crypto.spec.OAEPParameterSpec;
 import javax.crypto.spec.PSource;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
@@ -167,8 +164,9 @@ public abstract class AbstractAttestationCertificateAuthority
     private final DeviceManager deviceManager;
     private final DBManager<TPM2ProvisionerState> tpm2ProvisionerStateDBManager;
     private String tpmQuoteHash = "";
-    private String tpmSignatureHash = "";
+    private String tpmQuoteSignature = "";
     private String pcrValues;
+    private SupplyChainValidationSummary savedSummary;
 
     /**
      * Constructor.
@@ -455,7 +453,7 @@ public abstract class AbstractAttestationCertificateAuthority
         // perform supply chain validation
         SupplyChainValidationSummary summary = supplyChainValidationService.validateSupplyChain(
                 endorsementCredential, platformCredentials, device);
-
+        savedSummary = summary;
         // update the validation result in the device
         AppraisalStatus.Status validationResult = summary.getOverallValidationResult();
         device.setSupplyChainStatus(validationResult);
@@ -472,7 +470,8 @@ public abstract class AbstractAttestationCertificateAuthority
      */
     private AppraisalStatus.Status doQuoteValidation(final Device device) {
         // perform supply chain validation
-        SupplyChainValidationSummary scvs = supplyChainValidationService.validateQuote(device);
+        SupplyChainValidationSummary scvs = supplyChainValidationService.validateQuote(
+                device, savedSummary);
         AppraisalStatus.Status validationResult;
 
         // either validation wasn't enabled or device already failed
@@ -536,37 +535,63 @@ public abstract class AbstractAttestationCertificateAuthority
             Set<PlatformCredential> platformCredentials = parsePcsFromIdentityClaim(claim,
                     endorsementCredential);
 
-            // Parse through the Provisioner supplied TPM Quote and pcr values
-            // these fields are optional
-            if (request.getQuote() != null && !request.getQuote().isEmpty()) {
-                parseTPMQuote(request.getQuote().toStringUtf8());
-            }
-//            if (request.getPcrslist() != null && !request.getPcrslist().isEmpty()) {
-//                this.pcrValues = request.getPcrslist().toStringUtf8();
-//            }
-
             // Get device name and device
             String deviceName = claim.getDv().getNw().getHostname();
             Device device = deviceManager.getDevice(deviceName);
 
-            // Create signed, attestation certificate
-            X509Certificate attestationCertificate = generateCredential(akPub,
-                    endorsementCredential, platformCredentials, deviceName);
-            byte[] derEncodedAttestationCertificate = getDerEncodedCertificate(
-                    attestationCertificate);
+            // Parse through the Provisioner supplied TPM Quote and pcr values
+            // these fields are optional
+            if (request.getQuote() != null && !request.getQuote().isEmpty()) {
+                parseTPMQuote(request.getQuote().toStringUtf8());
+                TPMInfo savedInfo = device.getDeviceInfo().getTPMInfo();
+                TPMInfo tpmInfo = null;
+                try {
+                    tpmInfo = new TPMInfo(savedInfo.getTPMMake(),
+                        savedInfo.getTPMVersionMajor(),
+                        savedInfo.getTPMVersionMinor(),
+                        savedInfo.getTPMVersionRevMajor(),
+                        savedInfo.getTPMVersionRevMinor(),
+                        savedInfo.getPcrValues(),
+                        this.tpmQuoteHash.getBytes("UTF-8"),
+                        this.tpmQuoteSignature.getBytes("UTF-8"));
+                } catch (UnsupportedEncodingException e) {
+                    LOG.error(e);
+                }
+                DeviceInfoReport dvReport = new DeviceInfoReport(
+                        device.getDeviceInfo().getNetworkInfo(),
+                        device.getDeviceInfo().getOSInfo(),
+                        device.getDeviceInfo().getFirmwareInfo(),
+                        device.getDeviceInfo().getHardwareInfo(), tpmInfo,
+                        claim.getClientVersion());
+                device = this.deviceRegister.saveOrUpdateDevice(dvReport);
+            }
 
-            // We validated the nonce and made use of the identity claim so state can be deleted
-            tpm2ProvisionerStateDBManager.delete(tpm2ProvisionerState);
+            AppraisalStatus.Status validationResult = doQuoteValidation(device);
+            if (validationResult == AppraisalStatus.Status.PASS) {
+                // Create signed, attestation certificate
+                X509Certificate attestationCertificate = generateCredential(akPub,
+                        endorsementCredential, platformCredentials, deviceName);
+                byte[] derEncodedAttestationCertificate = getDerEncodedCertificate(
+                        attestationCertificate);
 
-            // Package the signed certificate into a response
-            ByteString certificateBytes = ByteString.copyFrom(derEncodedAttestationCertificate);
-            ProvisionerTpm2.CertificateResponse response = ProvisionerTpm2.CertificateResponse
-                    .newBuilder().setCertificate(certificateBytes).build();
+                // We validated the nonce and made use of the identity claim so state can be deleted
+                tpm2ProvisionerStateDBManager.delete(tpm2ProvisionerState);
 
-            saveAttestationCertificate(derEncodedAttestationCertificate, endorsementCredential,
-                    platformCredentials, device);
+                // Package the signed certificate into a response
+                ByteString certificateBytes = ByteString.copyFrom(derEncodedAttestationCertificate);
+                ProvisionerTpm2.CertificateResponse response = ProvisionerTpm2.CertificateResponse
+                        .newBuilder().setCertificate(certificateBytes).build();
 
-            return response.toByteArray();
+                saveAttestationCertificate(derEncodedAttestationCertificate, endorsementCredential,
+                        platformCredentials, device);
+
+                return response.toByteArray();
+            } else {
+                LOG.error("Supply chain validation did not succeed. "
+                        + "Firmware Quote Validation failed. Result is: "
+                        + validationResult);
+                return new byte[]{};
+            }
         } else {
             LOG.error("Could not process credential request. Invalid nonce provided: "
                     + request.getNonce().toString());
@@ -579,7 +604,8 @@ public abstract class AbstractAttestationCertificateAuthority
      * quote and the signature hash.
      * @param tpmQuote contains hash values for the quote and the signature
      */
-    private void parseTPMQuote(final String tpmQuote) {
+    private boolean parseTPMQuote(final String tpmQuote) {
+        boolean success = false;
         if (tpmQuote != null) {
             String[] lines = tpmQuote.split(":");
             if (lines[1].contains("signature")) {
@@ -587,8 +613,11 @@ public abstract class AbstractAttestationCertificateAuthority
             } else {
                 this.tpmQuoteHash = lines[1].trim();
             }
-            this.tpmSignatureHash = lines[2].trim();
+            this.tpmQuoteSignature = lines[2].trim();
+            success = true;
         }
+
+        return success;
     }
 
     /**
@@ -689,9 +718,24 @@ public abstract class AbstractAttestationCertificateAuthority
                 hwProto.getProductVersion(), hwProto.getSystemSerialNumber(),
                 firstChassisSerialNumber, firstBaseboardSerialNumber);
 
+        if (dv.getPcrslist() != null && !dv.getPcrslist().isEmpty()) {
+            this.pcrValues = dv.getPcrslist().toStringUtf8();
+        }
 
         // Get TPM info, currently unimplemented
         TPMInfo tpm = new TPMInfo();
+        try {
+            tpm = new TPMInfo(DeviceInfoReport.NOT_SPECIFIED,
+                    (short) 0,
+                    (short) 0,
+                    (short) 0,
+                    (short) 0,
+                    this.pcrValues.getBytes("UTF-8"),
+                    this.tpmQuoteHash.getBytes("UTF-8"),
+                    this.tpmQuoteSignature.getBytes("UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            tpm = new TPMInfo();
+        }
 
         // Create final report
         DeviceInfoReport dvReport = new DeviceInfoReport(nw, os, fw, hw, tpm,
@@ -1510,30 +1554,5 @@ public abstract class AbstractAttestationCertificateAuthority
                     "Encountered error while storing Attestation Certificate: "
                             + e.getMessage(), e);
         }
-    }
-
-    private String savePcrValues(final String pcrValues, final String deviceName) {
-        if (pcrValues != null && !pcrValues.isEmpty()) {
-            try {
-                if (Files.notExists(Paths.get(PCR_UPLOAD_FOLDER))) {
-                    Files.createDirectory(Paths.get(PCR_UPLOAD_FOLDER));
-                }
-                Path pcrPath = Paths.get(String.format("%s/%s",
-                        PCR_UPLOAD_FOLDER, deviceName));
-                if (Files.notExists(pcrPath)) {
-                    Files.createFile(pcrPath);
-                }
-                Files.write(pcrPath, pcrValues.getBytes("UTF8"));
-                return pcrPath.toString();
-            } catch (NoSuchFileException nsfEx) {
-                LOG.error(String.format("File Not found!: %s",
-                        deviceName));
-                LOG.error(nsfEx);
-            } catch (IOException ioEx) {
-                LOG.error(ioEx);
-            }
-        }
-
-        return "empty";
     }
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -478,6 +478,7 @@ public abstract class AbstractAttestationCertificateAuthority
             // this will just allow for the certificate to be saved.
             validationResult = AppraisalStatus.Status.PASS;
         } else {
+            device.setSummaryId(scvs.getId().toString());
             // update the validation result in the device
             validationResult = scvs.getOverallValidationResult();
             device.setSupplyChainStatus(validationResult);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationService.java
@@ -30,9 +30,7 @@ public interface SupplyChainValidationService {
      * A supplemental method that handles validating just the quote post main validation.
      *
      * @param device the associated device.
-     * @param summary the associated device summary
      * @return True if validation is successful, false otherwise.
      */
-    SupplyChainValidationSummary validateQuote(Device device,
-                                               SupplyChainValidationSummary summary);
+    SupplyChainValidationSummary validateQuote(Device device);
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationService.java
@@ -30,7 +30,9 @@ public interface SupplyChainValidationService {
      * A supplemental method that handles validating just the quote post main validation.
      *
      * @param device the associated device.
+     * @param summary the associated device summary
      * @return True if validation is successful, false otherwise.
      */
-    SupplyChainValidationSummary validateQuote(Device device);
+    SupplyChainValidationSummary validateQuote(Device device,
+                                               SupplyChainValidationSummary summary);
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationService.java
@@ -1,6 +1,7 @@
 package hirs.attestationca.service;
 
 import java.util.Set;
+
 import hirs.data.persist.Device;
 import hirs.data.persist.SupplyChainValidationSummary;
 import hirs.data.persist.certificate.EndorsementCredential;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationService.java
@@ -25,4 +25,12 @@ public interface SupplyChainValidationService {
     SupplyChainValidationSummary validateSupplyChain(EndorsementCredential ec,
                                                      Set<PlatformCredential> pc,
                                                      Device device);
+
+    /**
+     * A supplemental method that handles validating just the quote post main validation.
+     *
+     * @param device the associated device.
+     * @return True if validation is successful, false otherwise.
+     */
+    SupplyChainValidationSummary validateQuote(Device device);
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
@@ -448,20 +448,19 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
             }
 
             // Generate validation summary, save it, and return it.
-
             List<SupplyChainValidation> validations = new ArrayList<>();
             validations.addAll(summary.getValidations());
             validations.add(quoteScv);
             newSummary = new SupplyChainValidationSummary(device, validations);
 
             try {
-                supplyChainValidatorSummaryManager.update(newSummary);
+                supplyChainValidatorSummaryManager.save(summary);
             } catch (DBManagerException ex) {
                 LOGGER.error("Failed to save Supply Chain summary", ex);
             }
         }
 
-        return newSummary;
+        return summary;
     }
 
     private SupplyChainValidation validateEndorsementCredential(final EndorsementCredential ec,

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.LinkedList;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.Level;
 import hirs.appraiser.Appraiser;
@@ -47,6 +48,7 @@ import hirs.persist.DBManagerException;
 import hirs.persist.PersistenceConfiguration;
 import hirs.persist.PolicyManager;
 import hirs.validation.CredentialValidator;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -254,6 +256,7 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
         } catch (DBManagerException ex) {
             LOGGER.error("Failed to save Supply Chain summary", ex);
         }
+
         return summary;
     }
 
@@ -339,6 +342,7 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
             for (SwidResource swid : swids) {
                 baseline = swid.getPcrValues()
                         .toArray(new String[swid.getPcrValues().size()]);
+                LOGGER.error("is file size valid {}", swid.isValidFileSize());
             }
             pcrPolicy.setBaselinePcrs(baseline);
 
@@ -453,9 +457,14 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
 
             // Generate validation summary, save it, and return it.
             List<SupplyChainValidation> validations = new ArrayList<>();
+            SupplyChainValidationSummary previous
+                    = this.supplyChainValidatorSummaryManager.get(
+                    UUID.fromString(device.getSummaryId()));
+            validations.addAll(previous.getValidations());
             validations.add(quoteScv);
             summary = new SupplyChainValidationSummary(device, validations);
             supplyChainValidatorSummaryManager.save(summary);
+            supplyChainValidatorSummaryManager.delete(previous.getId());
         }
 
         return summary;

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
@@ -5,9 +5,11 @@ import hirs.attestationca.portal.datatables.DataTableResponse;
 import hirs.attestationca.portal.datatables.OrderedListQueryDataTableAdapter;
 import hirs.attestationca.portal.page.PageController;
 import hirs.attestationca.portal.page.params.NoPageParams;
+import hirs.data.persist.certificate.Certificate;
 import org.apache.logging.log4j.Logger;
 import static org.apache.logging.log4j.LogManager.getLogger;
 import org.hibernate.Criteria;
+import org.hibernate.criterion.Restrictions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -79,16 +81,17 @@ public class ValidationReportsPageController extends PageController<NoPageParams
         // define an alias so the composite object, device, can be used by the
         // datatables / query. This is necessary so the device.name property can
         // be used.
-        CriteriaModifier modifier = new CriteriaModifier() {
+        CriteriaModifier criteriaModifier = new CriteriaModifier() {
             @Override
             public void modify(final Criteria criteria) {
+                criteria.add(Restrictions.isNull(Certificate.ARCHIVE_FIELD));
                 criteria.createAlias("device", "device");
             }
         };
 
         FilteredRecordsList<SupplyChainValidationSummary> records =
                 OrderedListQueryDataTableAdapter.getOrderedList(SupplyChainValidationSummary.class,
-                        supplyChainValidatorSummaryManager, input, orderColumnName, modifier);
+                        supplyChainValidatorSummaryManager, input, orderColumnName, criteriaModifier);
 
         return new DataTableResponse<>(records, input);
     }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
@@ -90,8 +90,10 @@ public class ValidationReportsPageController extends PageController<NoPageParams
         };
 
         FilteredRecordsList<SupplyChainValidationSummary> records =
-                OrderedListQueryDataTableAdapter.getOrderedList(SupplyChainValidationSummary.class,
-                        supplyChainValidatorSummaryManager, input, orderColumnName, criteriaModifier);
+                OrderedListQueryDataTableAdapter.getOrderedList(
+                        SupplyChainValidationSummary.class,
+                        supplyChainValidatorSummaryManager, input, orderColumnName,
+                        criteriaModifier);
 
         return new DataTableResponse<>(records, input);
     }

--- a/HIRS_ProvisionerTPM2/include/CommandTpm2.h
+++ b/HIRS_ProvisionerTPM2/include/CommandTpm2.h
@@ -137,7 +137,7 @@ class CommandTpm2 {
     std::string getQuote(const std::string& pcr_selection,
             const std::string& nonce);
 
-    std::string getPcrsList();
+    std::string getPcrList();
 };
 
 }  // namespace tpm2

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -558,7 +558,7 @@ string CommandTpm2::getQuote(const string& pcr_selection,
  * Method to get the full list of pcrs from the TPM.
  *
  */
-string CommandTpm2::getPcrsList() {
+string CommandTpm2::getPcrList() {
     string pcrslist;
     stringstream argsStream;
 

--- a/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
+++ b/HIRS_ProvisionerTPM2/src/ProvisionerTpm2.proto
@@ -57,6 +57,7 @@ message DeviceInfo {
   required HardwareInfo hw = 2;
   required NetworkInfo nw = 3;
   required OsInfo os = 4;
+  optional bytes pcrslist = 5;
 }
 
 message IdentityClaim {
@@ -80,7 +81,6 @@ message IdentityClaimResponse {
 message CertificateRequest {
   required bytes nonce = 1;
   optional bytes quote = 2;
-  optional bytes pcrslist = 3;
 }
 
 message CertificateResponse {

--- a/HIRS_ProvisionerTPM2/src/RestfulClientProvisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/RestfulClientProvisioner.cpp
@@ -98,7 +98,7 @@ string RestfulClientProvisioner::sendIdentityClaim(
         stringstream errormsg;
         errormsg << "Error communicating with ACA server. "
                  << "Received response code: " << to_string(r.status_code)
-                 << "\n\nError message fom ACA was: "
+                 << "\n\nError message from ACA was: "
                  << JSONFieldParser::parseJsonStringField(r.text,
                                                           ACA_ERROR_FIELDNAME);
         throw HirsRuntimeException(errormsg.str(),

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -64,6 +64,7 @@ int provision() {
     // collect device info
     cout << "----> Collecting device information" << endl;
     hirs::pb::DeviceInfo dv = DeviceInfoCollector::collectDeviceInfo();
+    dv.set_pcrslist(tpm2.getPcrList());
 
     // send identity claim
     cout << "----> Sending identity claim to Attestation CA" << endl;
@@ -106,10 +107,14 @@ int provision() {
                 "14,15,16,17,18,19,20,21,22,23",
                 decryptedNonce));
 
-    certificateRequest.set_pcrslist(tpm2.getPcrsList());
     const string& akCertificateByteString
             = provisioner.sendAttestationCertificateRequest(certificateRequest);
 
+    if (akCertificateByteString == "") {
+        cout << "----> Provisioning failed.";
+        cout << "Please refer to the Attestation CA for details." << endl;
+        return 0;
+    }
     cout << "----> Storing attestation key certificate" << endl;
     tpm2.storeAKCertificate(akCertificateByteString);
     return 1;

--- a/HIRS_Utils/src/main/java/hirs/data/persist/Device.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/Device.java
@@ -95,6 +95,9 @@ public class Device extends AbstractEntity {
     @Column(name = "state_override_reason")
     private String overrideReason;
 
+    @Column(name = "summary_id")
+    private String summaryId;
+
     /**
      * Default constructor required by Hibernate.
      */
@@ -356,6 +359,22 @@ public class Device extends AbstractEntity {
             throw new NullPointerException(" supply chain validation status");
         }
         this.supplyChainValidationStatus = supplyChainValidationStatus;
+    }
+
+    /**
+     * Getter for the last summary id.
+     * @return UUID for the summary
+     */
+    public String getSummaryId() {
+        return summaryId;
+    }
+
+    /**
+     * Setter for the last summary id.
+     * @param summaryId UUID
+     */
+    public void setSummaryId(final String summaryId) {
+        this.summaryId = summaryId;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/PCRPolicy.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/PCRPolicy.java
@@ -123,12 +123,6 @@ public final class PCRPolicy extends Policy {
             String calculatedString = Hex.encodeHexString(
                     pcrInfoShort.getCalculatedDigest());
             validated = quoteString.contains(calculatedString);
-            if (validated) {
-                LOGGER.error("This is matching: ");
-
-            } else {
-                LOGGER.error("This is NOT matching: ");
-            }
         } catch (NoSuchAlgorithmException naEx) {
             LOGGER.error(naEx);
         }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/SwidResource.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/SwidResource.java
@@ -48,6 +48,7 @@ public class SwidResource {
     private List<String> pcrValues;
     private TpmWhiteListBaseline tpmWhiteList;
     private DigestAlgorithm digest = DigestAlgorithm.SHA1;
+    private boolean validFileSize = false;
 
     /**
      * Default constructor.
@@ -193,6 +194,14 @@ public class SwidResource {
     }
 
     /**
+     * flag for if the file sizes match with the swidtag.
+     * @return true if they match
+     */
+    public boolean isValidFileSize() {
+        return validFileSize;
+    }
+
+    /**
      * Getter for a generated map of the PCR values.
      *
      * @return mapping of PCR# to the actual value.
@@ -223,6 +232,7 @@ public class SwidResource {
             if (Files.exists(logPath)) {
                 logProcessor = new TCGEventLog(
                         Files.readAllBytes(logPath));
+//                this.validFileSize = Files.size(logPath) == Long.getLong(this.size);
             }
             this.setPcrValues(Arrays.asList(
                         logProcessor.getExpectedPCRValues()));

--- a/HIRS_Utils/src/main/java/hirs/data/persist/SwidResource.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/SwidResource.java
@@ -232,7 +232,6 @@ public class SwidResource {
             if (Files.exists(logPath)) {
                 logProcessor = new TCGEventLog(
                         Files.readAllBytes(logPath));
-//                this.validFileSize = Files.size(logPath) == Long.getLong(this.size);
             }
             this.setPcrValues(Arrays.asList(
                         logProcessor.getExpectedPCRValues()));

--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/IssuedAttestationCertificate.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/IssuedAttestationCertificate.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.UUID;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
-import javax.persistence.Column;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
@@ -20,8 +19,6 @@ import javax.persistence.ManyToOne;
  */
 @Entity
 public class IssuedAttestationCertificate extends DeviceAssociatedCertificate {
-
-    private static final int MAX_CERT_LENGTH_BYTES = 1024;
 
     /**
      * AIC label that must be used.
@@ -35,9 +32,6 @@ public class IssuedAttestationCertificate extends DeviceAssociatedCertificate {
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinColumn(name = "pc_id")
     private Set<PlatformCredential> platformCredentials;
-
-    @Column(nullable = true, length = MAX_CERT_LENGTH_BYTES)
-    private String pcrValues;
 
     /**
      * This class enables the retrieval of IssuedAttestationCertificate by their attributes.
@@ -128,21 +122,5 @@ public class IssuedAttestationCertificate extends DeviceAssociatedCertificate {
      */
     public Set<PlatformCredential> getPlatformCredentials() {
         return Collections.unmodifiableSet(platformCredentials);
-    }
-
-    /**
-     * Getter for the pcrValues passed up by the client.
-     * @return a string blob of pcrs
-     */
-    public String getPcrValues() {
-        return pcrValues;
-    }
-
-    /**
-     * Setter for the pcrValues passed up by the client.
-     * @param pcrValues to be stored.
-     */
-    public void setPcrValues(final String pcrValues) {
-        this.pcrValues = pcrValues;
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/info/TPMInfo.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/info/TPMInfo.java
@@ -24,6 +24,7 @@ import org.hibernate.annotations.Type;
 @Embeddable
 public class TPMInfo implements Serializable {
     private static final Logger LOGGER = LogManager.getLogger(TPMInfo.class);
+    private static final int MAX_BLOB_SIZE = 65535;
 
     @XmlElement
     @Column(length = DeviceInfoReport.MED_STRING_LENGTH, nullable = true)
@@ -52,6 +53,15 @@ public class TPMInfo implements Serializable {
     @JsonIgnore
     private X509Certificate identityCertificate;
 
+    @Column(nullable = true, length = MAX_BLOB_SIZE)
+    private byte[] pcrValues;
+
+    @Column(nullable = true, length = MAX_BLOB_SIZE)
+    private byte[] tpmQuoteHash;
+
+    @Column(nullable = true, length = MAX_BLOB_SIZE)
+    private byte[] tpmQuoteSignature;
+
     /**
      * Constructor used to create a TPMInfo object.
      *
@@ -68,17 +78,65 @@ public class TPMInfo implements Serializable {
      *            short representing the minor revision number for the TPM
      * @param identityCertificate
      *            byte array with the value of the identity certificate
+     * @param pcrValues
+     *            short representing the major revision number for the TPM
+     * @param tpmQuoteHash
+     *            short representing the minor revision number for the TPM
+     * @param tpmQuoteSignature
+     *            byte array with the value of the identity certificate
      */
+    @SuppressWarnings("parameternumber")
     public TPMInfo(final String tpmMake, final short tpmVersionMajor,
             final short tpmVersionMinor, final short tpmVersionRevMajor,
             final short tpmVersionRevMinor,
-            final X509Certificate identityCertificate) {
+            final X509Certificate identityCertificate, final byte[] pcrValues,
+                   final byte[] tpmQuoteHash, final byte[] tpmQuoteSignature) {
         setTPMMake(tpmMake);
         setTPMVersionMajor(tpmVersionMajor);
         setTPMVersionMinor(tpmVersionMinor);
         setTPMVersionRevMajor(tpmVersionRevMajor);
         setTPMVersionRevMinor(tpmVersionRevMinor);
         setIdentityCertificate(identityCertificate);
+        setPcrValues(pcrValues);
+        setTpmQuoteHash(tpmQuoteHash);
+        setTpmQuoteSignature(tpmQuoteSignature);
+    }
+
+    /**
+     * Constructor used to create a TPMInfo object without an identity
+     * certificate.
+     *
+     * @param tpmMake
+     *            String representing the make information for the TPM,
+     *            NullPointerException thrown if null
+     * @param tpmVersionMajor
+     *            short representing the major version number for the TPM
+     * @param tpmVersionMinor
+     *            short representing the minor version number for the TPM
+     * @param tpmVersionRevMajor
+     *            short representing the major revision number for the TPM
+     * @param tpmVersionRevMinor
+     *            short representing the minor revision number for the TPM
+     * @param pcrValues
+     *            short representing the major revision number for the TPM
+     * @param tpmQuoteHash
+     *            short representing the minor revision number for the TPM
+     * @param tpmQuoteSignature
+     *            byte array with the value of the identity certificate
+     */
+    @SuppressWarnings("parameternumber")
+    public TPMInfo(final String tpmMake, final short tpmVersionMajor,
+            final short tpmVersionMinor, final short tpmVersionRevMajor,
+            final short tpmVersionRevMinor, final byte[] pcrValues,
+                   final byte[] tpmQuoteHash, final byte[] tpmQuoteSignature) {
+        setTPMMake(tpmMake);
+        setTPMVersionMajor(tpmVersionMajor);
+        setTPMVersionMinor(tpmVersionMinor);
+        setTPMVersionRevMajor(tpmVersionRevMajor);
+        setTPMVersionRevMinor(tpmVersionRevMinor);
+        setPcrValues(pcrValues);
+        setTpmQuoteHash(tpmQuoteHash);
+        setTpmQuoteSignature(tpmQuoteSignature);
     }
 
     /**
@@ -98,13 +156,38 @@ public class TPMInfo implements Serializable {
      *            short representing the minor revision number for the TPM
      */
     public TPMInfo(final String tpmMake, final short tpmVersionMajor,
-            final short tpmVersionMinor, final short tpmVersionRevMajor,
-            final short tpmVersionRevMinor) {
-        setTPMMake(tpmMake);
-        setTPMVersionMajor(tpmVersionMajor);
-        setTPMVersionMinor(tpmVersionMinor);
-        setTPMVersionRevMajor(tpmVersionRevMajor);
-        setTPMVersionRevMinor(tpmVersionRevMinor);
+                   final short tpmVersionMinor, final short tpmVersionRevMajor,
+                   final short tpmVersionRevMinor) {
+        this(tpmMake, tpmVersionMajor, tpmVersionMinor, tpmVersionRevMajor,
+                tpmVersionRevMinor, null,
+                new byte[0], new byte[0], new byte[0]);
+    }
+
+    /**
+     * Constructor used to create a TPMInfo object without an identity
+     * certificate.
+     *
+     * @param tpmMake
+     *            String representing the make information for the TPM,
+     *            NullPointerException thrown if null
+     * @param tpmVersionMajor
+     *            short representing the major version number for the TPM
+     * @param tpmVersionMinor
+     *            short representing the minor version number for the TPM
+     * @param tpmVersionRevMajor
+     *            short representing the major revision number for the TPM
+     * @param tpmVersionRevMinor
+     *            short representing the minor revision number for the TPM
+     * @param identityCertificate
+     *            byte array with the value of the identity certificate
+     */
+    public TPMInfo(final String tpmMake, final short tpmVersionMajor,
+                   final short tpmVersionMinor, final short tpmVersionRevMajor,
+                   final short tpmVersionRevMinor,
+                   final X509Certificate identityCertificate) {
+        this(tpmMake, tpmVersionMajor, tpmVersionMinor, tpmVersionRevMajor,
+                tpmVersionRevMinor, identityCertificate,
+                new byte[0], new byte[0], new byte[0]);
     }
 
     /**
@@ -112,10 +195,13 @@ public class TPMInfo implements Serializable {
      */
     public TPMInfo() {
         this(DeviceInfoReport.NOT_SPECIFIED,
-            (short) 0,
-            (short) 0,
-            (short) 0,
-            (short) 0);
+                (short) 0,
+                (short) 0,
+                (short) 0,
+                (short) 0,
+                new byte[0],
+                new byte[0],
+                new byte[0]);
         identityCertificate = null;
     }
 
@@ -173,6 +259,30 @@ public class TPMInfo implements Serializable {
      */
     public X509Certificate getIdentityCertificate() {
         return identityCertificate;
+    }
+
+    /**
+     * Getter for the tpmQuote passed up by the client.
+     * @return a byte blob of quote
+     */
+    public final byte[] getTpmQuoteHash() {
+        return tpmQuoteHash.clone();
+    }
+
+    /**
+     * Getter for the quote signature.
+     * @return a byte blob.
+     */
+    public final byte[] getTpmQuoteSignature() {
+        return tpmQuoteSignature.clone();
+    }
+
+    /**
+     * Getter for the pcr values.
+     * @return a byte blob for the pcrValues.
+     */
+    public final byte[] getPcrValues() {
+        return pcrValues.clone();
     }
 
     @Override
@@ -284,5 +394,29 @@ public class TPMInfo implements Serializable {
         }
         LOGGER.debug("setting identity certificate");
         this.identityCertificate = identityCertificate;
+    }
+
+    private void setPcrValues(final byte[] pcrValues) {
+        if (pcrValues == null) {
+            this.pcrValues = new byte[0];
+        } else {
+            this.pcrValues = pcrValues.clone();
+        }
+    }
+
+    private void setTpmQuoteHash(final byte[] tpmQuoteHash) {
+        if (tpmQuoteHash == null) {
+            this.tpmQuoteHash = new byte[0];
+        } else {
+            this.tpmQuoteHash = tpmQuoteHash.clone();
+        }
+    }
+
+    private void setTpmQuoteSignature(final byte[] tpmQuoteSignature) {
+        if (tpmQuoteSignature == null) {
+            this.tpmQuoteSignature = new byte[0];
+        } else {
+            this.tpmQuoteSignature = tpmQuoteSignature.clone();
+        }
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/tpm/PcrComposite.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/tpm/PcrComposite.java
@@ -115,7 +115,7 @@ public class PcrComposite {
     @XmlElement(name = "ValueSize", required = true)
     public final int getValueSize() {
         int valueSize = 0;
-        for (TPMMeasurementRecord record: this.pcrValueList) {
+        for (TPMMeasurementRecord record : this.pcrValueList) {
             valueSize += record.getHash().getDigest().length;
         }
         return valueSize;

--- a/HIRS_Utils/src/main/java/hirs/data/persist/tpm/PcrInfoShort.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/tpm/PcrInfoShort.java
@@ -270,6 +270,7 @@ public class PcrInfoShort {
 
         while (iter.hasNext()) {
             TPMMeasurementRecord record = (TPMMeasurementRecord) iter.next();
+            LOGGER.error(record.getHash());
             byteBuffer.put(record.getHash().getDigest());
         }
 

--- a/HIRS_Utils/src/main/java/hirs/data/persist/tpm/PcrInfoShort.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/tpm/PcrInfoShort.java
@@ -270,7 +270,6 @@ public class PcrInfoShort {
 
         while (iter.hasNext()) {
             TPMMeasurementRecord record = (TPMMeasurementRecord) iter.next();
-            LOGGER.error(record.getHash());
             byteBuffer.put(record.getHash().getDigest());
         }
 
@@ -288,7 +287,6 @@ public class PcrInfoShort {
      * @return byte array representing the PcrInfoShort object
      */
     public final byte[] getValue() {
-
         ByteBuffer byteBuffer = ByteBuffer.allocate(getLength());
         byteBuffer.put(pcrSelection.getValue());
         byteBuffer.put((byte) localityAtRelease);

--- a/HIRS_Utils/src/main/java/hirs/data/persist/tpm/PcrSelection.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/tpm/PcrSelection.java
@@ -30,6 +30,10 @@ public class PcrSelection {
     private static final Logger LOGGER = LogManager
             .getLogger(PcrSelection.class);
     private static final int MAX_SIZE_PCR_ARRAY = 3;
+    /**
+     * All PCRs are on.
+     */
+    public static final int ALL_PCRS_ON = 0xffffff;
 
     @XmlAttribute(name = "PcrSelect", required = true)
     private final byte[] pcrSelect;
@@ -76,8 +80,7 @@ public class PcrSelection {
      *            long value representing the bits to be selected
      */
     public PcrSelection(final long pcrSelectLong) {
-        final int allPCRsOn = 0xffffff;
-        if (pcrSelectLong > allPCRsOn) {
+        if (pcrSelectLong > ALL_PCRS_ON) {
             LOGGER.error("pcrSelect long value must be less than 3 bytes");
             throw new InvalidParameterException("pcrSelect");
         }


### PR DESCRIPTION
This code push adds the ability to validate the pcrs against the quote provided by the provisioner.  

This sequence happens after the first set of validations and to validate the quote a new summary has to be generated along with the previous validations.  

Code tested against valid and non-valid swidtag and rim files.

#236 