### PR TITLE
[#423] Default signing credentials option for tcg_rim_tool

### DIFF
--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -49,6 +49,7 @@ public class Main {
                 String jksTruststoreFile = commander.getTruststoreFile();
                 String certificateFile = commander.getPublicCertificate();
                 String privateKeyFile = commander.getPrivateKeyFile();
+                boolean defaultKey = commander.isDefaultKey();
                 String rimEventLog = commander.getRimEventLog();
                 switch (createType) {
                     case "BASE":
@@ -62,9 +63,13 @@ public class Main {
                             gateway.setDefaultCredentials(false);
                             gateway.setPemCertificateFile(certificateFile);
                             gateway.setPemPrivateKeyFile(privateKeyFile);
-                        } else {
+                        } else if (defaultKey){
                             gateway.setDefaultCredentials(true);
                             gateway.setJksTruststoreFile(SwidTagConstants.DEFAULT_KEYSTORE_FILE);
+                        } else {
+                            System.out.println("A private key (-k) and public certificate (-p) " +
+                                    "are required, or the default key (-d) must be indicated.");
+                            System.exit(1);
                         }
                         if (rimEventLog.isEmpty()) {
                             System.out.println("Error: a support RIM is required!");

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -36,6 +36,9 @@ public class Commander {
             description = "The public key certificate to embed in the base RIM created by "
             + "this tool.")
     private String publicCertificate = "";
+    @Parameter(names = {"-d", "--default-key"},
+            description = "Use default signing credentials.")
+    private boolean defaultKey = false;
     @Parameter(names = {"-l", "--rimel <path>"}, order = 7,
             description = "The TCG eventlog file to use as a support RIM.")
     private String rimEventLog = "";
@@ -70,14 +73,16 @@ public class Commander {
         return publicCertificate;
     }
 
+    public boolean isDefaultKey() { return defaultKey; }
+
     public String getRimEventLog() { return rimEventLog; }
 
     public String printHelpExamples() {
         StringBuilder sb = new StringBuilder();
         sb.append("Create a base RIM using the values in attributes.json; " +
-                "sign it with the default keystore, alias, and password;\n");
+                "sign it with the default keystore; ");
         sb.append("and write the data to base_rim.swidtag:\n\n");
-        sb.append("\t\t-c base -a attributes.json -l support_rim.bin -o base_rim.swidtag\n\n\n");
+        sb.append("\t\t-c base -a attributes.json -d -l support_rim.bin -o base_rim.swidtag\n\n\n");
         sb.append("Create a base RIM using the default attribute values; ");
         sb.append("sign it using privateKey.pem; embed cert.pem in the signature block; ");
         sb.append("and write the data to console output:\n\n");
@@ -103,9 +108,11 @@ public class Commander {
                     !this.getPublicCertificate().isEmpty()) {
             sb.append("Private key file: " + this.getPrivateKeyFile() + System.lineSeparator());
             sb.append("Public certificate: " + this.getPublicCertificate() + System.lineSeparator());
-        } else {
+        } else if (this.isDefaultKey()){
             sb.append("Truststore file: default (" + SwidTagConstants.DEFAULT_KEYSTORE_FILE + ")"
                     + System.lineSeparator());
+        } else {
+            sb.append("Signing credential: (none given)" + System.lineSeparator());
         }
         sb.append("Event log support RIM: " + this.getRimEventLog() + System.lineSeparator());
         return sb.toString();


### PR DESCRIPTION
These changes require the user to give signing credentials via -k and -p, or indicate default credentials via -d.  If neither case is true then the tool exits with an error message.

Closes #423 