### PR TITLE
Protobuf Credential Blob check fix

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/AbstractAttestationCertificateAuthority.java
@@ -439,10 +439,11 @@ public abstract class AbstractAttestationCertificateAuthority
             }
         }
 
+        ByteString blobStr = ByteString.copyFrom(new byte[]{});
         if (validationResult == AppraisalStatus.Status.PASS) {
             RSAPublicKey akPub = parsePublicKey(claim.getAkPublicArea().toByteArray());
             byte[] nonce = generateRandomBytes(NONCE_LENGTH);
-            ByteString blobStr = tpm20MakeCredential(ekPub, akPub, nonce);
+            blobStr = tpm20MakeCredential(ekPub, akPub, nonce);
             SupplyChainPolicy scp = this.supplyChainValidationService.getPolicy();
             String pcrQuoteMask = PCR_QUOTE_MASK;
 
@@ -465,7 +466,12 @@ public abstract class AbstractAttestationCertificateAuthority
         } else {
             LOG.error("Supply chain validation did not succeed. Result is: "
                     + validationResult);
-            return new byte[]{};
+            // empty response
+            ProvisionerTpm2.IdentityClaimResponse response
+                    = ProvisionerTpm2.IdentityClaimResponse.newBuilder()
+                    .setCredentialBlob(blobStr)
+                    .build();
+            return response.toByteArray();
         }
     }
 

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -154,7 +154,7 @@ int provision() {
     string nonceBlob = icr.credential_blob();
     if (nonceBlob == "") {
         cout << "----> Provisioning failed." << endl;
-        cout << "The ACA did not send make credential information." << endl;
+        cout << "The ACA sent empty credential information." << endl;
         return 0;
     }
 

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -143,10 +143,16 @@ int provision() {
     RestfulClientProvisioner provisioner;
     string response = provisioner.sendIdentityClaim(identityClaim);
     hirs::pb::IdentityClaimResponse icr;
-    if (!icr.ParseFromString(response) || !icr.has_credential_blob()) {
-        cout << "----> Provisioning failed." << endl;
-        cout << "The ACA did not send make credential information." << endl;
-        return 0;
+
+    try {
+        if (response == "" || !icr.has_credential_blob()) {
+            logger.error("The ACA did not send make credential blob.");
+            cout << "----> Provisioning failed." << endl;
+            cout << "The ACA did not send make credential information." << endl;
+            return 0;
+        }
+    } catch (const google::protobuf::FatalException& e) {
+        logger.error(e.what());
     }
 
     string nonceBlob = icr.credential_blob();

--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -144,18 +144,19 @@ int provision() {
     string response = provisioner.sendIdentityClaim(identityClaim);
     hirs::pb::IdentityClaimResponse icr;
 
-    try {
-        if (response == "" || !icr.has_credential_blob()) {
-            logger.error("The ACA did not send make credential blob.");
-            cout << "----> Provisioning failed." << endl;
-            cout << "The ACA did not send make credential information." << endl;
-            return 0;
-        }
-    } catch (const google::protobuf::FatalException& e) {
-        logger.error(e.what());
+    if (!icr.ParseFromString(response) || !icr.has_credential_blob()) {
+        logger.error("The ACA did not send make credential blob.");
+        cout << "----> Provisioning failed." << endl;
+        cout << "The ACA did not send make credential information." << endl;
+        return 0;
     }
 
     string nonceBlob = icr.credential_blob();
+    if (nonceBlob == "") {
+        cout << "----> Provisioning failed." << endl;
+        cout << "The ACA did not send make credential information." << endl;
+        return 0;
+    }
 
     // activateIdentity requires we read makeCredential output from a file
     cout << "----> Received response. Attempting to decrypt nonce" << endl;


### PR DESCRIPTION
The provisioner was throwing an error to the standard printout because of protobuf. This had to do with the recent change to checking the Identity Claim Response and the use of the has_credentialBlob check.