### PR TITLE
Supplemental RIM Hash Fix

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/PageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/PageController.java
@@ -92,7 +92,6 @@ public abstract class PageController<P extends PageParams> {
      * @return A generic ModelAndView containing basic information for the page.
      */
     protected final ModelAndView getBaseModelAndView(final Page newPage) {
-
         ModelMap modelMap = new ExtendedModelMap();
 
         // add page information
@@ -110,7 +109,6 @@ public abstract class PageController<P extends PageParams> {
         }
 
         return new ModelAndView(newPage.getViewName(), modelMap);
-
     }
 
     /**
@@ -170,7 +168,5 @@ public abstract class PageController<P extends PageParams> {
         }
 
         return redirect;
-
     }
-
 }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -385,7 +385,7 @@ public class ReferenceManifestDetailsPageController
         // starts off checking if associated rim is null; that is irrelevant for
         // this statement.
         measurements = EventLogMeasurements.select(referenceManifestManager)
-                .byHexDecHash(support.getEventLogHash()).getRIM();
+                .byHexDecHash(support.getHexDecHash()).getRIM();
 
         if (support.isSwidPatch()) {
             data.put("swidPatch", "True");

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
@@ -160,7 +160,6 @@ public class ReferenceManifestPageController
             @Override
             public void modify(final Criteria criteria) {
                 criteria.add(Restrictions.isNull(Certificate.ARCHIVE_FIELD));
-
             }
         };
         FilteredRecordsList<ReferenceManifest> records


### PR DESCRIPTION
The look up for a supplemental RIM was using the wrong hash string to search the DB.  This caused the link between the swid tag and supplemental to be broken.

This fixes the issue.