### PR TITLE
RimLinkHash Fix

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -231,13 +231,11 @@ public class ReferenceManifestDetailsPageController
         data.put("entityThumbprint", baseRim.getEntityThumbprint());
         // Link
         data.put("linkHref", baseRim.getLinkHref());
+        data.put("linkHrefLink", "");
         for (BaseReferenceManifest bRim : BaseReferenceManifest
                 .select(referenceManifestManager).getRIMs()) {
             if (baseRim.getLinkHref().contains(bRim.getTagId())) {
-                data.put("linkHrefLink", bRim.getId().toString());
-                break;
-            } else {
-                data.put("linkHrefLink", "");
+                data.put("linkHrefLink", bRim.getId());
             }
         }
         data.put("linkRel", baseRim.getLinkRel());
@@ -255,16 +253,16 @@ public class ReferenceManifestDetailsPageController
         data.put("pcUriGlobal", baseRim.getPcURIGlobal());
         data.put("pcUriLocal", baseRim.getPcURILocal());
         data.put("rimLinkHash", baseRim.getRimLinkHash());
-        boolean hashLinked = false;
         if (baseRim.getRimLinkHash() != null) {
             ReferenceManifest rim = BaseReferenceManifest.select(referenceManifestManager)
-                    .byBase64Hash(baseRim.getRimLinkHash()).getRIM();
-            hashLinked = (rim != null);
-            if (hashLinked) {
+                    .byHexDecHash(baseRim.getRimLinkHash()).getRIM();
+            if (rim != null) {
                 data.put("rimLinkId", rim.getId());
+                data.put("linkHashValid", true);
+            } else {
+                data.put("linkHashValid", false);
             }
         }
-        data.put("linkHashValid", hashLinked);
         data.put("rimType", baseRim.getRimType());
 
         List<SwidResource> resources = baseRim.parseResource();

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
@@ -371,7 +371,7 @@
                             <div>
                                 <span>
                                     <c:choose>
-                                        <c:when test="${initialData.linkRel=='requires'}">
+                                        <c:when test="${not empty initialData.linkHrefLink}">
                                             <a href="${portal}/rim-details?id=${initialData.linkHrefLink}" rel="${initialData.linkRel}">${initialData.linkHref}</a>
                                         </c:when>
                                         <c:otherwise>

--- a/HIRS_Utils/src/main/java/hirs/data/persist/BaseReferenceManifest.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/BaseReferenceManifest.java
@@ -130,6 +130,16 @@ public class BaseReferenceManifest extends ReferenceManifest {
             setFieldValue(BASE_64_HASH_FIELD, base64Hash);
             return this;
         }
+
+        /**
+         * Specify the RIM hash associated with the base RIM.
+         * @param hexDecHash the hash of the file associated with the rim
+         * @return this instance
+         */
+        public Selector byHexDecHash(final String hexDecHash) {
+            setFieldValue(HEX_DEC_HASH_FIELD, hexDecHash);
+            return this;
+        }
     }
 
     /**


### PR DESCRIPTION
The rimlinkhash meta information wasn't linking up with the associated swidtag.  This is because the wrong hash look up was being used.  Previously when the hexDecHash and base64Hash were implemented, the main focus was on the rimel and not the swidtag.