### PR TITLE
[#343] Event digest update (UI)

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -790,7 +790,6 @@ public abstract class AbstractAttestationCertificateAuthority
          * 3. Update the support rim with swid tag information
          */
 
-
         if (dv.getLogfileCount() > 0) {
             for (ByteString logFile : dv.getLogfileList()) {
                 try {
@@ -805,6 +804,9 @@ public abstract class AbstractAttestationCertificateAuthority
                                 String.format("%s.rimel",
                                         defaultClientName),
                                 logFile.toByteArray());
+                        // this is a validity check
+                        new TCGEventLog(support.getRimBytes());
+                        // no issues, continue
                         support.setPlatformManufacturer(dv.getHw().getManufacturer());
                         support.setPlatformModel(dv.getHw().getProductName());
                         support.setFileName(String.format("%s_[%s].rimel", defaultClientName,
@@ -821,6 +823,9 @@ public abstract class AbstractAttestationCertificateAuthority
                     }
                 } catch (IOException ioEx) {
                     LOG.error(ioEx);
+                } catch (Exception ex) {
+                    LOG.error(String.format("Failed to load support rim: ", messageDigest.digest(
+                            logFile.toByteArray()))));
                 }
             }
         } else {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -825,7 +825,7 @@ public abstract class AbstractAttestationCertificateAuthority
                     LOG.error(ioEx);
                 } catch (Exception ex) {
                     LOG.error(String.format("Failed to load support rim: ", messageDigest.digest(
-                            logFile.toByteArray()))));
+                            logFile.toByteArray())));
                 }
             }
         } else {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -783,13 +783,6 @@ public abstract class AbstractAttestationCertificateAuthority
         Pattern pattern = Pattern.compile("([^\\s]+(\\.(?i)(rimpcr|rimel|bin|log))$)");
         Matcher matcher;
         MessageDigest messageDigest =  MessageDigest.getInstance("SHA-256");
-        /**
-         * We need to do a series of things when getting swid/log files from client
-         * 1. Store what is sent if, it doesn't exist
-         *       and if it does exist, update if needed
-         * 2. take the file name from the swid file and update the support RIMs
-         * 3. Update the support rim with swid tag information
-         */
 
         if (dv.getLogfileCount() > 0) {
             for (ByteString logFile : dv.getLogfileList()) {
@@ -957,14 +950,6 @@ public abstract class AbstractAttestationCertificateAuthority
                 .select(referenceManifestManager).byManufacturer(manufacturer).getRIMs();
 
         for (SupportReferenceManifest dbSupport : dbSupportRims) {
-            /**
-             * Because the log file we get isn't promised to be the baseline support rim.
-             * If it is a patch of supplemental we have to check that the baseline
-             * has been done
-             * and those entries can't become the baseline
-             *
-             * However, we don't know which log file is what until we link them to a swidtag
-             */
             if (dbSupport.getPlatformModel().equals(model)) {
                 ReferenceDigestRecord dbObj = new ReferenceDigestRecord(dbSupport,
                         manufacturer, model);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/service/SupplyChainValidationServiceImpl.java
@@ -9,6 +9,8 @@ import hirs.data.persist.Device;
 import hirs.data.persist.DeviceInfoReport;
 import hirs.data.persist.EventLogMeasurements;
 import hirs.data.persist.PCRPolicy;
+import hirs.data.persist.ReferenceDigestRecord;
+import hirs.data.persist.ReferenceDigestValue;
 import hirs.data.persist.ReferenceManifest;
 import hirs.data.persist.SupplyChainPolicy;
 import hirs.data.persist.SupplyChainValidation;
@@ -26,6 +28,8 @@ import hirs.persist.CrudManager;
 import hirs.persist.DBManagerException;
 import hirs.persist.PersistenceConfiguration;
 import hirs.persist.PolicyManager;
+import hirs.persist.ReferenceDigestManager;
+import hirs.persist.ReferenceEventManager;
 import hirs.persist.ReferenceManifestManager;
 import hirs.tpm.eventlog.TCGEventLog;
 import hirs.tpm.eventlog.TpmPcrEvent;
@@ -76,6 +80,8 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
     private PolicyManager policyManager;
     private AppraiserManager appraiserManager;
     private ReferenceManifestManager referenceManifestManager;
+    private ReferenceDigestManager referenceDigestManager;
+    private ReferenceEventManager referenceEventManager;
     private CertificateManager certificateManager;
     private CredentialValidator supplyChainCredentialValidator;
     private CrudManager<SupplyChainValidationSummary> supplyChainValidatorSummaryManager;
@@ -92,20 +98,27 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
      * @param referenceManifestManager           the RIM manager
      * @param supplyChainValidatorSummaryManager the summary manager
      * @param supplyChainCredentialValidator     the credential validator
+     * @param referenceDigestManager             the digest manager
+     * @param referenceEventManager              the even manager
      */
     @Autowired
+    @SuppressWarnings("ParameterNumberCheck")
     public SupplyChainValidationServiceImpl(
             final PolicyManager policyManager, final AppraiserManager appraiserManager,
             final CertificateManager certificateManager,
             final ReferenceManifestManager referenceManifestManager,
             final CrudManager<SupplyChainValidationSummary> supplyChainValidatorSummaryManager,
-            final CredentialValidator supplyChainCredentialValidator) {
+            final CredentialValidator supplyChainCredentialValidator,
+            final ReferenceDigestManager referenceDigestManager,
+            final ReferenceEventManager referenceEventManager) {
         this.policyManager = policyManager;
         this.appraiserManager = appraiserManager;
         this.certificateManager = certificateManager;
         this.referenceManifestManager = referenceManifestManager;
         this.supplyChainValidatorSummaryManager = supplyChainValidatorSummaryManager;
         this.supplyChainCredentialValidator = supplyChainCredentialValidator;
+        this.referenceDigestManager = referenceDigestManager;
+        this.referenceEventManager = referenceEventManager;
     }
 
     /**
@@ -354,10 +367,13 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
         AppraisalStatus fwStatus = null;
         String manufacturer = device.getDeviceInfo()
                 .getHardwareInfo().getManufacturer();
+        String model = device.getDeviceInfo()
+                .getHardwareInfo().getProductName();
         ReferenceManifest validationObject = null;
         ReferenceManifest baseReferenceManifest = null;
         ReferenceManifest supportReferenceManifest = null;
         ReferenceManifest measurement = null;
+        ReferenceDigestRecord digestRecord = null;
 
         baseReferenceManifest = BaseReferenceManifest.select(referenceManifestManager)
                 .byManufacturer(manufacturer).getRIM();
@@ -465,18 +481,22 @@ public class SupplyChainValidationServiceImpl implements SupplyChainValidationSe
                         // part 2 of firmware validation check: bios measurements
                         // vs baseline tcg event log
                         // find the measurement
-                        TCGEventLog tcgEventLog;
                         TCGEventLog tcgMeasurementLog;
+                        digestRecord = this.referenceDigestManager.getRecord(manufacturer, model);
                         LinkedList<TpmPcrEvent> tpmPcrEvents = new LinkedList<>();
+                        List<ReferenceDigestValue> eventValue;
+                        HashMap<String, ReferenceDigestValue> eventValueMap = new HashMap<>();
                         try {
                             if (measurement.getPlatformManufacturer().equals(manufacturer)) {
                                 tcgMeasurementLog = new TCGEventLog(measurement.getRimBytes());
-                                tcgEventLog = new TCGEventLog(
-                                        supportReferenceManifest.getRimBytes());
-                                for (TpmPcrEvent tpe : tcgEventLog.getEventList()) {
-                                    if (!tpe.eventCompare(
-                                            tcgMeasurementLog.getEventByNumber(
-                                                    tpe.getEventNumber()))) {
+                                eventValue = this.referenceEventManager
+                                        .getValuesByRecordId(digestRecord);
+                                for (ReferenceDigestValue rdv : eventValue) {
+                                    eventValueMap.put(rdv.getDigestValue(), rdv);
+                                }
+
+                                for (TpmPcrEvent tpe : tcgMeasurementLog.getEventList()) {
+                                    if (!eventValueMap.containsKey(tpe.getEventDigestStr())) {
                                         tpmPcrEvents.add(tpe);
                                     }
                                 }

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/service/SupplyChainValidationServiceImplTest.java
@@ -23,6 +23,8 @@ import hirs.persist.DBDeviceManager;
 import hirs.persist.DeviceGroupManager;
 import hirs.persist.DeviceManager;
 import hirs.persist.PolicyManager;
+import hirs.persist.ReferenceDigestManager;
+import hirs.persist.ReferenceEventManager;
 import hirs.validation.CredentialValidator;
 import hirs.validation.SupplyChainCredentialValidator;
 import org.mockito.ArgumentCaptor;
@@ -86,6 +88,12 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
 
     @Mock
     private CrudManager<SupplyChainValidationSummary> supplyChainValidationSummaryDBManager;
+
+    @Mock
+    private ReferenceDigestManager referenceDigestManager;
+
+    @Mock
+    private ReferenceEventManager referenceEventManager;
 
     @InjectMocks
     private SupplyChainValidationServiceImpl service;
@@ -400,7 +408,9 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
                 realCertMan,
                 null,
                 supplyChainValidationSummaryDBManager,
-                supplyChainCredentialValidator
+                supplyChainCredentialValidator,
+                referenceDigestManager,
+                referenceEventManager
         );
 
         CertificateAuthorityCredential globalSignCaCert = new CertificateAuthorityCredential(
@@ -460,7 +470,9 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
                 realCertMan,
                 null,
                 supplyChainValidationSummaryDBManager,
-                supplyChainCredentialValidator
+                supplyChainCredentialValidator,
+                referenceDigestManager,
+                referenceEventManager
         );
 
         CertificateAuthorityCredential rootCa = new CertificateAuthorityCredential(
@@ -506,7 +518,9 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
                 realCertMan,
                 null,
                 supplyChainValidationSummaryDBManager,
-                supplyChainCredentialValidator
+                supplyChainCredentialValidator,
+                referenceDigestManager,
+                referenceEventManager
         );
 
         EndorsementCredential endorsementCredential = new EndorsementCredential(
@@ -542,7 +556,9 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
                 realCertMan,
                 null,
                 supplyChainValidationSummaryDBManager,
-                supplyChainCredentialValidator
+                supplyChainCredentialValidator,
+                referenceDigestManager,
+                referenceEventManager
         );
 
         CertificateAuthorityCredential globalSignCaCert = new CertificateAuthorityCredential(
@@ -602,7 +618,9 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
                 realCertMan,
                 null,
                 supplyChainValidationSummaryDBManager,
-                supplyChainCredentialValidator
+                supplyChainCredentialValidator,
+                referenceDigestManager,
+                referenceEventManager
         );
 
         CertificateAuthorityCredential intelCa = new CertificateAuthorityCredential(
@@ -648,7 +666,9 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
                 realCertMan,
                 null,
                 supplyChainValidationSummaryDBManager,
-                supplyChainCredentialValidator
+                supplyChainCredentialValidator,
+                referenceDigestManager,
+                referenceEventManager
         );
 
         CertificateAuthorityCredential globalSignCaCert = new CertificateAuthorityCredential(
@@ -699,7 +719,9 @@ public class SupplyChainValidationServiceImplTest extends SpringPersistenceTest 
                 realCertMan,
                 null,
                 supplyChainValidationSummaryDBManager,
-                new SupplyChainCredentialValidator()
+                new SupplyChainCredentialValidator(),
+                referenceDigestManager,
+                referenceEventManager
         );
 
         CertificateAuthorityCredential stmEkRootCa = new CertificateAuthorityCredential(

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -306,17 +306,19 @@ public class ReferenceManifestDetailsPageController
         HashMap<String, Object> data = new HashMap<>();
         EventLogMeasurements measurements = null;
 
-        if (support.getAssociatedRim() == null
-                && (support.getPlatformManufacturer() != null
-                && !support.getPlatformManufacturer().isEmpty())) {
-            ReferenceManifest baseRim = BaseReferenceManifest.select(referenceManifestManager)
-                    .byManufacturer(support.getPlatformManufacturer()).getRIM();
-            if (baseRim != null) {
-                support.setAssociatedRim(baseRim.getId());
-                try {
-                    referenceManifestManager.update(support);
-                } catch (DBManagerException ex) {
-                    LOGGER.error("Failed to update Support RIM", ex);
+        if (support.getAssociatedRim() == null) {
+            Set<BaseReferenceManifest> baseRims = BaseReferenceManifest
+                    .select(referenceManifestManager)
+                    .byRimType(ReferenceManifest.BASE_RIM).getRIMs();
+            for (BaseReferenceManifest baseRim : baseRims) {
+                if (baseRim != null && baseRim.getAssociatedRim().equals(support.getId())) {
+                    support.setAssociatedRim(baseRim.getId());
+                    try {
+                        referenceManifestManager.update(support);
+                    } catch (DBManagerException ex) {
+                        LOGGER.error("Failed to update Support RIM", ex);
+                    }
+                    break;
                 }
             }
         }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -377,12 +377,11 @@ public class ReferenceManifestDetailsPageController
             HashMap<String, TpmPcrEvent> digestMap = new HashMap<>();
             for (TpmPcrEvent tpe : logProcessor.getEventList()) {
                 digestMap.put(tpe.getEventDigestStr(), tpe);
-                if (!support.isSwidSupplemental()) {
-                    if (!tpe.eventCompare(
+                if (!support.isSwidSupplemental()
+                        && !tpe.eventCompare(
                             measurementsProcess.getEventByNumber(
                                     tpe.getEventNumber()))) {
-                        tpe.setError(true);
-                    }
+                    tpe.setError(true);
                 }
                 tpmPcrEvents.add(tpe);
             }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -241,12 +241,10 @@ public class ReferenceManifestDetailsPageController
                     .getRIM();
             if (support != null) {
                 baseRim.setAssociatedRim(support.getId());
-//                logProcessor = new TCGEventLog(support.getRimBytes());
             }
         } else {
             support = SupportReferenceManifest.select(referenceManifestManager)
                     .byEntityId(baseRim.getAssociatedRim()).getRIM();
-//            logProcessor = new TCGEventLog(support.getRimBytes());
         }
         // going to have to pull the filename and grab that from the DB
         // to get the id to make the link

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -1,5 +1,9 @@
 package hirs.attestationca.portal.page.controllers;
 
+import hirs.attestationca.portal.page.Page;
+import hirs.attestationca.portal.page.PageController;
+import hirs.attestationca.portal.page.PageMessages;
+import hirs.attestationca.portal.page.params.ReferenceManifestDetailsPageParams;
 import hirs.data.persist.BaseReferenceManifest;
 import hirs.data.persist.EventLogMeasurements;
 import hirs.data.persist.ReferenceManifest;
@@ -10,23 +14,6 @@ import hirs.persist.CertificateManager;
 import hirs.persist.DBManagerException;
 import hirs.persist.ReferenceManifestManager;
 import hirs.tpm.eventlog.TCGEventLog;
-import hirs.attestationca.portal.page.Page;
-import hirs.attestationca.portal.page.PageController;
-import hirs.attestationca.portal.page.PageMessages;
-import hirs.attestationca.portal.page.params.ReferenceManifestDetailsPageParams;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.UUID;
-
 import hirs.tpm.eventlog.TpmPcrEvent;
 import hirs.utils.ReferenceManifestValidator;
 import org.apache.logging.log4j.LogManager;
@@ -36,6 +23,18 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * Controller for the Reference Manifest Details page.
@@ -187,16 +186,8 @@ public class ReferenceManifestDetailsPageController
         } else {
             data.put("swidCorpus", "False");
         }
-        if (baseRim.isSwidPatch() == 1) {
-            data.put("swidPatch", "True");
-        } else {
-            data.put("swidPatch", "False");
-        }
-        if (baseRim.isSwidSupplemental() == 1) {
-            data.put("swidSupplemental", "True");
-        } else {
-            data.put("swidSupplemental", "False");
-        }
+        data.put("swidPatch", baseRim.isSwidPatch());
+        data.put("swidSupplemental", baseRim.isSwidSupplemental());
         data.put("swidTagId", baseRim.getTagId());
         // Entity
         data.put("entityName", baseRim.getEntityName());

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -28,7 +28,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -225,12 +224,12 @@ public class ReferenceManifestDetailsPageController
                     .getRIM();
             if (support != null) {
                 baseRim.setAssociatedRim(support.getId());
-                logProcessor = new TCGEventLog(support.getRimBytes());
+//                logProcessor = new TCGEventLog(support.getRimBytes());
             }
         } else {
             support = SupportReferenceManifest.select(referenceManifestManager)
                     .byEntityId(baseRim.getAssociatedRim()).getRIM();
-            logProcessor = new TCGEventLog(support.getRimBytes());
+//            logProcessor = new TCGEventLog(support.getRimBytes());
         }
         // going to have to pull the filename and grab that from the DB
         // to get the id to make the link
@@ -244,11 +243,7 @@ public class ReferenceManifestDetailsPageController
                 } else {
                     data.put("supportRimHashValid", false);
                 }
-                swidRes.setPcrValues(Arrays.asList(
-                        logProcessor.getExpectedPCRValues()));
                 break;
-            } else {
-                swidRes.setPcrValues(new ArrayList<>());
             }
         }
 

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
@@ -41,6 +41,24 @@
                             </c:choose>
                         </div>
                     </div>
+                    <c:if test="${not initialData.swidBase}">
+                        <div class="row">
+                            <div class="col-md-1 col-md-offset-1">
+                                <span class="colHeader">RIM Type</span>
+                            </div>
+                            <div id="baseRim" class="col col-md-8">
+                                <c:if test="${initialData.swidCorpus}">
+                                    <div>SWID Corpus</div>
+                                </c:if>
+                                <c:if test="${initialData.swidPatch}">
+                                    <div>SWID Patch</div>
+                                </c:if>
+                                <c:if test="${initialData.swidSupplemental}">
+                                    <div>SWID Supplemental</div>
+                                </c:if>
+                            </div>
+                        </div>
+                    </c:if>
                     <div class="row">
                         <div class="col-md-1 col-md-offset-1">
                             <span class="colRimHeader">
@@ -57,7 +75,7 @@
                                     <ul>
                                         <c:if test="${initialData.crtm || initialData.bootManager || initialData.osLoader || initialData.osKernel}">
                                             <li>PC Client Boot path</li>
-                                            </c:if>
+                                        </c:if>
                                         <ul>
                                             <c:if test="${initialData.crtm}">
                                                 <li>Software Core Root of Trust for Measurement (SRTM)</li>
@@ -70,7 +88,7 @@
                                                 </c:if>
                                                 <c:if test="${initialData.osKernel}">
                                                 <li>OS Kernel</li>
-                                                </c:if>
+                                            </c:if>
                                         </ul>
                                         <c:if test="${initialData.acpiTables || initialData.smbiosTables || initialData.gptTable || initialData.defaultBootDevice}">
                                             <li>Device Configuration</li>
@@ -90,7 +108,7 @@
                                                 </c:if>
                                                 <c:if test="${initialData.defaultBootDevice}">
                                                 <li>Default boot device</li>
-                                                </c:if>
+                                            </c:if>
                                         </ul>
                                         <c:if test="${initialData.secureBoot || initialData.pk || initialData.kek || initialData.sigDb || initialData.forbiddenDbx}">
                                             <li>Secure Boot Variables</li>
@@ -110,7 +128,7 @@
                                                 </c:if>
                                                 <c:if test="${initialData.forbiddenDbx}">
                                                 <li>Forbidden Signatures Database (dbx)</li>
-                                                </c:if>
+                                            </c:if>
                                         </ul>
                                     </ul>
                                 </ul>
@@ -134,7 +152,6 @@
                                                 <li>OS Kernel</li>
                                                 </c:if>
                                         </ul>
-
                                         <c:if test="${not initialData.acpiTables || not initialData.smbiosTables || not initialData.gptTable || not initialData.bootOrder || not initialData.defaultBootDevice}">
                                             <li>Device Configuration</li>
                                             </c:if>
@@ -173,7 +190,7 @@
                                                 </c:if>
                                                 <c:if test="${not initialData.forbiddenDbx}">
                                                 <li>Forbidden Signatures Database (dbx)</li>
-                                                </c:if>
+                                            </c:if>
                                         </ul>
                                     </ul>
                                 </ul>
@@ -352,13 +369,24 @@
                         </c:if>
                         <div>Binding Spec:&nbsp;<span>${initialData.bindingSpec}</span></div>
                         <div>Binding Spec Version:&nbsp;<span>${initialData.bindingSpecVersion}</span></div>
-                        <c:if test="${not empty initiaData.pcUriGlobal}">
+                        <c:if test="${not empty initialData.pcUriGlobal}">
                             <div>PC URI Global:&nbsp;<span>${initialData.pcUriGlobal}</span></div>
                         </c:if>
-                        <c:if test="${not empty initiaData.pcUriLocal}">
+                        <c:if test="${not empty initialData.pcUriLocal}">
                             <div>PC URI Local:&nbsp;<span>${initialData.pcUriLocal}</span></div>
                         </c:if>
-                        <div>Rim Link Hash:&nbsp;<span>${initialData.rimLinkHash}</span></div>
+                        <div>Rim Link Hash:&nbsp;<span>${initialData.rimLinkHash}</span>
+                            <span>
+                                <c:choose>
+                                <c:when test="${initialData.linkHashValid}">
+                                    <img src="${passIcon}" title="SWID Tag exist.">
+                                </c:when>
+                                <c:otherwise>
+                                    <img src="${failIcon}" title="SWID Tag doesn't exist.">
+                                </c:otherwise>
+                                </c:choose>
+                            </span>
+                        </div>
                     </div>
                 </div>
                 <div class="row">

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
@@ -409,26 +409,27 @@
                                                                     </c:choose>
                                                                 </span>
                                                             </div>
+                                                            <div class="component col col-md-10">
+                                                                <span class="fieldHeader">File Size:</span>
+                                                                                                                                    <span class="fieldValue">${resource.getSize()}</span><br/>
+                                                                                                                                    <span class="fieldHeader">Hash:</span>
+                                                                                                                                    <span class="fieldValue" style="overflow-wrap: break-word">${resource.getHashValue()}</span><br/>
+                                                                                                                                    <c:if test="${not empty resource.getRimFormat()}">
+                                                                                                                                        <span class="fieldHeader">RIM Format:</span>
+                                                                                                                                        <span class="fieldValue">${resource.getRimFormat()}</span><br/>
+                                                                                                                                    </c:if>
+                                                                                                                                    <c:if test="${not empty resource.getRimType()}">
+                                                                                                                                        <span class="fieldHeader">RIM Type:</span>
+                                                                                                                                        <span class="fieldValue">${resource.getRimType()}</span><br/>
+                                                                                                                                    </c:if>
+                                                                                                                                    <c:if test="${not empty resource.getRimUriGlobal()}">
+                                                                                                                                        <span class="fieldHeader">URI Global:</span>
+                                                                                                                                        <span class="fieldValue">${resource.getRimUriGlobal()}</span><br/>
+                                                                </c:if>
+                                                            </div>
                                                             <c:choose>
                                                                 <c:when test="${not empty initialData.pcrList}">
                                                                     <div class="component col col-md-10">
-                                                                        <span class="fieldHeader">File Size:</span>
-                                                                        <span class="fieldValue">${resource.getSize()}</span><br/>
-                                                                        <span class="fieldHeader">Hash:</span>
-                                                                        <span class="fieldValue" style="overflow-wrap: break-word">${resource.getHashValue()}</span><br/>
-                                                                        <c:if test="${not empty resource.getRimFormat()}">
-                                                                            <span class="fieldHeader">RIM Format:</span>
-                                                                            <span class="fieldValue">${resource.getRimFormat()}</span><br/>
-                                                                        </c:if>
-                                                                        <c:if test="${not empty resource.getRimType()}">
-                                                                            <span class="fieldHeader">RIM Type:</span>
-                                                                            <span class="fieldValue">${resource.getRimType()}</span><br/>
-                                                                        </c:if>
-                                                                        <c:if test="${not empty resource.getRimUriGlobal()}">
-                                                                            <span class="fieldHeader">URI Global:</span>
-                                                                            <span class="fieldValue">${resource.getRimUriGlobal()}</span><br/>
-                                                                        </c:if>
-                                                                        <c:if test="${not empty initialData.pcrList}">
                                                                             <div class="panel-body">
                                                                                 <div class="component" role="tab" id="pcrValues">
                                                                                     <a role="button" data-toggle="collapse" data-parent="#directorycollapse" class="collapsed"
@@ -451,13 +452,13 @@
                                                                                     </div>
                                                                                 </div>
                                                                             </div>
-                                                                        </c:if>
                                                                     </div>
                                                                 </c:when>
                                                                 <c:otherwise>
                                                                     <div class="component col col-md-10" style="color: red; padding-left: 20px">Support RIM file named ${resource.getName()} was not imported via the Reference Integrity Manifest page.</div>
                                                                 </c:otherwise>
                                                             </c:choose>
+                                                            </div>
                                                         </div>                                                    
                                                     </div>
                                                 </c:forEach>

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
@@ -326,7 +326,7 @@
                     <div class="col-md-1 col-md-offset-1"><span class="colHeader">Link</span></div>
                     <div id="link" class="col col-md-8">
                         <c:if test="${not empty initialData.linkHref}">
-                            <div><span><a href="${initialData.linkHref}" rel="${initialData.linkRel}">${initialData.linkHref}</a></span>
+                            <div><span><a href="${portal}/rim-details?id=${initialData.linkHrefLink}" rel="${initialData.linkRel}">${initialData.linkHref}</a></span>
                             </div>
                             <div>Rel:&nbsp;<span>${initialData.linkRel}</span>
                             </div>
@@ -410,7 +410,7 @@
                                                                 </span>
                                                             </div>
                                                             <c:choose>
-                                                                <c:when test="${not empty resource.getPcrValues()}">
+                                                                <c:when test="${not empty initialData.pcrList}">
                                                                     <div class="component col col-md-10">
                                                                         <span class="fieldHeader">File Size:</span>
                                                                         <span class="fieldValue">${resource.getSize()}</span><br/>
@@ -428,7 +428,7 @@
                                                                             <span class="fieldHeader">URI Global:</span>
                                                                             <span class="fieldValue">${resource.getRimUriGlobal()}</span><br/>
                                                                         </c:if>
-                                                                        <c:if test="${not empty resource.getPcrValues()}"> 
+                                                                        <c:if test="${not empty initialData.pcrList}">
                                                                             <div class="panel-body">
                                                                                 <div class="component" role="tab" id="pcrValues">
                                                                                     <a role="button" data-toggle="collapse" data-parent="#directorycollapse" class="collapsed"
@@ -438,13 +438,15 @@
                                                                                 </div>
                                                                                 <div id="pcrscollapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingThree" aria-expanded="true">
                                                                                     <div>
-                                                                                        <c:forEach items="${resource.getPcrMap()}" var="pcrValue">
+                                                                                        <c:set var="count" value="0" scope="page"/>
+                                                                                        <c:forEach items="${initialData.pcrList}" var="pcrValue">
                                                                                             <div id="componentIdentifier" class="row">
-                                                                                                <div>                                                                                    
-                                                                                                    <span>${pcrValue.key}</span>
-                                                                                                    <span style="overflow-wrap: break-word">${pcrValue.value}</span>
+                                                                                                <div>
+                                                                                                    <span>PCR ${count} - </span>
+                                                                                                    <span style="overflow-wrap: break-word">${pcrValue}</span>
                                                                                                 </div>
                                                                                             </div>
+                                                                                            <c:set var="count" value="${count + 1}" scope="page"/>
                                                                                         </c:forEach>
                                                                                     </div>
                                                                                 </div>

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
@@ -411,20 +411,20 @@
                                                             </div>
                                                             <div class="component col col-md-10">
                                                                 <span class="fieldHeader">File Size:</span>
-                                                                                                                                    <span class="fieldValue">${resource.getSize()}</span><br/>
-                                                                                                                                    <span class="fieldHeader">Hash:</span>
-                                                                                                                                    <span class="fieldValue" style="overflow-wrap: break-word">${resource.getHashValue()}</span><br/>
-                                                                                                                                    <c:if test="${not empty resource.getRimFormat()}">
-                                                                                                                                        <span class="fieldHeader">RIM Format:</span>
-                                                                                                                                        <span class="fieldValue">${resource.getRimFormat()}</span><br/>
-                                                                                                                                    </c:if>
-                                                                                                                                    <c:if test="${not empty resource.getRimType()}">
-                                                                                                                                        <span class="fieldHeader">RIM Type:</span>
-                                                                                                                                        <span class="fieldValue">${resource.getRimType()}</span><br/>
-                                                                                                                                    </c:if>
-                                                                                                                                    <c:if test="${not empty resource.getRimUriGlobal()}">
-                                                                                                                                        <span class="fieldHeader">URI Global:</span>
-                                                                                                                                        <span class="fieldValue">${resource.getRimUriGlobal()}</span><br/>
+                                                                <span class="fieldValue">${resource.getSize()}</span><br/>
+                                                                <span class="fieldHeader">Hash:</span>
+                                                                <span class="fieldValue" style="overflow-wrap: break-word">${resource.getHashValue()}</span><br/>
+                                                                <c:if test="${not empty resource.getRimFormat()}">
+                                                                    <span class="fieldHeader">RIM Format:</span>
+                                                                    <span class="fieldValue">${resource.getRimFormat()}</span><br/>
+                                                                </c:if>
+                                                                <c:if test="${not empty resource.getRimType()}">
+                                                                    <span class="fieldHeader">RIM Type:</span>
+                                                                    <span class="fieldValue">${resource.getRimType()}</span><br/>
+                                                                </c:if>
+                                                                <c:if test="${not empty resource.getRimUriGlobal()}">
+                                                                    <span class="fieldHeader">URI Global:</span>
+                                                                    <span class="fieldValue">${resource.getRimUriGlobal()}</span><br/>
                                                                 </c:if>
                                                             </div>
                                                             <c:choose>
@@ -455,7 +455,9 @@
                                                                     </div>
                                                                 </c:when>
                                                                 <c:otherwise>
+                                                                <c:if test="${not initialData.swidPatch and not initialData.swidSupplemental}">
                                                                     <div class="component col col-md-10" style="color: red; padding-left: 20px">Support RIM file named ${resource.getName()} was not imported via the Reference Integrity Manifest page.</div>
+                                                                </c:if>
                                                                 </c:otherwise>
                                                             </c:choose>
                                                             </div>

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -160,7 +160,7 @@ int provision() {
             = provisioner.sendAttestationCertificateRequest(certificateRequest);
 
     if (akCertificateByteString == "") {
-        cout << "----> Provisioning failed.";
+        cout << "----> Provisioning the quote failed.";
         cout << "Please refer to the Attestation CA for details." << endl;
         return 0;
     }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/BaseReferenceManifest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/BaseReferenceManifest.java
@@ -41,8 +41,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
     @Column
     private String swidName = null;
     @Column
-    private String swidVersion = null;
-    @Column
     private int swidCorpus = 0;
     @Column
     private String colloquialVersion = null;
@@ -157,7 +155,7 @@ public class BaseReferenceManifest extends ReferenceManifest {
             this.swidCorpus = si.isCorpus() ? 1 : 0;
             this.setSwidPatch(si.isPatch());
             this.setSwidSupplemental(si.isSupplemental());
-            this.swidVersion = si.getVersion();
+            this.setSwidVersion(si.getVersion());
             if (si.getTagVersion() != null) {
                 this.setSwidTagVersion(si.getTagVersion().toString());
             }
@@ -433,24 +431,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
      */
     public void setSwidName(final String swidName) {
         this.swidName = swidName;
-    }
-
-    /**
-     * Getter for the SWID version.
-     *
-     * @return string of the version number
-     */
-    public String getSwidVersion() {
-        return swidVersion;
-    }
-
-    /**
-     * Setter for the SWID version.
-     *
-     * @param swidVersion string of the version
-     */
-    public void setSwidVersion(final String swidVersion) {
-        this.swidVersion = swidVersion;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/BaseReferenceManifest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/BaseReferenceManifest.java
@@ -45,10 +45,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
     @Column
     private int swidCorpus = 0;
     @Column
-    private int swidPatch = 0;
-    @Column
-    private int swidSupplemental = 0;
-    @Column
     private String colloquialVersion = null;
     @Column
     private String product = null;
@@ -159,8 +155,8 @@ public class BaseReferenceManifest extends ReferenceManifest {
             setTagId(si.getTagId());
             this.swidName = si.getName();
             this.swidCorpus = si.isCorpus() ? 1 : 0;
-            this.swidPatch = si.isPatch() ? 1 : 0;
-            this.swidSupplemental = si.isSupplemental() ? 1 : 0;
+            this.setSwidPatch(si.isPatch());
+            this.setSwidSupplemental(si.isSupplemental());
             this.swidVersion = si.getVersion();
             if (si.getTagVersion() != null) {
                 this.setSwidTagVersion(si.getTagVersion().toString());
@@ -476,42 +472,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
     }
 
     /**
-     * Getter for the patch flag.
-     *
-     * @return int flag for the patch flag
-     */
-    public int isSwidPatch() {
-        return swidPatch;
-    }
-
-    /**
-     * Setter for the patch flag.
-     *
-     * @param swidPatch int value
-     */
-    public void setSwidPatch(final int swidPatch) {
-        this.swidPatch = swidPatch;
-    }
-
-    /**
-     * Getter for the supplemental flag.
-     *
-     * @return int flag for the supplemental flag
-     */
-    public int isSwidSupplemental() {
-        return swidSupplemental;
-    }
-
-    /**
-     * Setter for the supplemental flag.
-     *
-     * @param swidSupplemental int value
-     */
-    public void setSwidSupplemental(final int swidSupplemental) {
-        this.swidSupplemental = swidSupplemental;
-    }
-
-    /**
      * Getter for the Entity Name.
      *
      * @return string of the entity name.
@@ -822,7 +782,7 @@ public class BaseReferenceManifest extends ReferenceManifest {
         return String.format("ReferenceManifest{swidName=%s,"
                         + "platformManufacturer=%s,"
                         + " platformModel=%s,"
-                        + "tagId=%s, rimHash=%d}",
+                        + "tagId=%s, rimHash=%s}",
                 swidName, this.getPlatformManufacturer(),
                 this.getPlatformModel(), getTagId(), this.getRimHash());
     }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/ReferenceDigestValue.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/ReferenceDigestValue.java
@@ -21,13 +21,15 @@ public class ReferenceDigestValue extends AbstractEntity {
     @Column
     private UUID digestRecordId;
     @Column(nullable = false)
-    private int eventNumber;
+    private int pcrIndex;
     @Column(nullable = false)
     private String digestValue;
     @Column(nullable = false)
     private String eventType;
     @Column(nullable = false)
     private boolean matchFail;
+    @Column(nullable = false)
+    private boolean patched = false;
 
     /**
      * Default Constructor.
@@ -35,28 +37,31 @@ public class ReferenceDigestValue extends AbstractEntity {
     public ReferenceDigestValue() {
         super();
         this.digestRecordId = UUID.randomUUID();
-        this.eventNumber = -1;
+        this.pcrIndex = -1;
         this.digestValue = "";
         this.eventType = "";
         this.matchFail = false;
+        this.patched = false;
     }
 
     /**
      * Default Constructor with parameters for all associated data.
      * @param digestRecordId the UUID of the associated record
-     * @param eventNumber the event number
+     * @param pcrIndex the event number
      * @param digestValue the key digest value
      * @param eventType the event type to store
      * @param matchFail the status of the baseline check
+     * @param patched the status of the value being updated to to patch
      */
-    public ReferenceDigestValue(final UUID digestRecordId, final int eventNumber,
+    public ReferenceDigestValue(final UUID digestRecordId, final int pcrIndex,
                                 final String digestValue, final String eventType,
-                                final boolean matchFail) {
+                                final boolean matchFail, final boolean patched) {
         this.digestRecordId = digestRecordId;
-        this.eventNumber = eventNumber;
+        this.pcrIndex = pcrIndex;
         this.digestValue = digestValue;
         this.eventType = eventType;
         this.matchFail = matchFail;
+        this.patched = patched;
     }
 
     /**
@@ -79,16 +84,16 @@ public class ReferenceDigestValue extends AbstractEntity {
      * Getter for the event number.
      * @return the stored value
      */
-    public int getEventNumber() {
-        return eventNumber;
+    public int getPcrIndex() {
+        return pcrIndex;
     }
 
     /**
      * Setter for the event number.
-     * @param eventNumber the value to store
+     * @param pcrIndex the value to store
      */
-    public void setEventNumber(final int eventNumber) {
-        this.eventNumber = eventNumber;
+    public void setPcrIndex(final int pcrIndex) {
+        this.pcrIndex = pcrIndex;
     }
 
     /**
@@ -139,6 +144,22 @@ public class ReferenceDigestValue extends AbstractEntity {
         this.matchFail = matchFail;
     }
 
+    /**
+     * Getter for the status of the patched state.
+     * @return patched flag
+     */
+    public boolean isPatched() {
+        return patched;
+    }
+
+    /**
+     * Setter for the status of the patched state.
+     * @param patched the flag to set
+     */
+    public void setPatched(final boolean patched) {
+        this.patched = patched;
+    }
+
     @Override
     public boolean equals(final Object obj) {
         if (this == obj) {
@@ -148,7 +169,7 @@ public class ReferenceDigestValue extends AbstractEntity {
             return false;
         }
         ReferenceDigestValue that = (ReferenceDigestValue) obj;
-        return eventNumber == that.eventNumber && matchFail == that.matchFail
+        return pcrIndex == that.pcrIndex && matchFail == that.matchFail
                 && Objects.equals(digestValue, that.digestValue)
                 && Objects.equals(digestRecordId, that.digestRecordId)
                 && Objects.equals(eventType, that.eventType);
@@ -156,7 +177,8 @@ public class ReferenceDigestValue extends AbstractEntity {
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(eventNumber, digestValue, digestRecordId, eventType, matchFail);
+        int result = Objects.hash(pcrIndex, digestValue, digestRecordId,
+                eventType, matchFail, patched);
         return result;
     }
 
@@ -165,6 +187,7 @@ public class ReferenceDigestValue extends AbstractEntity {
      * @return a string
      */
     public String toString() {
-        return String.format("ReferenceDigestValue: {%d, %b}", eventNumber, matchFail);
+        return String.format("ReferenceDigestValue: {%d, %s, %s, %b}",
+                pcrIndex, digestValue, eventType, matchFail);
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/ReferenceManifest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/ReferenceManifest.java
@@ -367,7 +367,8 @@ public abstract class ReferenceManifest extends ArchivableEntity {
     @Override
     public String toString() {
         return String.format("Filename->%s%nPlatform Manufacturer->%s%n"
-                + "Platform Model->%s%nRIM Type->%s", this.getFileName(),
-                this.platformManufacturer, this.platformModel, this.getRimType());
+                + "Platform Model->%s%nRIM Type->%s%nRIM Hash->%s", this.getFileName(),
+                this.platformManufacturer, this.platformModel, this.getRimType(),
+                this.getRimHash());
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/data/persist/ReferenceManifest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/ReferenceManifest.java
@@ -89,6 +89,8 @@ public abstract class ReferenceManifest extends ArchivableEntity {
     @Column
     private String swidTagVersion = null;
     @Column
+    private String swidVersion = null;
+    @Column
     private String platformModel = null;
     @Column(nullable = false)
     private String fileName = null;
@@ -243,6 +245,24 @@ public abstract class ReferenceManifest extends ArchivableEntity {
      */
     public void setSwidTagVersion(final String swidTagVersion) {
         this.swidTagVersion = swidTagVersion;
+    }
+
+    /**
+     * Getter for the SWID version.
+     *
+     * @return string of the version number
+     */
+    public String getSwidVersion() {
+        return swidVersion;
+    }
+
+    /**
+     * Setter for the SWID version.
+     *
+     * @param swidVersion string of the version
+     */
+    public void setSwidVersion(final String swidVersion) {
+        this.swidVersion = swidVersion;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/ReferenceManifest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/ReferenceManifest.java
@@ -1,23 +1,25 @@
 package hirs.data.persist;
 
-import java.util.Arrays;
-import java.util.UUID;
-import javax.persistence.Access;
-import javax.persistence.AccessType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hibernate.annotations.Type;
 
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
 import javax.persistence.Table;
 import javax.xml.XMLConstants;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.UUID;
 
 /**
  * This class represents the Reference Integrity Manifest object that will be
@@ -68,7 +70,7 @@ public abstract class ReferenceManifest extends ArchivableEntity {
     public static final String RIM_HASH_FIELD = "rimHash";
     @Column(nullable = false)
     @JsonIgnore
-    private final int rimHash;
+    private final String rimHash;
     @Column(columnDefinition = "blob", nullable = false)
     @JsonIgnore
     private byte[] rimBytes;
@@ -76,6 +78,10 @@ public abstract class ReferenceManifest extends ArchivableEntity {
     private String rimType = "Base";
     @Column
     private String tagId = null;
+    @Column
+    private boolean swidPatch = false;
+    @Column
+    private boolean swidSupplemental = false;
     @Column
     private String platformManufacturer = null;
     @Column
@@ -96,7 +102,7 @@ public abstract class ReferenceManifest extends ArchivableEntity {
     protected ReferenceManifest() {
         super();
         this.rimBytes = null;
-        this.rimHash = 0;
+        this.rimHash = "";
         this.rimType = null;
         this.platformManufacturer = null;
         this.platformManufacturerId = null;
@@ -118,7 +124,19 @@ public abstract class ReferenceManifest extends ArchivableEntity {
                 "Cannot construct a RIM from an empty byte array");
 
         this.rimBytes = rimBytes.clone();
-        this.rimHash = Arrays.hashCode(this.rimBytes);
+
+        MessageDigest digest = null;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException noSaEx) {
+            LOGGER.error(noSaEx);
+        }
+        if (digest == null) {
+            this.rimHash = "";
+        } else {
+            this.rimHash = Hex.encodeHexString(
+                    digest.digest(rimBytes));
+        }
     }
 
     /**
@@ -246,6 +264,42 @@ public abstract class ReferenceManifest extends ArchivableEntity {
     }
 
     /**
+     * Getter for the patch flag.
+     *
+     * @return int flag for the patch flag
+     */
+    public boolean isSwidPatch() {
+        return swidPatch;
+    }
+
+    /**
+     * Setter for the patch flag.
+     *
+     * @param swidPatch int value
+     */
+    public void setSwidPatch(final boolean swidPatch) {
+        this.swidPatch = swidPatch;
+    }
+
+    /**
+     * Getter for the supplemental flag.
+     *
+     * @return int flag for the supplemental flag
+     */
+    public boolean isSwidSupplemental() {
+        return swidSupplemental;
+    }
+
+    /**
+     * Setter for the supplemental flag.
+     *
+     * @param swidSupplemental int value
+     */
+    public void setSwidSupplemental(final boolean swidSupplemental) {
+        this.swidSupplemental = swidSupplemental;
+    }
+
+    /**
      * Getter for the associated RIM DB ID.
      * @return UUID for the rim
      */
@@ -279,13 +333,13 @@ public abstract class ReferenceManifest extends ArchivableEntity {
      *
      * @return int representation of the hash value
      */
-    public int getRimHash() {
+    public String getRimHash() {
         return rimHash;
     }
 
     @Override
     public int hashCode() {
-        return getRimHash();
+        return Arrays.hashCode(this.rimBytes);
     }
 
     @Override

--- a/HIRS_Utils/src/main/java/hirs/data/persist/SupportReferenceManifest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/SupportReferenceManifest.java
@@ -78,6 +78,26 @@ public class SupportReferenceManifest extends ReferenceManifest {
             setFieldValue(PLATFORM_MODEL, model);
             return this;
         }
+
+        /**
+         * Specify the file name that rims should have.
+         * @param fileName the name of the file associated with the rim
+         * @return this instance
+         */
+        public Selector byFileName(final String fileName) {
+            setFieldValue(RIM_FILENAME_FIELD, fileName);
+            return this;
+        }
+
+        /**
+         * Specify the RIM hash associated with the support RIM.
+         * @param rimHash the hash of the file associated with the rim
+         * @return this instance
+         */
+        public Selector byRimHash(final String rimHash) {
+            setFieldValue(RIM_HASH_FIELD, rimHash);
+            return this;
+        }
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/data/persist/SupportReferenceManifest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/SupportReferenceManifest.java
@@ -29,6 +29,8 @@ public class SupportReferenceManifest extends ReferenceManifest {
     private int pcrHash = 0;
     @Column
     private boolean updated = false;
+    @Column
+    private boolean processed = false;
 
     /**
      * This class enables the retrieval of SupportReferenceManifest by their attributes.
@@ -218,5 +220,30 @@ public class SupportReferenceManifest extends ReferenceManifest {
      */
     public void setUpdated(final boolean updated) {
         this.updated = updated;
+    }
+
+    /**
+     * Flag method on the status of supplemental processed.
+     * @return status of the flag
+     */
+    public boolean isProcessed() {
+        return processed;
+    }
+
+    /**
+     * Setter for the processed flag.
+     * @param processed status flag
+     */
+    public void setProcessed(final boolean processed) {
+        this.processed = processed;
+    }
+
+    /**
+     * This is a method to indicate whether or not this support
+     * rim is a base log file.
+     * @return flag for base.
+     */
+    public boolean isBaseSupport() {
+        return !this.isSwidSupplemental() && !this.isSwidPatch();
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/persist/DBReferenceDigestManager.java
+++ b/HIRS_Utils/src/main/java/hirs/persist/DBReferenceDigestManager.java
@@ -78,6 +78,37 @@ public class DBReferenceDigestManager extends DBManager<ReferenceDigestRecord>
     }
 
     @Override
+    public ReferenceDigestRecord getRecord(final String manufacturer, final String model) {
+        LOGGER.debug("Getting record for {} ~ {}", manufacturer, model);
+        if (manufacturer == null || model == null) {
+            LOGGER.error("No reference to get record from db {} ~ {}", manufacturer, model);
+            return null;
+        }
+
+        ReferenceDigestRecord dbRecord = null;
+        Transaction tx = null;
+        Session session = getFactory().getCurrentSession();
+        try {
+            LOGGER.debug("retrieving referenceDigestRecord from db");
+            tx = session.beginTransaction();
+            dbRecord = (ReferenceDigestRecord) session.createCriteria(ReferenceDigestRecord.class)
+                    .add(Restrictions.eq("manufacturer",
+                            manufacturer)).add(Restrictions.eq("model",
+                            model)).uniqueResult();
+            tx.commit();
+        } catch (Exception ex) {
+            final String msg = "unable to retrieve object";
+            LOGGER.error(msg, ex);
+            if (tx != null) {
+                LOGGER.debug("rolling back transaction");
+                tx.rollback();
+            }
+            throw new DBManagerException(msg, ex);
+        }
+        return dbRecord;
+    }
+
+    @Override
     public ReferenceDigestRecord getRecordById(final ReferenceDigestRecord referenceDigestRecord) {
         LOGGER.debug("Getting record for {}", referenceDigestRecord);
         if (referenceDigestRecord == null) {

--- a/HIRS_Utils/src/main/java/hirs/persist/DBReferenceEventManager.java
+++ b/HIRS_Utils/src/main/java/hirs/persist/DBReferenceEventManager.java
@@ -50,7 +50,7 @@ public class DBReferenceEventManager  extends DBManager<ReferenceDigestValue>
 
         if (referenceDigestValue.getDigestRecordId() == null
                 || referenceDigestValue.getDigestValue() == null
-                || referenceDigestValue.getEventNumber() == -1) {
+                || referenceDigestValue.getPcrIndex() == -1) {
             LOGGER.error("No reference to get record from db {}", referenceDigestValue);
             return null;
         }
@@ -67,7 +67,7 @@ public class DBReferenceEventManager  extends DBManager<ReferenceDigestValue>
                     .add(Restrictions.eq("digestValue",
                             referenceDigestValue.getDigestValue()))
                     .add(Restrictions.eq("eventNumber",
-                            referenceDigestValue.getEventNumber()))
+                            referenceDigestValue.getPcrIndex()))
                     .uniqueResult();
             tx.commit();
         } catch (Exception ex) {

--- a/HIRS_Utils/src/main/java/hirs/persist/ReferenceDigestManager.java
+++ b/HIRS_Utils/src/main/java/hirs/persist/ReferenceDigestManager.java
@@ -31,6 +31,15 @@ public interface ReferenceDigestManager {
     /**
      * Persists a new Reference Digest.
      *
+     * @param manufacturer the string of the manufacturer
+     * @param model the string of the model
+     * @return the persisted ReferenceDigestRecord
+     */
+    ReferenceDigestRecord getRecord(String manufacturer, String model);
+
+    /**
+     * Persists a new Reference Digest.
+     *
      * @param referenceDigestRecord the ReferenceDigestRecord
      * @return the persisted ReferenceDigestRecord
      */

--- a/HIRS_Utils/src/main/java/hirs/persist/ReferenceManifestSelector.java
+++ b/HIRS_Utils/src/main/java/hirs/persist/ReferenceManifestSelector.java
@@ -37,8 +37,11 @@ public abstract class ReferenceManifestSelector<T extends ReferenceManifest> {
      * String representing the database field for the model.
      */
     public static final String PLATFORM_MODEL = "platformModel";
+    /**
+     * String representing the database field for the filename.
+     */
+    public static final String RIM_FILENAME_FIELD = "fileName";
     private static final String RIM_TYPE_FIELD = "rimType";
-    private static final String RIM_FILENAME_FIELD = "fileName";
 
     private final ReferenceManifestManager referenceManifestManager;
     private final Class<T> referenceTypeClass;
@@ -100,7 +103,7 @@ public abstract class ReferenceManifestSelector<T extends ReferenceManifest> {
      * @param rimHash the hash code of the bytes to query for
      * @return this instance (for chaining further calls)
      */
-    public ReferenceManifestSelector<T> byHashCode(final int rimHash) {
+    public ReferenceManifestSelector<T> byHashCode(final String rimHash) {
         setFieldValue(hirs.data.persist.ReferenceManifest.RIM_HASH_FIELD, rimHash);
         return this;
     }

--- a/config/checkstyle/sun_checks.xml
+++ b/config/checkstyle/sun_checks.xml
@@ -123,7 +123,10 @@
             <property name="max" value="100"/>
         </module>
         <module name="MethodLength"/>
-        <module name="ParameterNumber"/>
+        <module name="ParameterNumber">
+            <property name="max" value="10"/>
+            <property name="tokens" value="METHOD_DEF"/>
+        </module>
 
 
         <!-- Checks for whitespace                               -->


### PR DESCRIPTION
In an effort to keep the PR a bit smaller.  This is the first part of event digest validation that is associated with #343.  

The first main thing this PR addresses is updating the UI to display the differences in support RIMs whether they are Supplemental or Patch. 

Because of updating the UI, more had to be updated in the background to make sure the support rims were updated with the correct information from the associated base, which depends on when each are uploaded and how they associate with one another.  A lot of the code change have to do with moving code around so that different fields within the RIM objects could be updated.

Also fixed a visual error that causes all support RIM events to show up red (error).  This had to do with the comparing of events by event number, which will never match up, to using the PCR Index.  This does part of the validation but only for page display, not during the Firmware Validation process.