### PR TITLE
[#238] Client Upload rewrite and validation

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -9,7 +9,7 @@ import hirs.attestationca.exceptions.UnexpectedServerException;
 import hirs.attestationca.service.SupplyChainValidationService;
 import hirs.data.persist.AppraisalStatus;
 import hirs.data.persist.BaseReferenceManifest;
-import hirs.data.persist.BiosMeasurements;
+import hirs.data.persist.EventLogMeasurements;
 import hirs.data.persist.Device;
 import hirs.data.persist.DeviceInfoReport;
 import hirs.data.persist.ReferenceManifest;
@@ -810,13 +810,13 @@ public abstract class AbstractAttestationCertificateAuthority
                     clientName);
             try {
                 // find previous version.  If it exists, delete it
-                support = BiosMeasurements.select(referenceManifestManager)
+                support = EventLogMeasurements.select(referenceManifestManager)
                         .byManufacturer(dv.getHw().getManufacturer())
                         .includeArchived().getRIM();
                 if (support != null) {
                     this.referenceManifestManager.delete(support);
                 }
-                support = new BiosMeasurements(fileName,
+                support = new EventLogMeasurements(fileName,
                         dv.getLivelog().toByteArray());
                 support.setPlatformManufacturer(dv.getHw().getManufacturer());
                 support.setPlatformModel(dv.getHw().getProductName());

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
@@ -7,7 +7,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 
 import hirs.data.persist.BaseReferenceManifest;
-import hirs.data.persist.BiosMeasurements;
+import hirs.data.persist.EventLogMeasurements;
 import hirs.data.persist.SupportReferenceManifest;
 import hirs.data.persist.TPMMeasurementRecord;
 import hirs.data.persist.PCRPolicy;
@@ -340,7 +340,7 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
                 .byManufacturer(manufacturer).getRIM();
         supportReferenceManifest = SupportReferenceManifest.select(referenceManifestManager)
                 .byManufacturer(manufacturer).getRIM();
-        measurement = BiosMeasurements.select(referenceManifestManager)
+        measurement = EventLogMeasurements.select(referenceManifestManager)
                 .byManufacturer(manufacturer).includeArchived().getRIM();
 
         String failedString = "";

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
@@ -247,14 +247,7 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
         if (policy.isFirmwareValidationEnabled()) {
             // may need to associated with device to pull the correct info
             // compare tpm quote with what is pulled from RIM associated file
-            try {
-                validations.add(validateFirmware(device, policy.getPcrPolicy()));
-            } catch (Exception ex) {
-                for (StackTraceElement ste : ex.getStackTrace()) {
-                    LOGGER.error(ste.toString());
-                }
-                LOGGER.error(ex.getMessage());
-            }
+            validations.add(validateFirmware(device, policy.getPcrPolicy()));
         }
 
         // Generate validation summary, save it, and return it.

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/reference-manifests.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/reference-manifests.jsp
@@ -60,7 +60,7 @@
                                 var html = '';
                                 html += rimDetailsLink(full.id);
                                 html += rimDownloadLink(full.id, pagePath);
-                                html += certificateDeleteLink(full.id, pagePath);
+                                html += rimDeleteLink(full.id, pagePath);
 
                                 return html;
                             }

--- a/HIRS_AttestationCAPortal/src/main/webapp/common/common.js
+++ b/HIRS_AttestationCAPortal/src/main/webapp/common/common.js
@@ -44,6 +44,17 @@ function handleDeleteRequest(id) {
 }
 
 /**
+* Handles user request to delete a cert. Prompts user to confirm.
+* Upon confirmation, submits the delete form which is required to make
+* a POST call to delete the reference integrity manifest.
+*/
+function handleRimDeleteRequest(id) {
+   if (confirm("Delete RIM?")) {
+       $('#deleteForm' + id).submit();
+   }
+}
+
+/**
 * Set the data tables using the columns definition, the ajax URL and
 * the ID of the table.
 * @param id of the data table
@@ -133,8 +144,24 @@ function rimDetailsLink(id){
 function certificateDeleteLink(id, pagePath){
     var icon = icons + '/ic_delete_black_24dp.png';
     var formURL = pagePath + "/delete";
-    
-    var html = '<a href="#!" onclick="handleDeleteRequest(\'' + id + '\')">' 
+
+    var html = '<a href="#!" onclick="handleDeleteRequest(\'' + id + '\')">'
+               + '<img src="' + icon + '" title="Delete"></a>'
+               + '<form id="deleteForm' + id + '" action="' + formURL + '" method="post">'
+               + '<input name="id" type="hidden" value="' + id + '"></form>';
+    return html;
+}
+
+/**
+* Create a RIM delete link for the specified ID
+* @param id of the RIM
+* @param pagePath path to the link
+*/
+function rimDeleteLink(id, pagePath){
+    var icon = icons + '/ic_delete_black_24dp.png';
+    var formURL = pagePath + "/delete";
+
+    var html = '<a href="#!" onclick="handleRimDeleteRequest(\'' + id + '\')">'
                + '<img src="' + icon + '" title="Delete"></a>'
                + '<form id="deleteForm' + id + '" action="' + formURL + '" method="post">'
                + '<input name="id" type="hidden" value="' + id + '"></form>';

--- a/HIRS_AttestationCAPortal/src/test/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageControllerTest.java
+++ b/HIRS_AttestationCAPortal/src/test/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageControllerTest.java
@@ -1,5 +1,6 @@
 package hirs.attestationca.portal.page.controllers;
 
+import hirs.data.persist.BaseReferenceManifest;
 import hirs.data.persist.ReferenceManifest;
 import hirs.persist.ReferenceManifestManager;
 import hirs.attestationca.portal.page.Page;
@@ -65,7 +66,7 @@ public class ReferenceManifestPageControllerTest extends PageControllerTest {
                 .andReturn();
 
         Set<ReferenceManifest> records
-                = referenceManifestManager.get(ReferenceManifest
+                = referenceManifestManager.get(BaseReferenceManifest
                         .select(referenceManifestManager).includeArchived());
         Assert.assertEquals(records.size(), 1);
 
@@ -135,7 +136,7 @@ public class ReferenceManifestPageControllerTest extends PageControllerTest {
                 "Pre-existing RIM found and unarchived (generated_good.swidtag): ");
 
         // verify the cert was actually stored
-        Set<ReferenceManifest> records = referenceManifestManager.get(ReferenceManifest.select(
+        Set<ReferenceManifest> records = referenceManifestManager.get(BaseReferenceManifest.select(
                 referenceManifestManager));
         Assert.assertEquals(records.size(), 1);
 
@@ -162,7 +163,8 @@ public class ReferenceManifestPageControllerTest extends PageControllerTest {
 
         // verify the cert was actually stored
         Set<ReferenceManifest> records
-                = referenceManifestManager.get(ReferenceManifest.select(referenceManifestManager));
+                = referenceManifestManager.get(BaseReferenceManifest
+                .select(referenceManifestManager));
         Assert.assertEquals(records.size(), 1);
 
         ReferenceManifest rim = records.iterator().next();
@@ -180,7 +182,7 @@ public class ReferenceManifestPageControllerTest extends PageControllerTest {
                 .andReturn();
 
         Set<ReferenceManifest> records
-                = referenceManifestManager.get(ReferenceManifest
+                = referenceManifestManager.get(BaseReferenceManifest
                         .select(referenceManifestManager).includeArchived());
         Assert.assertEquals(records.size(), 1);
 

--- a/HIRS_Utils/src/main/java/hirs/data/persist/BaseReferenceManifest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/BaseReferenceManifest.java
@@ -1,6 +1,8 @@
 package hirs.data.persist;
 
 import hirs.persist.DBReferenceManifestManager;
+import hirs.persist.ReferenceManifestManager;
+import hirs.persist.ReferenceManifestSelector;
 import hirs.utils.xjc.BaseElement;
 import hirs.utils.xjc.Directory;
 import hirs.utils.xjc.FilesystemItem;
@@ -75,6 +77,56 @@ public class BaseReferenceManifest extends ReferenceManifest {
     private String entityThumbprint = null;
     private String linkHref = null;
     private String linkRel = null;
+
+    /**
+     * This class enables the retrieval of BaseReferenceManifest by their attributes.
+     */
+    public static class Selector extends ReferenceManifestSelector<BaseReferenceManifest> {
+        /**
+         * Construct a new ReferenceManifestSelector that will use
+         * the given (@link ReferenceManifestManager}
+         * to retrieve one or may BaseReferenceManifest.
+         *
+         * @param referenceManifestManager the reference manifest manager to be used to retrieve
+         * reference manifests.
+         */
+        public Selector(final ReferenceManifestManager referenceManifestManager) {
+            super(referenceManifestManager, BaseReferenceManifest.class);
+        }
+
+        /**
+         * Specify the platform manufacturer that rims must have to be considered
+         * as matching.
+         * @param manufacturer string for the manufacturer
+         * @return this instance
+         */
+        public Selector byManufacturer(final String manufacturer) {
+            setFieldValue(PLATFORM_MANUFACTURER, manufacturer);
+            return this;
+        }
+
+        /**
+         * Specify the platform manufacturer id that rims must have to be considered
+         * as matching.
+         * @param manufacturerId string for the id of the manufacturer
+         * @return this instance
+         */
+        public Selector byManufacturerId(final String manufacturerId) {
+            setFieldValue(PLATFORM_MANUFACTURER_ID, manufacturerId);
+            return this;
+        }
+
+        /**
+         * Specify the platform model that rims must have to be considered
+         * as matching.
+         * @param model string for the model
+         * @return this instance
+         */
+        public Selector byModel(final String model) {
+            setFieldValue(PLATFORM_MODEL, model);
+            return this;
+        }
+    }
 
     /**
      * Support constructor for the RIM object.
@@ -160,6 +212,17 @@ public class BaseReferenceManifest extends ReferenceManifest {
      */
     protected BaseReferenceManifest() {
 
+    }
+
+    /**
+     * Get a Selector for use in retrieving ReferenceManifest.
+     *
+     * @param rimMan the ReferenceManifestManager to be used to retrieve
+     * persisted RIMs
+     * @return a Selector instance to use for retrieving RIMs
+     */
+    public static Selector select(final ReferenceManifestManager rimMan) {
+        return new Selector(rimMan);
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/BiosMeasurements.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/BiosMeasurements.java
@@ -19,31 +19,31 @@ import java.util.Collection;
 
 /**
  * Sub class that will just focus on PCR Values and Events.
+ * Similar to {@link hirs.data.persist.SupportReferenceManifest}
+ * however this is the live log from the client.
  */
 @Entity
-public class SupportReferenceManifest extends ReferenceManifest {
-    private static final Logger LOGGER = LogManager.getLogger(SupportReferenceManifest.class);
+public class BiosMeasurements extends ReferenceManifest {
+    private static final Logger LOGGER = LogManager.getLogger(BiosMeasurements.class);
 
     @Column
     @JsonIgnore
     private int pcrHash = 0;
-    @Column
-    private boolean updated = false;
 
     /**
      * This class enables the retrieval of SupportReferenceManifest by their attributes.
      */
-    public static class Selector extends ReferenceManifestSelector<SupportReferenceManifest> {
+    public static class Selector extends ReferenceManifestSelector<BiosMeasurements> {
         /**
-         * Construct a new ReferenceManifestSelector that will
-         * use the given (@link ReferenceManifestManager}
+         * Construct a new ReferenceManifestSelector that
+         * will use the given (@link ReferenceManifestManager}
          * to retrieve one or may SupportReferenceManifest.
          *
          * @param referenceManifestManager the reference manifest manager to be used to retrieve
          * reference manifests.
          */
         public Selector(final ReferenceManifestManager referenceManifestManager) {
-            super(referenceManifestManager, SupportReferenceManifest.class);
+            super(referenceManifestManager, BiosMeasurements.class, false);
         }
 
         /**
@@ -81,36 +81,35 @@ public class SupportReferenceManifest extends ReferenceManifest {
     }
 
     /**
-     * Main constructor for the RIM object. This takes in a byte array of a
-     * valid swidtag file and parses the information.
+     * Support constructor for the RIM object.
+     *
+     * @param rimBytes byte array representation of the RIM
+     * @throws java.io.IOException if unable to unmarshal the string
+     */
+    public BiosMeasurements(final byte[] rimBytes) throws IOException {
+        this("blank.measurement", rimBytes);
+    }
+    /**
+     * Support constructor for the RIM object.
      *
      * @param fileName - string representation of the uploaded file.
      * @param rimBytes byte array representation of the RIM
-     * @throws IOException if unable to unmarshal the string
+     * @throws java.io.IOException if unable to unmarshal the string
      */
-    public SupportReferenceManifest(final String fileName,
-                                    final byte[] rimBytes) throws IOException {
+    public BiosMeasurements(final String fileName,
+                            final byte[] rimBytes
+                            ) throws IOException {
         super(rimBytes);
         this.setFileName(fileName);
-        this.setRimType(SUPPORT_RIM);
+        this.setRimType(MEASUREMENT_RIM);
+        this.archive("Measurement event log");
         this.pcrHash = 0;
-    }
-
-    /**
-     * Main constructor for the RIM object. This takes in a byte array of a
-     * valid swidtag file and parses the information.
-     *
-     * @param rimBytes byte array representation of the RIM
-     * @throws IOException if unable to unmarshal the string
-     */
-    public SupportReferenceManifest(final byte[] rimBytes) throws IOException {
-        this("blank.rimel", rimBytes);
     }
 
     /**
      * Default constructor necessary for Hibernate.
      */
-    protected SupportReferenceManifest() {
+    protected BiosMeasurements() {
         super();
         this.pcrHash = 0;
     }
@@ -182,21 +181,5 @@ public class SupportReferenceManifest extends ReferenceManifest {
      */
     public void setPcrHash(final int pcrHash) {
         this.pcrHash = pcrHash;
-    }
-
-    /**
-     * Indicates if the support rim has updated information from the base.
-     * @return flag indicating that it is up to date
-     */
-    public boolean isUpdated() {
-        return updated;
-    }
-
-    /**
-     * Setter for the support RIM flag status.
-     * @param updated updated flag status
-     */
-    public void setUpdated(final boolean updated) {
-        this.updated = updated;
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/EventLogMeasurements.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/EventLogMeasurements.java
@@ -23,8 +23,8 @@ import java.util.Collection;
  * however this is the live log from the client.
  */
 @Entity
-public class BiosMeasurements extends ReferenceManifest {
-    private static final Logger LOGGER = LogManager.getLogger(BiosMeasurements.class);
+public class EventLogMeasurements extends ReferenceManifest {
+    private static final Logger LOGGER = LogManager.getLogger(EventLogMeasurements.class);
 
     @Column
     @JsonIgnore
@@ -33,7 +33,7 @@ public class BiosMeasurements extends ReferenceManifest {
     /**
      * This class enables the retrieval of SupportReferenceManifest by their attributes.
      */
-    public static class Selector extends ReferenceManifestSelector<BiosMeasurements> {
+    public static class Selector extends ReferenceManifestSelector<EventLogMeasurements> {
         /**
          * Construct a new ReferenceManifestSelector that
          * will use the given (@link ReferenceManifestManager}
@@ -43,7 +43,7 @@ public class BiosMeasurements extends ReferenceManifest {
          * reference manifests.
          */
         public Selector(final ReferenceManifestManager referenceManifestManager) {
-            super(referenceManifestManager, BiosMeasurements.class, false);
+            super(referenceManifestManager, EventLogMeasurements.class, false);
         }
 
         /**
@@ -86,7 +86,7 @@ public class BiosMeasurements extends ReferenceManifest {
      * @param rimBytes byte array representation of the RIM
      * @throws java.io.IOException if unable to unmarshal the string
      */
-    public BiosMeasurements(final byte[] rimBytes) throws IOException {
+    public EventLogMeasurements(final byte[] rimBytes) throws IOException {
         this("blank.measurement", rimBytes);
     }
     /**
@@ -96,8 +96,8 @@ public class BiosMeasurements extends ReferenceManifest {
      * @param rimBytes byte array representation of the RIM
      * @throws java.io.IOException if unable to unmarshal the string
      */
-    public BiosMeasurements(final String fileName,
-                            final byte[] rimBytes
+    public EventLogMeasurements(final String fileName,
+                                final byte[] rimBytes
                             ) throws IOException {
         super(rimBytes);
         this.setFileName(fileName);
@@ -109,7 +109,7 @@ public class BiosMeasurements extends ReferenceManifest {
     /**
      * Default constructor necessary for Hibernate.
      */
-    protected BiosMeasurements() {
+    protected EventLogMeasurements() {
         super();
         this.pcrHash = 0;
     }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/ReferenceManifest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/ReferenceManifest.java
@@ -9,8 +9,6 @@ import javax.persistence.Entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
-import hirs.persist.ReferenceManifestManager;
-import hirs.persist.ReferenceManifestSelector;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.annotations.Type;
@@ -39,6 +37,10 @@ public abstract class ReferenceManifest extends ArchivableEntity {
      * String for display of a Support RIM.
      */
     public static final String SUPPORT_RIM = "Support";
+    /**
+     * String for display of a Support RIM.
+     */
+    public static final String MEASUREMENT_RIM = "Measurement";
 
     /**
      * String for the xml schema ios standard.
@@ -59,26 +61,6 @@ public abstract class ReferenceManifest extends ArchivableEntity {
     public static final String SCHEMA_PACKAGE = "hirs.utils.xjc";
 
     private static final Logger LOGGER = LogManager.getLogger(ReferenceManifest.class);
-
-    /**
-     * This class enables the retrieval of PlatformCredentials by their
-     * attributes.
-     */
-    public static class Selector
-            extends ReferenceManifestSelector<ReferenceManifest> {
-
-        /**
-         * Construct a new ReferenceManifestSelector that will use the given
-         * {@link ReferenceManifestManager} to retrieve one or many Reference
-         * Integrity Manifest.
-         *
-         * @param referenceManifestManager the RIM manager to be used to
-         * retrieve RIMs
-         */
-        public Selector(final ReferenceManifestManager referenceManifestManager) {
-            super(referenceManifestManager);
-        }
-    }
 
     /**
      * Holds the name of the 'rimHash' field.
@@ -107,17 +89,6 @@ public abstract class ReferenceManifest extends ArchivableEntity {
     @Type(type = "uuid-char")
     @Column
     private UUID associatedRim;
-
-    /**
-     * Get a Selector for use in retrieving ReferenceManifest.
-     *
-     * @param rimMan the ReferenceManifestManager to be used to retrieve
-     * persisted RIMs
-     * @return a ReferenceManifest.Selector instance to use for retrieving RIMs
-     */
-    public static Selector select(final ReferenceManifestManager rimMan) {
-        return new Selector(rimMan);
-    }
 
     /**
      * Default constructor necessary for Hibernate.

--- a/HIRS_Utils/src/main/java/hirs/persist/DBReferenceManifestManager.java
+++ b/HIRS_Utils/src/main/java/hirs/persist/DBReferenceManifestManager.java
@@ -86,10 +86,11 @@ public class DBReferenceManifestManager extends DBManager<ReferenceManifest>
      */
     @Override
     @SuppressWarnings("unchecked")
-    public Set<ReferenceManifest> get(final ReferenceManifestSelector referenceManifestSelector) {
+    public <T extends  ReferenceManifest> Set<T> get(
+            final ReferenceManifestSelector referenceManifestSelector) {
         LOGGER.info("Getting the full set of Reference Manifest files.");
         return new HashSet<>(
-                (List<ReferenceManifest>) getWithCriteria(
+                (List<T>) getWithCriteria(
                         referenceManifestSelector.getReferenceManifestClass(),
                         Collections.singleton(referenceManifestSelector.getCriterion())
                 )

--- a/HIRS_Utils/src/main/java/hirs/persist/ReferenceManifestManager.java
+++ b/HIRS_Utils/src/main/java/hirs/persist/ReferenceManifestManager.java
@@ -28,10 +28,11 @@ public interface ReferenceManifestManager extends OrderedListQuerier<ReferenceMa
     /**
      * Retrieve RIMs according to the given {@link ReferenceManifestSelector}.
      *
+     * @param <T> the type of reference manifest that will be retrieved
      *  @param referenceManifestSelector a {@link ReferenceManifestSelector} to use for querying
      * @return a Set of matching RIMs, which may be empty
      */
-    Set<ReferenceManifest> get(ReferenceManifestSelector referenceManifestSelector);
+    <T extends ReferenceManifest> Set<T> get(ReferenceManifestSelector referenceManifestSelector);
 
     /**
      * Delete the given RIM.

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent.java
@@ -55,6 +55,7 @@ public class TpmPcrEvent {
     private static final int INDENT_3 = 3;
     /**
      * Log format. SHA1=1, Crytpo agile=2.
+     * this can be refactored out
      */
     private int logFormat = -1;
     /**
@@ -102,6 +103,7 @@ public class TpmPcrEvent {
      */
     private byte[] eventDataSha256hash;
     private EvPostCode evPostCode;
+    private int eventNumber;
 
     /**
      * Constructor.
@@ -246,6 +248,22 @@ public class TpmPcrEvent {
      */
     public byte[] getEvent() {
         return java.util.Arrays.copyOf(event, event.length);
+    }
+
+    /**
+     * Getter for the event number for this event.
+     * @return the # for this event
+     */
+    public int getEventNumber() {
+        return eventNumber;
+    }
+
+    /**
+     * Setter for the event number.
+     * @param eventNumber position in the list
+     */
+    public final void setEventNumber(final int eventNumber) {
+        this.eventNumber = eventNumber;
     }
 
     /**
@@ -450,6 +468,7 @@ public class TpmPcrEvent {
     public String processEvent(final byte[] event, final byte[] eventContent, final int eventNumber)
             throws CertificateException, NoSuchAlgorithmException, IOException {
         int eventID = (int) eventType;
+        this.eventNumber = eventNumber;
         description += "Event# " + eventNumber + ": ";
         description += "Index PCR[" + getPcrIndex() + "]\n";
         description += "Event Type: 0x" + Long.toHexString(eventType) + " " + eventString(eventID);
@@ -684,6 +703,19 @@ public class TpmPcrEvent {
             }
         }
         return result;
+    }
+
+    /**
+     * This method takes in an event and compares the hashes to verify that they match.
+     * @param tpmPcrEvent an event to match.
+     * @return true if the event # matches and the hash is correct.
+     */
+    public boolean eventCompare(final TpmPcrEvent tpmPcrEvent) {
+        if (tpmPcrEvent.getPcrIndex() != this.getPcrIndex()) {
+            return false;
+        }
+
+        return Arrays.equals(this.digest, tpmPcrEvent.getEventDigest());
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent1.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent1.java
@@ -31,14 +31,14 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
     /**
      * Constructor.
      *
-     * @param is ByteArrayInputStream holding the TCG Log event.
+     * @param is          ByteArrayInputStream holding the TCG Log event.
      * @param eventNumber event position within the event log.
-     * @throws IOException if an error occurs in parsing the event.
+     * @throws IOException              if an error occurs in parsing the event.
      * @throws NoSuchAlgorithmException if an undefined algorithm is encountered.
-     * @throws CertificateException If a certificate within an event can't be processed.
+     * @throws CertificateException     If a certificate within an event can't be processed.
      */
     public TpmPcrEvent1(final ByteArrayInputStream is, final int eventNumber)
-                    throws IOException, CertificateException, NoSuchAlgorithmException {
+            throws IOException, CertificateException, NoSuchAlgorithmException {
         super(is);
         setDigestLength(EvConstants.SHA1_LENGTH);
         setLogFormat(1);
@@ -63,22 +63,22 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
             eventContent = new byte[eventSize];
             is.read(eventContent);
             setEventContent(eventContent);
-        // copy entire event into a byte array for processing
-        int eventLength = rawIndex.length + rawType.length + eventDigest.length
-                                 + rawEventSize.length;
-        int offset = 0;
-        event = new byte[eventLength];
-        System.arraycopy(rawIndex, 0, event, offset, rawIndex.length);
-        offset += rawIndex.length;
-        System.arraycopy(rawType, 0, event, offset, rawType.length);
-        offset += rawType.length;
-        System.arraycopy(eventDigest, 0, event, offset, eventDigest.length);
-        offset += eventDigest.length;
-        System.arraycopy(rawEventSize, 0, event, offset, rawEventSize.length);
-        offset += rawEventSize.length;
-        setEventData(event);
-        //System.arraycopy(eventContent, 0, event, offset, eventContent.length);
-        this.processEvent(event, eventContent, eventNumber);
+            // copy entire event into a byte array for processing
+            int eventLength = rawIndex.length + rawType.length + eventDigest.length
+                    + rawEventSize.length;
+            int offset = 0;
+            event = new byte[eventLength];
+            System.arraycopy(rawIndex, 0, event, offset, rawIndex.length);
+            offset += rawIndex.length;
+            System.arraycopy(rawType, 0, event, offset, rawType.length);
+            offset += rawType.length;
+            System.arraycopy(eventDigest, 0, event, offset, eventDigest.length);
+            offset += eventDigest.length;
+            System.arraycopy(rawEventSize, 0, event, offset, rawEventSize.length);
+            offset += rawEventSize.length;
+            setEventData(event);
+            //System.arraycopy(eventContent, 0, event, offset, eventContent.length);
+            this.processEvent(event, eventContent, eventNumber);
         }
- }
+    }
 }

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent2.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent2.java
@@ -66,14 +66,14 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
     /**
      * Constructor.
      *
-     * @param is ByteArrayInputStream holding the TCG Log event
+     * @param is          ByteArrayInputStream holding the TCG Log event
      * @param eventNumber event position within the event log.
-     * @throws IOException if an error occurs in parsing the event
+     * @throws IOException              if an error occurs in parsing the event
      * @throws NoSuchAlgorithmException if an undefined algorithm is encountered.
-     * @throws CertificateException If a certificate within an event can't be processed.
+     * @throws CertificateException     If a certificate within an event can't be processed.
      */
     public TpmPcrEvent2(final ByteArrayInputStream is, final int eventNumber)
-                    throws IOException, CertificateException, NoSuchAlgorithmException {
+            throws IOException, CertificateException, NoSuchAlgorithmException {
         super(is);
         setDigestLength(EvConstants.SHA256_LENGTH);
         setLogFormat(2);
@@ -110,9 +110,9 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
             is.read(eventContent);
             setEventContent(eventContent);
             int eventLength = rawIndex.length + rawType.length + eventDigest.length
-                                                  + rawEventSize.length;
+                    + rawEventSize.length;
             int offset = 0;
-            for (TcgTpmtHa hash:hashlist) {
+            for (TcgTpmtHa hash : hashlist) {
                 eventLength += hash.getBuffer().length;
             }
             event = new byte[eventLength];
@@ -128,13 +128,5 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
             setEventData(event);
             this.processEvent(event, eventContent, eventNumber);
         }
-    }
-
-    /**
-     * Returns a list of digests within this event.
-     * @return a list of digests.
-     */
-    public ArrayList<TcgTpmtHa> getHashList() {
-        return hashlist;
     }
 }


### PR DESCRIPTION
This commit includes a completed rewrite of the ReferenceManifestSelector framework.  Like the previous rewrite, it was easier and made more sense to create addition classes and that are specific to a type of RIM (base, support, measurement) for referencing in the DB.  Once this was rewritten the code was modified to validate the measurement against the support rim.

This PR is part 2 of #238 