### PR TITLE
Cpp Compiler Warning fixes

### DIFF
--- a/HIRS_ProvisionerTPM2/src/DeviceInfoCollector.cpp
+++ b/HIRS_ProvisionerTPM2/src/DeviceInfoCollector.cpp
@@ -208,15 +208,18 @@ hirs::pb::OsInfo DeviceInfoCollector::collectOsInfo() {
         while (getline(releaseFile, line)) {
             stringstream ss(line);
             string item;
-            vector<string> tokens;
+            std::vector<string> tokens;
             char* delim = const_cast<char*>("=");
             while (getline(ss, item, *delim)) {
                 tokens.push_back(item);
             }
-            if (tokens.size() > 0 && tokens.at(0) == "ID") {
-                info.set_distribution(tokens.at(1));
-            } else if (tokens.size() > 0 && tokens.at(0) == "VERSION_ID") {
-                info.set_distributionrelease(tokens.at(1));
+            for (int i=0; i < tokens.size(); i++) {
+                if (tokens[i] == "ID") {
+                    info.set_distribution(tokens[i+1]);
+                }
+                if (tokens[i] == "VERSION_ID") {
+                    info.set_distributionrelease(tokens[i+1]);
+                }
             }
         }
         releaseFile.close();

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -178,7 +178,7 @@ void printHelp() {
     cout << helpMessage.str() << endl;
 }
 
-int main(int argc, char** argv) {
+int main(int argc, const char** argv) {
     string log_directory = "/var/log/hirs/provisioner";
 
     // directory should be created by rpm install


### PR DESCRIPTION
There are warning that newer compilers are throwing for vector.at and vector.size.  These are removed.  In addition a char** in a main parameter was made into a const.