### PR TITLE
[#409] Loop will exit if delta component is matched.

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java
@@ -659,14 +659,17 @@ public final class SupplyChainCredentialValidator implements CredentialValidator
                             // error
                             resultMessage.append("ADDED attempted with prior instance\n");
                             deltaSb.append(String.format("%s;", ci.hashCode()));
+                            break;
                         }
                         if (ciV2.isModified()) {
                             // since the base list doesn't have this ci
                             // just add the delta
                             baseCompList.add(deltaCi);
+                            break;
                         }
                         if (ciV2.isRemoved()) {
                             baseCompList.remove(ciV2);
+                            break;
                         }
                         // if it is a remove
                         // we do nothing because baseCompList doesn't have it


### PR DESCRIPTION
https://github.com/nsacyber/HIRS/blob/3f9c6c9d444ebc3611f0c763f905de399680654e/HIRS_Utils/src/main/java/hirs/validation/SupplyChainCredentialValidator.java#L658-L669

This loop needs to exit if the component from the delta cert is matched. Otherwise the loop will continue to try to match the additional components which will not match and could throw errors. This fix will get me past my current issue.