### PR TITLE
[#345] Refactor recursion in SupplyChainCredentialValidator.validateCertChain

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -1399,38 +1399,36 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
             throw new SupplyChainValidatorException(
                     "Certificate or validation certificates are null");
         }
+        final String intCAError = "Intermediate signing cert found, check for CA cert";
         String foundRootOfCertChain = "";
-        Iterator<X509Certificate> certIterator = additionalCerts.iterator();
-        X509Certificate trustedCert;
-        boolean issuerMatchesSubject = false;
-        boolean signatureMatchesPublicKey = false;
+        X509Certificate startOfChain = cert;
 
-        while (foundRootOfCertChain.isEmpty() && certIterator.hasNext()) {
-            trustedCert = certIterator.next();
-            issuerMatchesSubject = issuerMatchesSubjectDN(cert, trustedCert);
-            signatureMatchesPublicKey = signatureMatchesPublicKey(cert, trustedCert);
-            if (issuerMatchesSubject && signatureMatchesPublicKey) {
-                if (isSelfSigned(trustedCert)) {
-                    foundRootOfCertChain = "";
-                    LOGGER.info("CA Root found.");
-                    break;
-                } else if (!cert.equals(trustedCert)) {
-                    foundRootOfCertChain = "Intermediate signing cert found, check for CA cert "
-                            + cert.getIssuerDN().getName();
-                }
-            } else {
-                if (!issuerMatchesSubject) {
-                    foundRootOfCertChain = "Issuer DN does not match Subject DN";
-                }
-                if (!signatureMatchesPublicKey) {
-                    foundRootOfCertChain = "Certificate signature failed to verify";
+        do {
+            for (X509Certificate trustedCert : additionalCerts) {
+                boolean issuerMatchesSubject = issuerMatchesSubjectDN(startOfChain, trustedCert);
+                boolean signatureMatchesPublicKey = signatureMatchesPublicKey(startOfChain,
+                                                                                trustedCert);
+                if (issuerMatchesSubject && signatureMatchesPublicKey) {
+                    if (isSelfSigned(trustedCert)) {
+                        LOGGER.info("CA Root found.");
+                        return "";
+                    } else {
+                        foundRootOfCertChain = intCAError;
+                        startOfChain = trustedCert;
+                        break;
+                    }
+                } else {
+                    if (!issuerMatchesSubject) {
+                        foundRootOfCertChain = "Issuer DN does not match Subject DN";
+                    }
+                    if (!signatureMatchesPublicKey) {
+                        foundRootOfCertChain = "Certificate signature failed to verify";
+                    }
                 }
             }
-        }
+        } while (foundRootOfCertChain.equals(intCAError));
 
-        if (!foundRootOfCertChain.isEmpty()) {
-            LOGGER.error(foundRootOfCertChain);
-        }
+        LOGGER.error(foundRootOfCertChain);
         return foundRootOfCertChain;
     }
 


### PR DESCRIPTION
Previous changes to this method did not adequately refactor the old recursive code.  This PR accounts for all possible sequences of trusted certs encountered in the truststore so that the full issuing chain is discovered if present.

Closes #345 