### PR TITLE
Firmware Event Numbering Fix

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -315,9 +315,10 @@ public class ReferenceManifestDetailsPageController
                     LOGGER.error("Failed to update Support RIM", ex);
                 }
             }
-            measurements = EventLogMeasurements.select(referenceManifestManager)
-                    .byManufacturer(support.getPlatformManufacturer()).getRIM();
         }
+
+        measurements = EventLogMeasurements.select(referenceManifestManager)
+                .byManufacturer(support.getPlatformManufacturer()).getRIM();
 
         data.put("baseRim", support.getTagId());
         data.put("associatedRim", support.getAssociatedRim());

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
@@ -200,11 +200,11 @@
                                     <c:choose>
                                         <c:when test="${event.isError()}">
                                             <tr style="background: tomato">
-                                            </c:when>
-                                            <c:otherwise>
+                                        </c:when>
+                                        <c:otherwise>
                                             <tr>
-                                            </c:otherwise>
-                                        </c:choose>
+                                        </c:otherwise>
+                                    </c:choose>
                                         <td style="width: 75px">${count}</td>
                                         <td class="pcrCell">PCR${event.getPcrIndex()}</td>
                                         <td>${event.getEventTypeStr()}</td>
@@ -243,7 +243,7 @@
                                     <div class="event-element">
                                         <div class="event-data">
                                             <div class="data-label">Event#:</div>
-                                            <div class="data-value">${sEvent.getEventNumber()}</div>
+                                            <div class="data-value">${sEvent.getEventNumber()+1}</div>
                                         </div>           
                                         <div class="event-data">
                                             <div class="data-label">PCR Index:</div>
@@ -268,7 +268,7 @@
                                     <div class="event-element">
                                         <div class="event-data">
                                             <div class="data-label">Event#:</div>
-                                            <div class="data-value">${lEvent.getEventNumber()}</div>
+                                            <div class="data-value">${lEvent.getEventNumber()+1}</div>
                                         </div>           
                                         <div class="event-data">
                                             <div class="data-label">PCR Index:</div>


### PR DESCRIPTION
Updated the printing of the event number for the failed events.  This is to match them with the event number on the support rim page.  Support rim page starts at 1 but the method used on the failure page starts at 0.  Also while investigating this issue, I noted that the coloring of the failure event disappears after the first viewing of that page.  This was fixed.  The conditions to check for an error were being ignored after the first load.