### PR TITLE
Serial Number Display Fix

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/util/CertificateStringMapBuilder.java
@@ -53,10 +53,10 @@ public final class CertificateStringMapBuilder {
         if (certificate != null) {
             data.put("issuer", certificate.getIssuer());
             //Serial number in hex value
-            data.put("serialNumber", Long.toHexString(certificate.getSerialNumber().longValue()));
+            data.put("serialNumber", Hex.toHexString(certificate.getSerialNumber().toByteArray()));
             if (!certificate.getAuthoritySerialNumber().equals(BigInteger.ZERO)) {
-                data.put("authSerialNumber", Long.toHexString(certificate
-                        .getAuthoritySerialNumber().longValue()));
+                data.put("authSerialNumber", Hex.toHexString(certificate
+                        .getAuthoritySerialNumber().toByteArray()));
             }
             if (certificate.getId() != null) {
                 data.put("certificateId", certificate.getId().toString());


### PR DESCRIPTION
Updated the code for authority serial number and serial number for the general info for any certificate to no longer use the getLong method of the Big Integer object.  This truncated the value.  Instead, the new code uses the Hex.toHexString method from bouncy castle.