### PR TITLE
Bug Fix for Base RIM Details Page

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -773,6 +773,8 @@ public abstract class AbstractAttestationCertificateAuthority
                     this.referenceManifestManager.save(dbBaseRim);
                 } else {
                     LOG.info("Client provided Base RIM already loaded in database.");
+                    dbBaseRim.restore();
+                    dbBaseRim.resetCreateTime();
                 }
 
                 tagId = dbBaseRim.getTagId();
@@ -798,7 +800,7 @@ public abstract class AbstractAttestationCertificateAuthority
                     support.setTagId(tagId);
                     this.referenceManifestManager.save(support);
                 } else {
-                    LOG.error("Client provided Support RIM already loaded in database.");
+                    LOG.info("Client provided Support RIM already loaded in database.");
                     if (dbBaseRim != null) {
                         support.setPlatformManufacturer(dbBaseRim.getPlatformManufacturer());
                         support.setPlatformModel(dbBaseRim.getPlatformModel());
@@ -807,6 +809,8 @@ public abstract class AbstractAttestationCertificateAuthority
                         support.setTagId(dbBaseRim.getTagId());
                     }
 
+                    support.restore();
+                    support.resetCreateTime();
                     this.referenceManifestManager.update(support);
                 }
             } catch (IOException ioEx) {

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -102,6 +102,7 @@ public class ReferenceManifestDetailsPageController
                 LOGGER.error(uuidError, iaEx);
             } catch (Exception ioEx) {
                 LOGGER.error(ioEx);
+                LOGGER.trace(ioEx);
             }
             if (data.isEmpty()) {
                 String notFoundMessage = "Unable to find RIM with ID: " + params.getId();
@@ -236,6 +237,10 @@ public class ReferenceManifestDetailsPageController
                 baseRim.setAssociatedRim(support.getId());
                 logProcessor = new TCGEventLog(support.getRimBytes());
             }
+        } else {
+            support = SupportReferenceManifest.select(referenceManifestManager)
+                    .byEntityId(baseRim.getAssociatedRim()).getRIM();
+            logProcessor = new TCGEventLog(support.getRimBytes());
         }
         // going to have to pull the filename and grab that from the DB
         // to get the id to make the link

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -74,7 +74,15 @@ int provision() {
     const std::string& swid_file = props.get("tcg.swidtag.file", "");
     try {
         dv.set_logfile(hirs::file_utils::fileToString(rim_file));
+    } catch (HirsRuntimeException& hirsRuntimeException) {
+        logger.error(hirsRuntimeException.what());
+    }
+    try {
         dv.set_swidfile(hirs::file_utils::fileToString(swid_file));
+    } catch (HirsRuntimeException& hirsRuntimeException) {
+        logger.error(hirsRuntimeException.what());
+    }
+    try {
         dv.set_livelog(hirs::file_utils::fileToString(
         "/sys/kernel/security/tpm0/binary_bios_measurements"));
     } catch (HirsRuntimeException& hirsRuntimeException) {


### PR DESCRIPTION
If the Support RIM was uploaded, separately, first, then the Base; the base RIM details page would display a linked Support RIM but no expected PCR values.

To replicate this behavior on master, upload a support rim.  Then separately upload a Base RIM.