### PR TITLE
Vendor Table JSON refactor

### DIFF
--- a/package/rpm/HIRS.spec
+++ b/package/rpm/HIRS.spec
@@ -260,7 +260,7 @@ fi
 %attr(664, root, tomcat) /opt/hirs/default-properties/attestationca/banner.properties
 %attr(664, root, tomcat) /opt/hirs/default-properties/attestationca/persistence.properties
 %attr(664, root, tomcat) /opt/hirs/default-properties/component-class.json
-%attr(664, root, tomcat) /opt/hirs/default-properties/attestationca/vendor-table.json
+%attr(664, root, tomcat) /opt/hirs/default-properties/vendor-table.json
 %attr(774, root, tomcat) /opt/hirs/scripts/common/aca
 %attr(774, root, tomcat) /opt/hirs/scripts/aca
 %attr(774, root, tomcat) /opt/hirs/extras/aca/tomcat-mysql-hirs.pp
@@ -330,7 +330,7 @@ cp HIRS_Utils/src/main/resources/persistence.properties %{buildroot}/opt/hirs/de
 cp HIRS_Utils/src/main/resources/logging.properties %{buildroot}/opt/hirs/default-properties/attestationca/
 cp HIRS_Utils/src/main/resources/banner.properties %{buildroot}/opt/hirs/default-properties/attestationca/
 cp HIRS_Utils/src/main/resources/component-class.json %{buildroot}/opt/hirs/default-properties/
-cp HIRS_Utils/src/main/resources/vendor-table.json %{buildroot}/opt/hirs/default-properties/attestationca/
+cp -n HIRS_Utils/src/main/resources/vendor-table.json %{buildroot}/opt/hirs/default-properties/
 
 # install extras
 mkdir -p %{buildroot}/opt/hirs/extras

--- a/tools/tcg_eventlog_tool/README.md
+++ b/tools/tcg_eventlog_tool/README.md
@@ -31,7 +31,7 @@ In both cases the tcg_eventlog_tool-X.X.jar file should have been placed in the 
 Currenty only a install file for Linux RPM is supported.
 
 To create an RPM on a linux device use the following command in the dame directory:
-> ./gradlew builRPM
+> ./gradlew buildRPM
 
 # Installing
 Currenty only a install package for Linux is supported. 

--- a/tools/tcg_eventlog_tool/build.gradle
+++ b/tools/tcg_eventlog_tool/build.gradle
@@ -108,13 +108,15 @@ ospackage {
         link("/usr/local/bin/elt", "/opt/hirs/eventlog/scripts/eventlog.sh", 0x755)
     }
 
-    into('/opt/hirs/default-properties/eventlogtool') {
+    into('/tmp/') {
         fileMode 0664
         from ('../../HIRS_Utils/src/main/resources/vendor-table.json') {
             addParentDirs true
             createDirectoryEntry true
         }
     }
+
+    postInstall file('scripts/vendor-table.sh')
 
     buildRpm {
         arch = I386

--- a/tools/tcg_eventlog_tool/scripts/vendor-table.sh
+++ b/tools/tcg_eventlog_tool/scripts/vendor-table.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+HIRS_DIR="/opt/hirs/default-properties"
+VENDOR_FILE="vendor-table.json"
+
+# check that the directory exists
+if [ ! -d "$HIRS_DIR" ]; then
+  mkdir -p $HIRS_DIR
+fi
+
+# in case there was a problem, still check and if all is well
+# move the file with no-clobber
+if [ -d "$HIRS_DIR" ]; then
+  # if the file doesn't exist
+  if [ ! -f "$HIRS_DIR/$VENDOR_FILE" ]; then
+    mv -n "/tmp/$VENDOR_FILE" $HIRS_DIR
+    chmod 0644 "$HIRS_DIR/$VENDOR_FILE"
+  else
+    # if it does, then just remove the tmp folder version
+    rm "/tmp/$VENDOR_FILE"
+  fi
+fi


### PR DESCRIPTION
This commit updates the location of the vendor-table.json which is used by the ACA and the eventlog tool.  The previous change moved the vendor-table.json to a separate folder, however the code was not updated to reflect the change.  This instead updates how the two install handle the file.  The ACA was updated not to clobber the file if it exists and the eventlog tool was updated to do the same through an additional script during post install.

This was tested by installing the ACA first, then the eventlog tool.  And then tested in reverse, both attempts passed without crashing.