### PR TITLE
[#458] Validation Status fix

### DIFF
--- a/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
+++ b/HIRS_ProvisionerTPM2/src/TPM2_Provisioner.cpp
@@ -198,16 +198,18 @@ int provision() {
             = provisioner.sendAttestationCertificateRequest(certificateRequest);
 
     hirs::pb::CertificateResponse cr;
-    if (!cr.ParseFromString(akCertificateByteString) && cr.has_status()) {
+    cr.ParseFromString(akCertificateByteString);
+    if (cr.has_status()) {
         if (cr.status() == hirs::pb::ResponseStatus::FAIL) {
-            cout << "----> Provisioning the quote failed.";
+            cout << "----> Provisioning the quote failed. ";
             cout << "Please refer to the Attestation CA for details." << endl;
             return 0;
         }
     }
 
     if (akCertificateByteString == "") {
-        cout << "----> Provisioning the quote failed.";
+        cout << "----> Provisioning the quote failed. "
+             << "Certificate returned is empty. ";
         cout << "Please refer to the Attestation CA for details." << endl;
         return 0;
     }


### PR DESCRIPTION
This issue didn't actually involve the Device object not updating the validation status.  This is a missed changed for #442 .   The Certificate Response object check caused a problem with reading the response and ignored the status.

Closes #458 
