### PR TITLE
[#396] DevID display update

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AcaDbInit.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AcaDbInit.java
@@ -28,8 +28,7 @@ public final class AcaDbInit {
     public static synchronized void insertDefaultEntries(
             final AppraiserManager appraiserManager,
             final DeviceGroupManager deviceGroupManager,
-            final PolicyManager policyManager
-    ) {
+            final PolicyManager policyManager) {
         LOG.info("Ensuring default ACA database entries are present.");
 
         // Ensure the default group exists.  It may have already been created by the Server RPM
@@ -38,8 +37,7 @@ public final class AcaDbInit {
             LOG.info("Default group not found; saving...");
             defaultGroup = deviceGroupManager.saveDeviceGroup(new DeviceGroup(
                     DeviceGroup.DEFAULT_GROUP,
-                    "This is the default group"
-            ));
+                    "This is the default group"));
             LOG.info("Saved default group.");
         }
 
@@ -61,8 +59,7 @@ public final class AcaDbInit {
         // Create the SupplyChainPolicy
         LOG.info("Saving default supply chain policy...");
         SupplyChainPolicy supplyChainPolicy = new SupplyChainPolicy(
-                SupplyChainPolicy.DEFAULT_POLICY
-        );
+                SupplyChainPolicy.DEFAULT_POLICY);
         policyManager.savePolicy(supplyChainPolicy);
         policyManager.setDefaultPolicy(supplyChainAppraiser, supplyChainPolicy);
         policyManager.setPolicy(supplyChainAppraiser, defaultGroup, supplyChainPolicy);

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/model/PolicyPageModel.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/model/PolicyPageModel.java
@@ -14,7 +14,9 @@ public class PolicyPageModel {
     private boolean enablePcCertificateAttributeValidation;
     private boolean enableFirmwareValidation;
     private boolean issueAttestationCertificate;
+    private boolean issueDevIdCertificate;
     private boolean generateOnExpiration;
+    private boolean devIdExpirationFlag;
     private boolean enableIgnoreIma;
     private boolean enableIgnoreTboot;
     private boolean enableIgnoreGpt;
@@ -25,14 +27,19 @@ public class PolicyPageModel {
     private String ecValidate;
     private String fmValidate;
     private String attestationCertificateIssued;
+    private String devIdCertificateIssued;
     private String generationExpirationOn;
+    private String devIdExpirationChecked;
     private String numOfValidDays;
     private String reissueThreshold;
+    private String devIdReissueThreshold;
     private String ignoreIma;
     private String ignoretBoot;
     private String ignoreGpt;
     private String expirationValue;
+    private String devIdExpirationValue;
     private String thresholdValue;
+    private String devIdThresholdValue;
 
     /**
      * Constructor. Sets fields from policy.
@@ -45,7 +52,9 @@ public class PolicyPageModel {
         this.enablePcCertificateAttributeValidation = policy.isPcAttributeValidationEnabled();
         this.enableFirmwareValidation = policy.isFirmwareValidationEnabled();
         this.issueAttestationCertificate = policy.isIssueAttestationCertificate();
+        this.issueDevIdCertificate = policy.isIssueDevIdCertificate();
         this.generateOnExpiration = policy.isGenerateOnExpiration();
+        this.devIdExpirationFlag = policy.isDevIdExpirationFlag();
         this.numOfValidDays = policy.getValidityDays();
         this.reissueThreshold = policy.getReissueThreshold();
         this.enableIgnoreIma = policy.isIgnoreImaEnabled();
@@ -53,6 +62,9 @@ public class PolicyPageModel {
         this.enableIgnoreGpt = policy.isIgnoreGptEnabled();
         this.expirationValue = policy.getValidityDays();
         this.thresholdValue = policy.getReissueThreshold();
+        this.devIdExpirationValue = policy.getDevIdValidityDays();
+        this.devIdReissueThreshold = policy.getDevIdReissueThreshold();
+        this.devIdThresholdValue = policy.getDevIdReissueThreshold();
     }
 
     /**
@@ -104,6 +116,15 @@ public class PolicyPageModel {
      */
     public boolean isIssueAttestationCertificate() {
         return issueAttestationCertificate;
+    }
+
+    /**
+     * Gets the Dev ID Certificate issued State.
+     *
+     * @return the issued state.
+     */
+    public boolean isIssueDevIdCertificate() {
+        return issueDevIdCertificate;
     }
 
     /**
@@ -185,12 +206,12 @@ public class PolicyPageModel {
     }
 
     /**
-     * Gets the attestation certificate issued state.
+     * Gets the DevID certificate issued state.
      *
      * @return the model string representation of this field.
      */
-    public String getGenerationExpirationOn() {
-        return generationExpirationOn;
+    public String getDevIdCertificateIssued() {
+        return devIdCertificateIssued;
     }
 
     /**
@@ -209,6 +230,15 @@ public class PolicyPageModel {
      */
     public String getReissueThreshold() {
         return reissueThreshold;
+    }
+
+    /**
+     * Gets the number of selected threshold days.
+     *
+     * @return the number of the days for reissue
+     */
+    public String getDevIdReissueThreshold() {
+        return devIdReissueThreshold;
     }
 
     /**
@@ -280,9 +310,17 @@ public class PolicyPageModel {
      *
      * @param issueAttestationCertificate true if generating Certificates.
      */
-    public void setIssueAttestationCertificate(
-            final boolean issueAttestationCertificate) {
+    public void setIssueAttestationCertificate(final boolean issueAttestationCertificate) {
         this.issueAttestationCertificate = issueAttestationCertificate;
+    }
+
+    /**
+     * Sets the Dev ID Certificate Issued state.
+     *
+     * @param issueDevIdCertificate true if generating Certificates.
+     */
+    public void setIssueDevIdCertificate(final boolean issueDevIdCertificate) {
+        this.issueDevIdCertificate = issueDevIdCertificate;
     }
 
     /**
@@ -368,6 +406,24 @@ public class PolicyPageModel {
     }
 
     /**
+     * Sets the Issued DevID Certificate state.
+     *
+     * @param devIdCertificateIssued "checked" if generating certificates.
+     */
+    public void setDevIdCertificateIssued(final String devIdCertificateIssued) {
+        this.devIdCertificateIssued = devIdCertificateIssued;
+    }
+
+    /**
+     * Gets the attestation certificate issued state.
+     *
+     * @return the model string representation of this field.
+     */
+    public String getGenerationExpirationOn() {
+        return generationExpirationOn;
+    }
+
+    /**
      * Sets the generation expiration state.
      *
      * @param generationExpirationOn "checked" if generating expiration is on.
@@ -375,6 +431,43 @@ public class PolicyPageModel {
     public void setGenerationExpirationOn(
             final String generationExpirationOn) {
         this.generationExpirationOn = generationExpirationOn;
+    }
+
+    /**
+     * Gets the attestation certificate issued state.
+     *
+     * @return the model string representation of this field.
+     */
+    public String getDevIdExpirationChecked() {
+        return devIdExpirationChecked;
+    }
+
+    /**
+     * Sets the generation expiration state.
+     *
+     * @param devIdExpirationChecked "checked" if generating expiration is on.
+     */
+    public void setDevIdExpirationChecked(
+            final String devIdExpirationChecked) {
+        this.devIdExpirationChecked = devIdExpirationChecked;
+    }
+
+    /**
+     * Gets the DevID certificate issued state.
+     *
+     * @return the model string representation of this field.
+     */
+    public boolean getDevIdExpirationFlag() {
+        return devIdExpirationFlag;
+    }
+
+    /**
+     * Sets the generation expiration state.
+     *
+     * @param devIdExpirationFlag "checked" if generating expiration is on.
+     */
+    public void setDevIdExpirationFlag(final boolean devIdExpirationFlag) {
+        this.devIdExpirationFlag = devIdExpirationFlag;
     }
 
     /**
@@ -421,6 +514,22 @@ public class PolicyPageModel {
     }
 
     /**
+     * Getter for the DevID expiration value.
+     * @return the value
+     */
+    public String getDevIdExpirationValue() {
+        return devIdExpirationValue;
+    }
+
+    /**
+     * Setter for the DevID expiration value.
+     * @param devIdExpirationValue string value
+     */
+    public void setDevIdExpirationValue(final String devIdExpirationValue) {
+        this.devIdExpirationValue = devIdExpirationValue;
+    }
+
+    /**
      * Getter for the expiration value.
      * @return the thresholdValue
      */
@@ -436,6 +545,22 @@ public class PolicyPageModel {
         this.thresholdValue = thresholdValue;
     }
 
+    /**
+     * Getter for the expiration value.
+     * @return the devIdThresholdValue
+     */
+    public String getDevIdThresholdValue() {
+        return devIdThresholdValue;
+    }
+
+    /**
+     * Setter for the expiration value.
+     * @param devIdThresholdValue string value
+     */
+    public void setDevIdThresholdValue(final String devIdThresholdValue) {
+        this.devIdThresholdValue = devIdThresholdValue;
+    }
+
     @Override
     public String toString() {
         return "PolicyPageModel{"
@@ -445,7 +570,18 @@ public class PolicyPageModel {
                 + enablePcCertificateAttributeValidation
                 + ", enableFirmwareValidation=" + enableFirmwareValidation
                 + ", issueAttestationCertificate=" + issueAttestationCertificate
+                + ", issueDevIdCertificate=" + issueDevIdCertificate
                 + ", generateOnExpiration=" + generateOnExpiration
-                + ", numOfValidDays=" + numOfValidDays + "}";
+                + ", numOfValidDays=" + numOfValidDays
+                + ", reissueThreshold=" + reissueThreshold
+                + ", enableIgnoreIma=" + enableIgnoreIma
+                + ", enableIgnoreTboot=" + enableIgnoreTboot
+                + ", enableIgnoreGpt=" + enableIgnoreGpt
+                + ", expirationValue=" + expirationValue
+                + ", thresholdValue=" + thresholdValue
+                + ", devIdExpirationValue=" + devIdExpirationValue
+                + ", devIdReissueThreshold=" + devIdReissueThreshold
+                + ", devIdThresholdValue=" + devIdThresholdValue
+                + "}";
     }
 }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/Page.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/Page.java
@@ -30,7 +30,7 @@ public enum Page {
     /**
      * Page to display issued certificates.
      */
-    ISSUED_CERTIFICATES("Issued Attestation Certificates", "ic_library_books",
+    ISSUED_CERTIFICATES("Issued Certificates", "ic_library_books",
         null, "certificate-request/"),
     /**
      * Page to display certificate validation reports.

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PolicyPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PolicyPageController.java
@@ -247,6 +247,50 @@ public class PolicyPageController extends PageController<NoPageParams> {
     }
 
     /**
+     * Updates the DevID Certificate generation policy setting and redirects
+     * back to the original page.
+     *
+     * @param ppModel The data posted by the form mapped into an object.
+     * @param attr RedirectAttributes used to forward data back to the original page.
+     * @return View containing the url and parameters
+     * @throws URISyntaxException if malformed URI
+     */
+    @RequestMapping(value = "update-issue-devid", method = RequestMethod.POST)
+    public RedirectView updateDevIdVal(@ModelAttribute final PolicyPageModel ppModel,
+                                             final RedirectAttributes attr)
+            throws URISyntaxException {
+
+        // set the data received to be populated back into the form
+        Map<String, Object> model = new HashMap<>();
+        PageMessages messages = new PageMessages();
+        String successMessage;
+        boolean issuedDevIdOptionEnabled
+                = ppModel.getDevIdCertificateIssued()
+                .equalsIgnoreCase(ENABLED_CHECKED_PARAMETER_VALUE);
+
+        try {
+            SupplyChainPolicy policy = getDefaultPolicyAndSetInModel(ppModel, model);
+
+            if (issuedDevIdOptionEnabled) {
+                successMessage = "DevID Certificate generation enabled.";
+            } else {
+                successMessage = "DevID Certificate generation disabled.";
+                policy.setDevIdExpirationFlag(false);
+            }
+
+            policy.setIssueDevIdCertificate(issuedDevIdOptionEnabled);
+            savePolicyAndApplySuccessMessage(ppModel, model, messages, successMessage, policy);
+        } catch (PolicyManagerException e) {
+            handlePolicyManagerUpdateError(model, messages, e,
+                    "Error changing ACA DevID Certificate generation policy",
+                    "Error updating policy. \n" + e.getMessage());
+        }
+
+        // return the redirect
+        return redirectToSelf(new NoPageParams(), model, attr);
+    }
+
+    /**
      * Updates the state of the policy setting that indicates that the generation
      * will occur in a set time frame and redirects
      * back to the original page.
@@ -318,6 +362,76 @@ public class PolicyPageController extends PageController<NoPageParams> {
 
     /**
      * Updates the state of the policy setting that indicates that the generation
+     * will occur in a set time frame and redirects
+     * back to the original page.
+     *
+     * @param ppModel The data posted by the form mapped into an object.
+     * @param attr RedirectAttributes used to forward data back to the original page.
+     * @return View containing the url and parameters
+     * @throws URISyntaxException if malformed URI
+     */
+    @RequestMapping(value = "update-devid-expire-on", method = RequestMethod.POST)
+    public RedirectView updateDevIdExpireOnVal(@ModelAttribute final PolicyPageModel ppModel,
+                                          final RedirectAttributes attr)
+            throws URISyntaxException {
+
+        // set the data received to be populated back into the form
+        Map<String, Object> model = new HashMap<>();
+        PageMessages messages = new PageMessages();
+        String successMessage;
+        String numOfDays;
+
+        boolean generateDevIdCertificateEnabled = false;
+        // because this is just one option, there is not 'unchecked' value, so it is either
+        // 'checked' or null
+        if (ppModel.getDevIdExpirationChecked() != null) {
+            generateDevIdCertificateEnabled
+                    = ppModel.getDevIdExpirationChecked()
+                    .equalsIgnoreCase(ENABLED_CHECKED_PARAMETER_VALUE);
+        }
+
+        try {
+            SupplyChainPolicy policy = getDefaultPolicyAndSetInModel(ppModel, model);
+            boolean issuedDevIdOptionEnabled
+                    = policy.isIssueDevIdCertificate();
+
+            if (issuedDevIdOptionEnabled) {
+                if (generateDevIdCertificateEnabled) {
+                    successMessage = "DevID Certificate generation expiration time enabled.";
+                } else {
+                    successMessage = "DevID Certificate generation expiration time disabled.";
+                }
+
+                if (generateDevIdCertificateEnabled) {
+                    numOfDays = ppModel.getDevIdExpirationValue();
+                    if (numOfDays == null) {
+                        numOfDays = SupplyChainPolicy.TEN_YEARS;
+                    }
+                } else {
+                    numOfDays = policy.getDevIdValidityDays();
+                }
+
+                policy.setDevIdValidityDays(numOfDays);
+            } else {
+                generateDevIdCertificateEnabled = false;
+                successMessage = "DevID Certificate generation is disabled, "
+                        + "can not set time expiration";
+            }
+
+            policy.setDevIdExpirationFlag(generateDevIdCertificateEnabled);
+            savePolicyAndApplySuccessMessage(ppModel, model, messages, successMessage, policy);
+        } catch (PolicyManagerException e) {
+            handlePolicyManagerUpdateError(model, messages, e,
+                    "Error changing ACA DevID Certificate generation policy",
+                    "Error updating policy. \n" + e.getMessage());
+        }
+
+        // return the redirect
+        return redirectToSelf(new NoPageParams(), model, attr);
+    }
+
+    /**
+     * Updates the state of the policy setting that indicates that the generation
      * will occur in a set time frame from the end validity date and redirects
      * back to the original page.
      *
@@ -379,6 +493,75 @@ public class PolicyPageController extends PageController<NoPageParams> {
         } catch (PolicyManagerException e) {
             handlePolicyManagerUpdateError(model, messages, e,
                     "Error changing ACA Attestation Certificate generation policy",
+                    "Error updating policy. \n" + e.getMessage());
+        }
+
+        // return the redirect
+        return redirectToSelf(new NoPageParams(), model, attr);
+    }
+
+    /**
+     * Updates the state of the policy setting that indicates that the generation
+     * will occur in a set time frame from the end validity date and redirects
+     * back to the original page.
+     *
+     * @param ppModel The data posted by the form mapped into an object.
+     * @param attr RedirectAttributes used to forward data back to the original page.
+     * @return View containing the url and parameters
+     * @throws URISyntaxException if malformed URI
+     */
+    @RequestMapping(value = "update-devid-threshold", method = RequestMethod.POST)
+    public RedirectView updateDevIdThresholdVal(@ModelAttribute final PolicyPageModel ppModel,
+                                           final RedirectAttributes attr)
+            throws URISyntaxException {
+        // set the data received to be populated back into the form
+        Map<String, Object> model = new HashMap<>();
+        PageMessages messages = new PageMessages();
+        String successMessage;
+        String threshold;
+
+        boolean generateDevIdCertificateEnabled = false;
+        // because this is just one option, there is not 'unchecked' value, so it is either
+        // 'checked' or null
+        if (ppModel.getDevIdExpirationChecked() != null) {
+            generateDevIdCertificateEnabled
+                    = ppModel.getDevIdExpirationChecked()
+                    .equalsIgnoreCase(ENABLED_CHECKED_PARAMETER_VALUE);
+        }
+
+        try {
+            SupplyChainPolicy policy = getDefaultPolicyAndSetInModel(ppModel, model);
+            boolean issuedDevIdOptionEnabled
+                    = policy.isIssueDevIdCertificate();
+
+            if (issuedDevIdOptionEnabled) {
+                if (generateDevIdCertificateEnabled) {
+                    successMessage = "DevID Certificate generation threshold time enabled.";
+                } else {
+                    successMessage = "DevID Certificate generation threshold time disabled.";
+                }
+
+                if (generateDevIdCertificateEnabled) {
+                    threshold = ppModel.getDevIdThresholdValue();
+                    if (threshold == null) {
+                        threshold = SupplyChainPolicy.YEAR;
+                    }
+                } else {
+                    threshold = ppModel.getDevIdReissueThreshold();
+                }
+
+                policy.setDevIdReissueThreshold(threshold);
+            } else {
+                generateDevIdCertificateEnabled = false;
+                successMessage = "DevID Certificate generation is disabled, "
+                        + "can not set time expiration";
+            }
+
+            policy.setDevIdExpirationFlag(generateDevIdCertificateEnabled);
+            savePolicyAndApplySuccessMessage(ppModel, model, messages, successMessage, policy);
+        } catch (PolicyManagerException e) {
+            handlePolicyManagerUpdateError(model, messages, e,
+                    "Error changing ACA DevID Certificate generation policy",
                     "Error updating policy. \n" + e.getMessage());
         }
 

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/index.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/index.jsp
@@ -55,10 +55,10 @@
                     </div>
                     <h3>
                         <a href="${certificateRequest}/issued-certificates">
-                            <img src="${icons}/ic_library_books_black_24dp.png" /> Issued Attestation Certificates
+                            <img src="${icons}/ic_library_books_black_24dp.png" /> Issued Certificates
                         </a>
                     </h3>        
-                    <h4>View Attestation Certificates issued by this CA</h4>
+                    <h4>View Certificates issued by this CA</h4>
                     <h3>
                         <a href="${portal}/validation-reports"><img src="${icons}/ic_assignment_black_24dp.png" /> Validation Reports</a>
                     </h3> 

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/issued-certificates.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/issued-certificates.jsp
@@ -12,7 +12,7 @@
     <jsp:attribute name="script">
         <script type="text/javascript" src="${lib}/jquery.spring-friendly/jquery.spring-friendly.js"></script>
     </jsp:attribute>
-    <jsp:attribute name="pageHeaderTitle">Issued Attestation Certificates</jsp:attribute>
+    <jsp:attribute name="pageHeaderTitle">Issued Certificates</jsp:attribute>
 
     <jsp:body>
         <div class="aca-data-table">

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
@@ -162,10 +162,10 @@
             </div>
             <br />
 
-            <%-- Generate DevID Certificate--%>
+            <%-- Generate LDevID Certificate--%>
             <div class="aca-input-box">
                 <form:form method="POST" modelAttribute="initialData" action="policy/update-issue-devid">
-                    <li>Generate DevID Certificate: ${initialData.issueDevIdCertificate ? 'Enabled' : 'Disabled'}
+                    <li>Generate LDevID Certificate: ${initialData.issueDevIdCertificate ? 'Enabled' : 'Disabled'}
                         <my:editor id="issuedDevIdCertificatePolicyEditor" label="Edit Settings">
                             <div class="radio">
                                 <label><input id="devIdTop" type="radio" name="devIdCertificateIssued" ${initialData.issueDevIdCertificate ? '' : 'checked'} value="unchecked"/> Never generate a DevID Certificate</label>
@@ -177,12 +177,12 @@
                 </form:form>
                     <ul>
                         <form:form method="POST" modelAttribute="initialData" action="policy/update-devid-expire-on">
-                            <li>DevID Certificate Validity period: ${initialData.devIdExpirationFlag ? 'Enabled' : 'Disabled'}
+                            <li>LDevID Certificate Validity period: ${initialData.devIdExpirationFlag ? 'Enabled' : 'Disabled'}
                                 <my:editor id="issuedDevIdCertificatePolicyExpirationEditor" label="Edit Settings">
                                     <div class="radio">
                                         <label>
                                         <input id="devIdBot" type="checkbox" name="devIdExpirationChecked" ${initialData.devIdExpirationFlag ? 'checked' : ''} value="checked" />
-                                        Attestation Certificate validity period (Default 3651 days)<br />
+                                        LDevID Certificate validity period (Default 3651 days)<br />
                                         Select period in days: <input id="devIdExpirationValue" type="text" name="devIdExpirationValue" value="${initialData.devIdExpirationValue}" />
                                         </label>
                                     </div>
@@ -190,12 +190,12 @@
                             </li>
                         </form:form>
                         <form:form method="POST" modelAttribute="initialData" action="policy/update-devid-threshold">
-                            <li>DevID Certificate Renewal period: ${initialData.devIdExpirationFlag ? 'Enabled' : 'Disabled'}
+                            <li>LDevID Certificate Renewal period: ${initialData.devIdExpirationFlag ? 'Enabled' : 'Disabled'}
                                 <my:editor id="issuedDevIdCertificatePolicyGenerateEditor" label="Edit Settings">
                                     <div class="radio">
                                         <label>
                                         <input id="devIdBot" type="checkbox" name="devIdExpirationChecked" ${initialData.devIdExpirationFlag ? 'checked' : ''} value="checked" />
-                                        Renew 'n' days before DevID Certificate's  'Not After' Validity date (Default 365 days)<br />
+                                        Renew 'n' days before LDevID Certificate's  'Not After' Validity date (Default 365 days)<br />
                                         Select 'n' period in days: <input id="devIdThresholdValue" type="text" name="devIdThresholdValue" value="${initialData.devIdThresholdValue}" />
                                         </label>
                                     </div>

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
@@ -116,6 +116,7 @@
                 </li>
             </div>
             <br />
+
             <%-- Generate Attestation Certificate--%>
             <div class="aca-input-box">
                 <form:form method="POST" modelAttribute="initialData" action="policy/update-issue-attestation">
@@ -129,8 +130,8 @@
                             </div>
                         </my:editor>
                 </form:form>
-                        <ul>
-                <form:form method="POST" modelAttribute="initialData" action="policy/update-expire-on">
+                    <ul>
+                        <form:form method="POST" modelAttribute="initialData" action="policy/update-expire-on">
                             <li>Attestation Certificate Validity period: ${initialData.generateOnExpiration ? 'Enabled' : 'Disabled'}
                                 <my:editor id="issuedCertificatePolicyExpirationEditor" label="Edit Settings">
                                     <div class="radio">
@@ -142,8 +143,8 @@
                                     </div>
                                 </my:editor>
                             </li>
-                </form:form>
-                <form:form method="POST" modelAttribute="initialData" action="policy/update-threshold">
+                        </form:form>
+                        <form:form method="POST" modelAttribute="initialData" action="policy/update-threshold">
                             <li>Attestation Certificate Renewal period: ${initialData.generateOnExpiration ? 'Enabled' : 'Disabled'}
                                 <my:editor id="issuedCertificatePolicyGenerateEditor" label="Edit Settings">
                                     <div class="radio">
@@ -155,9 +156,54 @@
                                     </div>
                                 </my:editor>
                             </li>
+                        </form:form>
+                    </ul>
+                </li>
+            </div>
+            <br />
+
+            <%-- Generate DevID Certificate--%>
+            <div class="aca-input-box">
+                <form:form method="POST" modelAttribute="initialData" action="policy/update-issue-devid">
+                    <li>Generate DevID Certificate: ${initialData.issueDevIdCertificate ? 'Enabled' : 'Disabled'}
+                        <my:editor id="issuedDevIdCertificatePolicyEditor" label="Edit Settings">
+                            <div class="radio">
+                                <label><input id="devIdTop" type="radio" name="devIdCertificateIssued" ${initialData.issueDevIdCertificate ? '' : 'checked'} value="unchecked"/> Never generate a DevID Certificate</label>
+                            </div>
+                            <div class="radio">
+                                <label><input id="devIdMid" type="radio" name="devIdCertificateIssued" ${initialData.issueDevIdCertificate ? 'checked' : ''} value="checked"/> Conditionally generate an DevID Certificate before 'Not After' expiration date</label>
+                            </div>
+                        </my:editor>
                 </form:form>
-                        </ul>
-                    </li>
+                    <ul>
+                        <form:form method="POST" modelAttribute="initialData" action="policy/update-devid-expire-on">
+                            <li>DevID Certificate Validity period: ${initialData.devIdExpirationFlag ? 'Enabled' : 'Disabled'}
+                                <my:editor id="issuedDevIdCertificatePolicyExpirationEditor" label="Edit Settings">
+                                    <div class="radio">
+                                        <label>
+                                        <input id="devIdBot" type="checkbox" name="devIdExpirationChecked" ${initialData.devIdExpirationFlag ? 'checked' : ''} value="checked" />
+                                        Attestation Certificate validity period (Default 3651 days)<br />
+                                        Select period in days: <input id="devIdExpirationValue" type="text" name="devIdExpirationValue" value="${initialData.devIdExpirationValue}" />
+                                        </label>
+                                    </div>
+                                </my:editor>
+                            </li>
+                        </form:form>
+                        <form:form method="POST" modelAttribute="initialData" action="policy/update-devid-threshold">
+                            <li>DevID Certificate Renewal period: ${initialData.devIdExpirationFlag ? 'Enabled' : 'Disabled'}
+                                <my:editor id="issuedDevIdCertificatePolicyGenerateEditor" label="Edit Settings">
+                                    <div class="radio">
+                                        <label>
+                                        <input id="devIdBot" type="checkbox" name="devIdExpirationChecked" ${initialData.devIdExpirationFlag ? 'checked' : ''} value="checked" />
+                                        Renew 'n' days before DevID Certificate's  'Not After' Validity date (Default 365 days)<br />
+                                        Select 'n' period in days: <input id="devIdThresholdValue" type="text" name="devIdThresholdValue" value="${initialData.devIdThresholdValue}" />
+                                        </label>
+                                    </div>
+                                </my:editor>
+                            </li>
+                        </form:form>
+                    </ul>
+                </li>
             </div>
         </ul>
     </jsp:body>

--- a/HIRS_Utils/src/main/java/hirs/data/persist/SupplyChainPolicy.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/SupplyChainPolicy.java
@@ -49,13 +49,25 @@ public class SupplyChainPolicy extends Policy {
     private boolean issueAttestationCertificate = true;
 
     @Column(nullable = false)
+    private boolean issueDevIdCertificate = true;
+
+    @Column(nullable = false)
     private String validityDays = TEN_YEARS;
+
+    @Column(nullable = false)
+    private String devIdValidityDays = TEN_YEARS;
 
     @Column(nullable = false)
     private String reissueThreshold = YEAR;
 
     @Column(nullable = false)
+    private String devIdReissueThreshold = YEAR;
+
+    @Column(nullable = false)
     private boolean generateOnExpiration = false;
+
+    @Column(nullable = false)
+    private boolean devIdExpirationFlag = false;
 
     @Embedded
     private PCRPolicy pcrPolicy = new PCRPolicy();
@@ -238,8 +250,7 @@ public class SupplyChainPolicy extends Policy {
      * valid if their supply chain is otherwise verified.
      *
      * @param enableExpiredCertificateValidation whether or not to allow expired credentials and
-     *                                           certificates to be considered
-     * valid
+     *                                           certificates to be considered valid
      */
     public void setExpiredCertificateValidationEnabled(
             final boolean enableExpiredCertificateValidation) {
@@ -301,6 +312,22 @@ public class SupplyChainPolicy extends Policy {
     }
 
     /**
+     * Returns whether or not to generate an DevID Issued Certificate.
+     * @return current state for generation.
+     */
+    public boolean isIssueDevIdCertificate() {
+        return issueDevIdCertificate;
+    }
+
+    /**
+     * Sets whether or not to generate an DevID Issued Certificate.
+     * @param issueDevIdCertificate the flag for generation.
+     */
+    public void setIssueDevIdCertificate(final boolean issueDevIdCertificate) {
+        this.issueDevIdCertificate = issueDevIdCertificate;
+    }
+
+    /**
      * Getter for the number of days for the certificates validity.
      * @return number of days
      */
@@ -314,6 +341,22 @@ public class SupplyChainPolicy extends Policy {
      */
     public void setValidityDays(final String validityDays) {
         this.validityDays = validityDays;
+    }
+
+    /**
+     * Getter for the number of days for the certificates validity.
+     * @return number of days
+     */
+    public String getDevIdValidityDays() {
+        return devIdValidityDays;
+    }
+
+    /**
+     * Setter for the number of days for validity.
+     * @param devIdValidityDays validity.
+     */
+    public void setDevIdValidityDays(final String devIdValidityDays) {
+        this.devIdValidityDays = devIdValidityDays;
     }
 
     /**
@@ -335,6 +378,24 @@ public class SupplyChainPolicy extends Policy {
     }
 
     /**
+     * Getter for the number of days before the expiration to reissue
+     * a certificate.
+     * @return number of days
+     */
+    public String getDevIdReissueThreshold() {
+        return devIdReissueThreshold;
+    }
+
+    /**
+     * Setter for the number of days before the expiration to reissue
+     * a certificate.
+     * @param devIdReissueThreshold validity.
+     */
+    public void setDevIdReissueThreshold(final String devIdReissueThreshold) {
+        this.devIdReissueThreshold = devIdReissueThreshold;
+    }
+
+    /**
      * Getter for the state of when to generate a certificate.
      * @return true or false
      */
@@ -348,5 +409,21 @@ public class SupplyChainPolicy extends Policy {
      */
     public void setGenerateOnExpiration(final boolean generateOnExpiration) {
         this.generateOnExpiration = generateOnExpiration;
+    }
+
+    /**
+     * Getter for the state of when to generate a certificate.
+     * @return true or false
+     */
+    public boolean isDevIdExpirationFlag() {
+        return devIdExpirationFlag;
+    }
+
+    /**
+     * Setter for the state of when to generate a certificate.
+     * @param devIdExpirationFlag sets true or false
+     */
+    public void setDevIdExpirationFlag(final boolean devIdExpirationFlag) {
+        this.devIdExpirationFlag = devIdExpirationFlag;
     }
 }


### PR DESCRIPTION
This is an initial commit updates the policy page.  Adds additional policies for generating a DevID.  The underlying code doesn't actually generate one yet.  But the SupplyChainPolicy holds the flags.

```
- Generate DevID Certificate: Disabled 
-- DevID Certificate Validity period: Disabled 
-- DevID Certificate Renewal period: Disabled

```
This mimics the normal attestation setup.