### PR TITLE
[#437] Add versioning to tcg_rim_tool RPM name

### DIFF
--- a/tools/tcg_rim_tool/build.gradle
+++ b/tools/tcg_rim_tool/build.gradle
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-	compile 'javax.json:javax.json-api:1.1.4', 'org.glassfish:javax.json:1.1.4',  'com.beust:jcommander:1.72', 'org.bouncycastle:bcmail-jdk15on:1.59'
+	compile 'javax.json:javax.json-api:1.1.4', 'org.glassfish:javax.json:1.1.4', 'com.beust:jcommander:1.72', 'org.bouncycastle:bcmail-jdk15on:1.59'
 	testCompile 'org.testng:testng:6.8.8'
 }
 

--- a/tools/tcg_rim_tool/build.gradle
+++ b/tools/tcg_rim_tool/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'java'
-version = '2.1.0'
 
 repositories {
 	mavenCentral()

--- a/tools/tcg_rim_tool/package.sh
+++ b/tools/tcg_rim_tool/package.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
+VERSION=2.1.0
+GIT_HASH=`git rev-parse HEAD | head -c6`
+GIT_COMMIT_UNIX_TIMESTAMP=`git show -s --format=%ct | xargs echo -n`
+RELEASE="$((GIT_COMMIT_UNIX_TIMESTAMP)).$GIT_HASH"
+name="tcg_rim_tool"
 
 # Enter package directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 pushd $SCRIPT_DIR
 
-name="tcg_rim_tool"
-
-tar -cf $name.tar build.gradle gradle* src/ docs/ rim_fields.json keystore.jks scripts/
-gzip -f $name.tar
+tar -cf "$name-$VERSION.$RELEASE".tar build.gradle gradle* src/ docs/ rim_fields.json keystore.jks scripts/
+gzip -f "$name-$VERSION.$RELEASE".tar
 if [ -d rpmbuild ]; then
 	rm -rf rpmbuild
 fi
 mkdir -p rpmbuild/BUILD rpmbuild/BUILDROOT rpmbuild/SOURCES rpmbuild/RPMS rpmbuild/SPECS rpmbuild/SRPMS
-rpmbuild -bb $name.spec --define "_sourcedir $PWD" --define "_topdir $PWD/rpmbuild"
+rpmbuild -bb $name.spec --define "_sourcedir $PWD" --define "_topdir $PWD/rpmbuild" --define 'RELEASE '$RELEASE --define 'VERSION '$VERSION
 
 popd

--- a/tools/tcg_rim_tool/tcg_rim_tool.spec
+++ b/tools/tcg_rim_tool/tcg_rim_tool.spec
@@ -12,6 +12,8 @@ BuildRequires:  java-headless >= 1:1.8.0
 %description
 This tool will generate a base RIM file for PC clients in accordance with the schema located at http://standards.iso.org/iso/19770/-2/2015/schema.xsd.  The generated RIM can either be empty if no arguments are given, or contain a payload if an input file is provided.  The tool can also verify a given RIMfile against the schema. Use -h or --help to see a list of commands and uses.
 
+%global __os_install_post %{nil}
+
 %prep
 %setup -q -c -n %{name}
 

--- a/tools/tcg_rim_tool/tcg_rim_tool.spec
+++ b/tools/tcg_rim_tool/tcg_rim_tool.spec
@@ -1,11 +1,11 @@
 Name:           tcg_rim_tool
-Version:        2.1.0
-Release:        1%{?dist}
+Version:        %{?VERSION}
+Release:        %{?RELEASE}
 Summary:        A java command-line tool to create PC client root RIM
 
 License:        ASL 2.0
 URL:            https://github.com/nsacyber/HIRS
-Source0:     	%{name}.tar.gz   
+Source0:     	%{name}-%{version}.%{release}.tar.gz   
 
 BuildRequires:  java-headless >= 1:1.8.0
 
@@ -19,7 +19,7 @@ This tool will generate a base RIM file for PC clients in accordance with the sc
 rm -f /opt/hirs/rimtool/%{name}*.jar
 
 %build
-./gradlew build
+./gradlew -Pversion=%{version} build
 
 %install
 mkdir -p %{buildroot}/opt/hirs/rimtool/ %{buildroot}/usr/local/bin


### PR DESCRIPTION
Changes: 
- Add git timestamp and hash to the rpm name.
- Centralize version number to package.sh.

Closes #437 