### PR TITLE
Support RIM Filename Fix

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -286,7 +286,7 @@ public class ReferenceManifestDetailsPageController
         // to get the id to make the link
         for (SwidResource swidRes : resources) {
             if (support != null && swidRes.getName()
-                    .equals(support.getFileName())) {
+                    .equalsIgnoreCase(support.getFileName())) {
                 RIM_VALIDATOR.validateSupportRimHash(support.getRimBytes(),
                         swidRes.getHashValue());
                 if (RIM_VALIDATOR.isSupportRimValid()) {

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -285,8 +285,8 @@ public class ReferenceManifestDetailsPageController
         // going to have to pull the filename and grab that from the DB
         // to get the id to make the link
         for (SwidResource swidRes : resources) {
-            if (support != null && swidRes.getName()
-                    .equalsIgnoreCase(support.getFileName())) {
+            if (support != null && swidRes.getHashValue()
+                    .equalsIgnoreCase(support.getHexDecHash())) {
                 RIM_VALIDATOR.validateSupportRimHash(support.getRimBytes(),
                         swidRes.getHashValue());
                 if (RIM_VALIDATOR.isSupportRimValid()) {

--- a/HIRS_Utils/src/main/java/hirs/utils/JsonUtils.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/JsonUtils.java
@@ -84,7 +84,7 @@ public final class JsonUtils {
         JsonObject jsonObject = new JsonObject();
 
         if (Files.notExists(jsonPath)) {
-            LOGGER.error(String.format("No file found at %s.", jsonPath.toString()));
+            LOGGER.warn(String.format("No file found at %s.", jsonPath.toString()));
         } else {
             try {
                 InputStream inputStream = new FileInputStream(jsonPath.toString());


### PR DESCRIPTION
The rim hash validation icon is coming up red when both base and support RIMs are loaded.  This fixes that issue.

The file name of the associated resource file (support RIM) in the swidTag did not match the actual file name of the support rim.  This causes the if condition that leads to the support rim hash check to fail.  The if condition has now been changed to ignore case since a small port of the file name was different.