### PR TITLE
[#418] Change json parsing package

### DIFF
--- a/tools/tcg_rim_tool/build.gradle
+++ b/tools/tcg_rim_tool/build.gradle
@@ -6,7 +6,7 @@ repositories {
 }
 
 dependencies {
-	compile 'com.eclipsesource.minimal-json:minimal-json:0.9.5', 'com.beust:jcommander:1.72', 'org.bouncycastle:bcmail-jdk15on:1.59'
+	compile 'javax.json:javax.json-api:1.1.4', 'org.glassfish:javax.json:1.1.4',  'com.beust:jcommander:1.72', 'org.bouncycastle:bcmail-jdk15on:1.59'
 	testCompile 'org.testng:testng:6.8.8'
 }
 


### PR DESCRIPTION
Changing the json parser from com.eclipsesource.json to javax.json resolved the issue where a quoted boolean value in the json attributes file (e.g. "patch": "false") caused the rim tool to output an invalid swidtag.

Closes #418 