### PR TITLE
Docker Pull update for Travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 install: true
 
 script:
-        - echo "docker login -u "$DOCKER_USER" -p "$DOCKER_PWD" 
+        - docker login -u "$DOCKER_USER" -p "$DOCKER_PWD" 
         - docker run --rm -v $(pwd):/HIRS hirs/hirs-ci:centos7 /bin/bash -c "cd /HIRS; ./gradlew :$SUBPROJECT:build -x test :$TCG_RIM_TOOL:build"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,31 +40,31 @@ jobs:
   include:
     - stage: Packaging and System Tests
       script:
-	    - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
+            - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
             - docker run --rm -v $(pwd):/HIRS hirs/hirs-ci:ubuntu18 /bin/bash -c "cd /HIRS; ./package/package.ubuntu.sh"
       env: null
       name: "Package Ubuntu"
     - stage: Packaging and System Tests
       script: 
-	    - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
+            - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
             - .ci/system-tests/./run-system-tests.sh
       env: null
       name: "System Tests TPM 1.2"
     - stage: Packaging and System Tests
       script: 
-	    - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
+            - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
             - .ci/system-tests/./run-system-tests-tpm2.sh
       env: null
       name: "System Tests TPM 2.0"
     - stage: Packaging and System Tests
       script: 
-	    - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
+            - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
             - .ci/system-tests/./run-system-tests-tpm2-base-delta-bad.sh
       env: null
       name: "System Tests TPM 2.0 Base/Delta(Bad)"
     - stage: Packaging and System Tests
       script: 
-	    - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
+            - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
             - .ci/system-tests/./run-system-tests-tpm2-base-delta-good.sh
       env: null
       name: "System Tests TPM 2.0 Base/Delta(Good)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 install: true
 
 script:
-        - docker login -u "$DOCKER_USER" -p "$DOCKER_PWD" 
+        - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
         - docker run --rm -v $(pwd):/HIRS hirs/hirs-ci:centos7 /bin/bash -c "cd /HIRS; ./gradlew :$SUBPROJECT:build -x test :$TCG_RIM_TOOL:build"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ script:
         - echo "$DOCKER_HUB_ACCESS_TOKEN" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin
         - docker run --rm -v $(pwd):/HIRS hirs/hirs-ci:centos7 /bin/bash -c "cd /HIRS; ./gradlew :$SUBPROJECT:build -x test :$TCG_RIM_TOOL:build"
 
+
 jobs:
   include:
     - stage: Packaging and System Tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ cache:
 install: true
 
 script:
+        - echo "$DOCKER_HUB_ACCESS_TOKEN" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin
         - docker run --rm -v $(pwd):/HIRS hirs/hirs-ci:centos7 /bin/bash -c "cd /HIRS; ./gradlew :$SUBPROJECT:build -x test :$TCG_RIM_TOOL:build"
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,26 +36,35 @@ script:
         - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
         - docker run --rm -v $(pwd):/HIRS hirs/hirs-ci:centos7 /bin/bash -c "cd /HIRS; ./gradlew :$SUBPROJECT:build -x test :$TCG_RIM_TOOL:build"
 
-
 jobs:
   include:
     - stage: Packaging and System Tests
-      script: docker run --rm -v $(pwd):/HIRS hirs/hirs-ci:ubuntu18 /bin/bash -c "cd /HIRS; ./package/package.ubuntu.sh"
+      script:
+	    - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
+            - docker run --rm -v $(pwd):/HIRS hirs/hirs-ci:ubuntu18 /bin/bash -c "cd /HIRS; ./package/package.ubuntu.sh"
       env: null
       name: "Package Ubuntu"
     - stage: Packaging and System Tests
-      script: .ci/system-tests/./run-system-tests.sh
+      script: 
+	    - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
+            - .ci/system-tests/./run-system-tests.sh
       env: null
       name: "System Tests TPM 1.2"
     - stage: Packaging and System Tests
-      script: .ci/system-tests/./run-system-tests-tpm2.sh
+      script: 
+	    - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
+            - .ci/system-tests/./run-system-tests-tpm2.sh
       env: null
       name: "System Tests TPM 2.0"
     - stage: Packaging and System Tests
-      script: .ci/system-tests/./run-system-tests-tpm2-base-delta-bad.sh
+      script: 
+	    - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
+            - .ci/system-tests/./run-system-tests-tpm2-base-delta-bad.sh
       env: null
       name: "System Tests TPM 2.0 Base/Delta(Bad)"
     - stage: Packaging and System Tests
-      script: .ci/system-tests/./run-system-tests-tpm2-base-delta-good.sh
+      script: 
+	    - echo $DOCKER_PWD | docker login -u "$DOCKER_USER" --password-stdin 
+            - .ci/system-tests/./run-system-tests-tpm2-base-delta-good.sh
       env: null
       name: "System Tests TPM 2.0 Base/Delta(Good)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ cache:
 install: true
 
 script:
-        - echo "$DOCKER_HUB_ACCESS_TOKEN" | docker login -u "$DOCKER_HUB_USERNAME" --password-stdin
+        - echo "docker login -u "$DOCKER_USER" -p "$DOCKER_PWD" 
         - docker run --rm -v $(pwd):/HIRS hirs/hirs-ci:centos7 /bin/bash -c "cd /HIRS; ./gradlew :$SUBPROJECT:build -x test :$TCG_RIM_TOOL:build"
 
 

--- a/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
+++ b/HIRS_ProvisionerTPM2/src/CommandTpm2.cpp
@@ -816,10 +816,10 @@ string CommandTpm2::runTpm2CommandWithRetry(const string& command,
         try {
             if (command.compare(kTpm2ToolsNvReadCommand) == 0) {
                 return hirs::utils::Process::runData(command, args,
-                                                 "CommandTpm2.cpp", sourceCodeLineNumber);
+                            "CommandTpm2.cpp", sourceCodeLineNumber);
             } else {
                 return hirs::utils::Process::run(command, args,
-                                                 "CommandTpm2.cpp", sourceCodeLineNumber);
+                             "CommandTpm2.cpp", sourceCodeLineNumber);
             }
         } catch (HirsRuntimeException& ex) {
             tpmErrorCode = Tpm2ToolsOutputParser::parseTpmErrorCode(ex.what());


### PR DESCRIPTION
TRavis ci Builds are failing due to the new restriction on Docker Hub for anonymous pulls. This PR addresses this issue.

closes issue-367