### PR TITLE
[#345] Modify SupplyChainCredentialValidator class to loop through truststore

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -1405,7 +1405,7 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
         boolean issuerMatchesSubject = false;
         boolean signatureMatchesPublicKey = false;
 
-        while (foundRootOfCertChain.isEmpty() && certIterator.hasNext()) {
+        while (certIterator.hasNext()) {
             trustedCert = certIterator.next();
             issuerMatchesSubject = issuerMatchesSubjectDN(cert, trustedCert);
             signatureMatchesPublicKey = signatureMatchesPublicKey(cert, trustedCert);


### PR DESCRIPTION
One line change to SupplyChainCredentialValidator to loop fully through truststore.  Removing the while loop condition will prevent it from exiting prematurely.

Closes #345 