### PR TITLE
XJC Generation Tweak

### DIFF
--- a/HIRS_Utils/config/genXjcLibrary.sh
+++ b/HIRS_Utils/config/genXjcLibrary.sh
@@ -12,4 +12,6 @@ fi
 
 XSD_FILE=$SRC_DIR/main/resources/swid_schema.xsd
 
-xjc -p hirs.utils.xjc $XSD_FILE -d $DEST_DIR -quiet
+if [ ! -d "$DEST_DIR/hirs/utils/xjc" ]; then
+  xjc -p hirs.utils.xjc $XSD_FILE -d $DEST_DIR -quiet
+fi


### PR DESCRIPTION
The current script for generating the xjc didn't check if the files already existed. This causes the script to run multiple times during a build, which slows down the build process. This tweak checks the location to see if it exists and skips generating the xjc again.

