### PR TITLE
[#336] Script to download ACAPortal validation reports

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
@@ -193,7 +193,8 @@ public class ValidationReportsPageController extends PageController<NoPageParams
                     }
                     break;
                 case "createTimes":
-                    if (!parameterValue.equals(UNDEFINED)) {
+                    if (!parameterValue.equals(UNDEFINED)
+                        && !parameterValue.isEmpty()) {
                         String[] timestamps = parameterValue.split(",");
                         for (String timestamp : timestamps) {
                             createTimes.add(LocalDateTime.parse(timestamp,
@@ -202,7 +203,8 @@ public class ValidationReportsPageController extends PageController<NoPageParams
                     }
                     break;
                 case "deviceNames":
-                    if (!parameterValue.equals(UNDEFINED)) {
+                    if (!parameterValue.equals(UNDEFINED)
+                        && !parameterValue.isEmpty()) {
                         deviceNames = parameterValue.split(",");
                     }
                     break;
@@ -240,8 +242,10 @@ public class ValidationReportsPageController extends PageController<NoPageParams
                     reportData.deleteCharAt(reportData.length() - 1);
                     reportData.append("\n,,,,,");
                 }
+                if (reportData.lastIndexOf(",") > 4) {
+                    reportData.delete(reportData.lastIndexOf(",") - 4, reportData.length());
+                }
             }
-            reportData.delete(reportData.lastIndexOf(",") - 4, reportData.length());
         }
         bufferedWriter.append(columnHeaders + "\n");
         bufferedWriter.append(reportData.toString() + "\n");

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
@@ -42,9 +42,11 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Controller for the Validation Reports page.
@@ -60,7 +62,7 @@ public class ValidationReportsPageController extends PageController<NoPageParams
     private static String columnHeaders = "Verified Manufacturer,"
             + "Model,SN,Verification Date,Device Status,"
             + "Component name,Component manufacturer,Component model,"
-            + "Component SN,Component status";
+            + "Component SN,Issuer,Component status";
     private static final String DEFAULT_COMPANY = "AllDevices";
     private static final String UNDEFINED = "undefined";
     private static final Logger LOGGER = getLogger(ValidationReportsPageController.class);
@@ -261,13 +263,40 @@ public class ValidationReportsPageController extends PageController<NoPageParams
      */
     private ArrayList<ArrayList<String>> parseComponents(final PlatformCredential pc) {
         ArrayList<ArrayList<String>> parsedComponents = new ArrayList<ArrayList<String>>();
+        ArrayList<ArrayList<Object>> chainComponents = new ArrayList<>();
         if (pc.getComponentIdentifiers() != null
                 && pc.getComponentIdentifiers().size() > 0) {
             LOGGER.info("Component failures: " + pc.getComponentFailures());
+            // get all the certificates associated with the platform serial
+            List<PlatformCredential> chainCertificates = PlatformCredential
+                    .select(certificateManager)
+                    .byBoardSerialNumber(pc.getPlatformSerial())
+                    .getCertificates().stream().collect(Collectors.toList());
+            // combine all components in each certificate
+            for (ComponentIdentifier ci : pc.getComponentIdentifiers()) {
+                ArrayList<Object> issuerAndComponent = new ArrayList<Object>();
+                issuerAndComponent.add(pc.getIssuer());
+                issuerAndComponent.add(ci);
+                chainComponents.add(issuerAndComponent);
+            }
+
+            for (PlatformCredential delta : chainCertificates) {
+                if (!delta.isBase()) {
+                    for (ComponentIdentifier ci : delta.getComponentIdentifiers()) {
+                        ArrayList<Object> issuerAndComponent = new ArrayList<Object>();
+                        issuerAndComponent.add(delta.getIssuer());
+                        issuerAndComponent.add(ci);
+                        chainComponents.add(issuerAndComponent);
+                    }
+                }
+            }
             ArrayList<String> componentFailures =
                     new ArrayList<String>(Arrays.asList(pc.getComponentFailures().split(";")));
-            for (ComponentIdentifier ci : pc.getComponentIdentifiers()) {
+            for (ArrayList<Object> issuerAndComponent : chainComponents) {
                 ArrayList<String> componentData = new ArrayList<String>();
+                String issuer = (String) issuerAndComponent.get(0);
+                issuer = issuer.replaceAll(",", " ");
+                ComponentIdentifier ci = (ComponentIdentifier) issuerAndComponent.get(1);
                 if (ci instanceof ComponentIdentifierV2) {
                     componentData.add(((ComponentIdentifierV2) ci).getComponentClass().toString());
                 } else {
@@ -276,6 +305,7 @@ public class ValidationReportsPageController extends PageController<NoPageParams
                 componentData.add(ci.getComponentManufacturer().getString());
                 componentData.add(ci.getComponentModel().getString());
                 componentData.add(ci.getComponentSerial().getString());
+                componentData.add(issuer);
                 //Failing components are identified by manufacturer + model
                 if (componentFailures.contains(componentData.get(1) + componentData.get(2))) {
                     componentData.add("Fail");

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
@@ -40,7 +40,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.UUID;
@@ -264,9 +263,11 @@ public class ValidationReportsPageController extends PageController<NoPageParams
     private ArrayList<ArrayList<String>> parseComponents(final PlatformCredential pc) {
         ArrayList<ArrayList<String>> parsedComponents = new ArrayList<ArrayList<String>>();
         ArrayList<ArrayList<Object>> chainComponents = new ArrayList<>();
+
+        StringBuilder componentFailureString = new StringBuilder();
         if (pc.getComponentIdentifiers() != null
                 && pc.getComponentIdentifiers().size() > 0) {
-            LOGGER.info("Component failures: " + pc.getComponentFailures());
+            componentFailureString.append(pc.getComponentFailures());
             // get all the certificates associated with the platform serial
             List<PlatformCredential> chainCertificates = PlatformCredential
                     .select(certificateManager)
@@ -280,18 +281,18 @@ public class ValidationReportsPageController extends PageController<NoPageParams
                 chainComponents.add(issuerAndComponent);
             }
 
-            for (PlatformCredential delta : chainCertificates) {
-                if (!delta.isBase()) {
-                    for (ComponentIdentifier ci : delta.getComponentIdentifiers()) {
+            for (PlatformCredential cert : chainCertificates) {
+                componentFailureString.append(cert.getComponentFailures());
+                if (!cert.isBase()) {
+                    for (ComponentIdentifier ci : cert.getComponentIdentifiers()) {
                         ArrayList<Object> issuerAndComponent = new ArrayList<Object>();
-                        issuerAndComponent.add(delta.getIssuer());
+                        issuerAndComponent.add(cert.getIssuer());
                         issuerAndComponent.add(ci);
                         chainComponents.add(issuerAndComponent);
                     }
                 }
             }
-            ArrayList<String> componentFailures =
-                    new ArrayList<String>(Arrays.asList(pc.getComponentFailures().split(";")));
+            LOGGER.info("Component failures: " + componentFailureString.toString());
             for (ArrayList<Object> issuerAndComponent : chainComponents) {
                 ArrayList<String> componentData = new ArrayList<String>();
                 String issuer = (String) issuerAndComponent.get(0);
@@ -306,8 +307,8 @@ public class ValidationReportsPageController extends PageController<NoPageParams
                 componentData.add(ci.getComponentModel().getString());
                 componentData.add(ci.getComponentSerial().getString());
                 componentData.add(issuer);
-                //Failing components are identified by manufacturer + model
-                if (componentFailures.contains(componentData.get(1) + componentData.get(2))) {
+                //Failing components are identified by hashcode
+                if (componentFailureString.toString().contains(String.valueOf(ci.hashCode()))) {
                     componentData.add("Fail");
                 } else {
                     componentData.add("Pass");

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ValidationReportsPageController.java
@@ -35,6 +35,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -138,6 +139,7 @@ public class ValidationReportsPageController extends PageController<NoPageParams
      * @param response object
      * @throws IOException thrown by BufferedWriter object
      */
+    @SuppressWarnings("checkstyle:magicnumber")
     @RequestMapping(value = "download", method = RequestMethod.POST)
     public void download(final HttpServletRequest request,
                          final HttpServletResponse response) throws IOException {
@@ -211,7 +213,7 @@ public class ValidationReportsPageController extends PageController<NoPageParams
         response.setHeader("Content-Disposition",
                 "attachment;filename=validation_report.csv");
         BufferedWriter bufferedWriter = new BufferedWriter(
-                new OutputStreamWriter(response.getOutputStream(), "UTF-8"));
+                new OutputStreamWriter(response.getOutputStream(), StandardCharsets.UTF_8));
         StringBuilder reportData = new StringBuilder();
         bufferedWriter.append("Company: " + company + "\n");
         bufferedWriter.append("Contract number: " + contractNumber + "\n");
@@ -237,8 +239,8 @@ public class ValidationReportsPageController extends PageController<NoPageParams
                     reportData.deleteCharAt(reportData.length() - 1);
                     reportData.append("\n,,,,,");
                 }
-                reportData.delete(reportData.lastIndexOf("\n"), reportData.length());
             }
+            reportData.delete(reportData.lastIndexOf(",") - 4, reportData.length());
         }
         bufferedWriter.append(columnHeaders + "\n");
         bufferedWriter.append(reportData.toString() + "\n");

--- a/scripts/download_validation_reports.sh
+++ b/scripts/download_validation_reports.sh
@@ -3,8 +3,15 @@
 #User input parameters:
 #$1 filter start date 'yyyy-mm-dd'
 #$2 filter end date 'yyyy-mm-dd'
+#$3 ACA address, default is localhost if not given
 
-endpoint="https://localhost:8443/HIRS_AttestationCAPortal/portal/validation-reports"
+if [ -z "$3" ]
+ then
+  endpoint="https://localhost:8443/HIRS_AttestationCAPortal/portal/validation-reports"
+ else
+  endpoint="https://$3:8443/HIRS_AttestationCAPortal/portal/validation-reports"
+fi
+echo "$endpoint"
 content=$(curl --insecure $endpoint/list)
 rawTimes=$(jq -r '.data | map(.createTime | tostring) | join(",")' <<< "$content")
 createTimes=""

--- a/scripts/download_validation_reports.sh
+++ b/scripts/download_validation_reports.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#User input parameters:
+#$1 filter start date 'yyyy-mm-dd'
+#$2 filter end date 'yyyy-mm-dd'
+
+endpoint="https://localhost:8443/HIRS_AttestationCAPortal/portal/validation-reports"
+content=$(curl --insecure $endpoint/list)
+rawTimes=$(jq -r '.data | map(.createTime | tostring) | join(",")' <<< "$content")
+createTimes=""
+for i in ${rawTimes//,/ }
+do
+	createTimes+="$(date -u +"%Y-%m-%d %H:%M:%S" -d @"$(($i/1000))"),"
+done
+deviceNames=$(jq -r '.data | map(.device.name) | join(",")' <<< "$content")
+echo "Create times: $createTimes"
+echo "Device names: $deviceNames"
+curl --data "dateStart=$1&dateEnd=$2&createTimes=$createTimes&deviceNames=$deviceNames" --insecure $endpoint/download
+


### PR DESCRIPTION
This pull request creates a command line script to invoke the download function on the validation report page on the ACA Portal.  Execution is summarized as:
1. get user parameters for filter start and end times in the format yyyy-mm-dd
2. pull data from the validation-reports/list end point
3. parse data for create time of each report and corresponding device name
4. pass user parameters, create times, and device names to validation-reports/download endpoint
5. CSV output is printed to standard output

Closes #336 