### PR TITLE
[#382] Install check to avoid file conflict

### DIFF
--- a/package/rpm/HIRS.spec
+++ b/package/rpm/HIRS.spec
@@ -260,7 +260,7 @@ fi
 %attr(664, root, tomcat) /opt/hirs/default-properties/attestationca/banner.properties
 %attr(664, root, tomcat) /opt/hirs/default-properties/attestationca/persistence.properties
 %attr(664, root, tomcat) /opt/hirs/default-properties/component-class.json
-%attr(664, root, tomcat) /opt/hirs/default-properties/vendor-table.json
+%attr(664, root, tomcat) /opt/hirs/default-properties/attestationca/vendor-table.json
 %attr(774, root, tomcat) /opt/hirs/scripts/common/aca
 %attr(774, root, tomcat) /opt/hirs/scripts/aca
 %attr(774, root, tomcat) /opt/hirs/extras/aca/tomcat-mysql-hirs.pp
@@ -330,7 +330,7 @@ cp HIRS_Utils/src/main/resources/persistence.properties %{buildroot}/opt/hirs/de
 cp HIRS_Utils/src/main/resources/logging.properties %{buildroot}/opt/hirs/default-properties/attestationca/
 cp HIRS_Utils/src/main/resources/banner.properties %{buildroot}/opt/hirs/default-properties/attestationca/
 cp HIRS_Utils/src/main/resources/component-class.json %{buildroot}/opt/hirs/default-properties/
-cp HIRS_Utils/src/main/resources/vendor-table.json %{buildroot}/opt/hirs/default-properties/
+cp HIRS_Utils/src/main/resources/vendor-table.json %{buildroot}/opt/hirs/default-properties/attestationca/
 
 # install extras
 mkdir -p %{buildroot}/opt/hirs/extras

--- a/tools/tcg_eventlog_tool/build.gradle
+++ b/tools/tcg_eventlog_tool/build.gradle
@@ -69,7 +69,7 @@ ospackage {
     packageName = 'tcg_eventlog_tool'
     os = LINUX
     arch = NOARCH
-    version = '2.0.0'
+    version = '2.1.0'
     release = '1'
 
     into '/opt/hirs/eventlog'
@@ -108,7 +108,7 @@ ospackage {
         link("/usr/local/bin/elt", "/opt/hirs/eventlog/scripts/eventlog.sh", 0x755)
     }
 
-    into('/opt/hirs/default-properties/') {
+    into('/opt/hirs/default-properties/eventlogtool') {
         fileMode 0664
         from ('../../HIRS_Utils/src/main/resources/vendor-table.json') {
             addParentDirs true


### PR DESCRIPTION
Add checks to avoid conflict during ACA and tcg_eventool install over vendor-tables.json.

Closes #382 