### PR TITLE
.NET provisioner update usage of static paccor file 

### DIFF
--- a/HIRS_Provisioner.NET/hirs/Resources/ProvisionerTpm2.proto
+++ b/HIRS_Provisioner.NET/hirs/Resources/ProvisionerTpm2.proto
@@ -77,9 +77,15 @@ message TpmQuote {
   required string success = 1;
 }
 
+enum ResponseStatus {
+  PASS = 0;
+  FAIL = 1;
+}
+
 message IdentityClaimResponse {
-  required bytes credential_blob = 1;
+  optional bytes credential_blob = 1;
   optional string pcr_mask = 2;
+  optional ResponseStatus status = 3 [default = FAIL];
 }
 
 message CertificateRequest {
@@ -88,6 +94,7 @@ message CertificateRequest {
 }
 
 message CertificateResponse {
-  required bytes certificate = 1;
+  optional bytes certificate = 1;
+  optional ResponseStatus status = 2 [default = FAIL];
 }
 

--- a/HIRS_Provisioner.NET/hirs/appsettings.json
+++ b/HIRS_Provisioner.NET/hirs/appsettings.json
@@ -20,7 +20,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:HH:mm:ss} {SourceContext} [{Level}] {Message}{NewLine}{Exception}",
+          "outputTemplate": "{Message}{NewLine}",
           "theme": "Serilog.Sinks.SystemConsole.Themes.SystemConsoleTheme::Grayscale, Serilog.Sinks.Console",
 		  "restrictedToMinimumLevel": "Information"
         }

--- a/HIRS_Provisioner.NET/hirs/appsettings.json
+++ b/HIRS_Provisioner.NET/hirs/appsettings.json
@@ -21,7 +21,8 @@
         "Name": "Console",
         "Args": {
           "outputTemplate": "[{Timestamp:HH:mm:ss} {SourceContext} [{Level}] {Message}{NewLine}{Exception}",
-          "theme": "Serilog.Sinks.SystemConsole.Themes.SystemConsoleTheme::Grayscale, Serilog.Sinks.Console"
+          "theme": "Serilog.Sinks.SystemConsole.Themes.SystemConsoleTheme::Grayscale, Serilog.Sinks.Console",
+		  "restrictedToMinimumLevel": "Information"
         }
       },
       {

--- a/HIRS_Provisioner.NET/hirs/src/client/IHirsAcaClient.cs
+++ b/HIRS_Provisioner.NET/hirs/src/client/IHirsAcaClient.cs
@@ -13,7 +13,7 @@ namespace hirs {
         /// <param name="identityClaim">Evidence about the client.</param>
         /// <returns>The <see cref="Task"/>&lt;<see cref="IdentityClaimResponse"/>&gt; from the
         /// ACA. The response is wrapped in a Task.</returns>
-        Task<IdentityClaimResponse> postIdentityClaim(IdentityClaim identityClaim);
+        Task<IdentityClaimResponse> PostIdentityClaim(IdentityClaim identityClaim);
         /// <summary>
         /// Send the <see cref="CertificateRequest"/> to the ACA. The request is delivered
         /// asynchronously to the ACA. However, the client will wait for the response.
@@ -23,7 +23,7 @@ namespace hirs {
         /// <returns>The <see cref="Task"/>&lt;<see cref="CertificateResponse"/>&gt; from the ACA.
         /// The response is wrapped in a Task. It will contain a certificate or the reason why
         /// the certificate request was rejected.</returns>
-        Task<CertificateResponse> postCertificateRequest(CertificateRequest certReq);
+        Task<CertificateResponse> PostCertificateRequest(CertificateRequest certReq);
         /// <summary>
         /// Collect client evidence regarding a Device into an object that can be interpreted by
         /// the ACA.
@@ -37,7 +37,7 @@ namespace hirs {
         /// encoded in DER or PEM.</param>
         /// <param name="paccoroutput">Platform Manifest in a JSON format.</param>
         /// <returns>An <see cref="IdentityClaim"/> object that can be sent to the ACA.</returns>
-        IdentityClaim createIdentityClaim(DeviceInfo dv, byte[] akPublicArea, byte[] ekPublicArea,
+        IdentityClaim CreateIdentityClaim(DeviceInfo dv, byte[] akPublicArea, byte[] ekPublicArea,
                                        byte[] endorsementCredential,
                                        List<byte[]> platformCredentials, string paccoroutput);
         /// <summary>
@@ -48,6 +48,6 @@ namespace hirs {
         /// <param name="ctqr">TPM Quote data from the client Device.</param>
         /// <returns>A <see cref="CertificateRequest"/> object that can be sent to the
         /// ACA.</returns>
-        CertificateRequest createAkCertificateRequest(byte[] secret, CommandTpmQuoteResponse ctqr);
+        CertificateRequest CreateAkCertificateRequest(byte[] secret, CommandTpmQuoteResponse ctqr);
     }
 }

--- a/HIRS_Provisioner.NET/hirs/src/config/CLI.cs
+++ b/HIRS_Provisioner.NET/hirs/src/config/CLI.cs
@@ -1,37 +1,34 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using CommandLine;
+﻿using CommandLine;
 
 namespace hirs {
     public class CLI {
-        [Option(SetName="type", Default = false, HelpText = "Connect to the TPM by IP. Use the format ip:port. By default will connect to " + CommandTpm.DefaultSimulatorNamePort + ".")]
-        public bool tcp {
+        [Option("tcp", SetName="type", Default = false, HelpText = "Connect to the TPM by IP. Use the format ip:port. By default will connect to " + CommandTpm.DefaultSimulatorNamePort + ".")]
+        public bool Tcp {
             get; set;
         }
 
-        [Option(SetName = "type", Default = false, HelpText = "Connect to a Windows TPM device.")]
-        public bool win {
+        [Option("win", SetName = "type", Default = false, HelpText = "Connect to a Windows TPM device.")]
+        public bool Win {
             get; set;
         }
 
-        [Option(SetName = "type", Default = false, HelpText = "Connect to a Linux TPM device.")]
-        public bool nix {
+        [Option("nix", SetName = "type", Default = false, HelpText = "Connect to a Linux TPM device.")]
+        public bool Nix {
             get; set;
         }
 
-        [Option(Default = false, HelpText = "Notify the program of intent to connect to a TPM simulator.")]
-        public bool sim {
+        [Option("sim", Default = false, HelpText = "Notify the program of intent to connect to a TPM simulator.")]
+        public bool Sim {
             get; set;
         }
 
-        [Option(Default = CommandTpm.DefaultSimulatorNamePort, HelpText = "IP of the TPM Device. Use the format ip:port.")]
-        public string ip {
+        [Option("ip", Default = CommandTpm.DefaultSimulatorNamePort, HelpText = "IP of the TPM Device. Use the format ip:port.")]
+        public string Ip {
             get; set;
         }
 
-        [Option(Default = false, HelpText = "Clear any existing hirs AK and create a new one.")]
-        public bool replaceAK {
+        [Option("replaceAK", Default = false, HelpText = "Clear any existing hirs AK and create a new one.")]
+        public bool ReplaceAK {
             get; set;
         }
 

--- a/HIRS_Provisioner.NET/hirs/src/config/ClientExitCodes.cs
+++ b/HIRS_Provisioner.NET/hirs/src/config/ClientExitCodes.cs
@@ -1,0 +1,18 @@
+﻿
+namespace hirs {
+    public enum ClientExitCodes {
+        SUCCESS = 0, // Full successful program completion 
+        FAIL = 1, // Unknown/Generic failure resulting in exit 
+        USER_ERROR = 20, // Generic user error 
+        MISSING_CONFIG = 21, // Config file missing 
+        ACA_UNREACHABLE = 22, // Nothing found at the address specified 
+        NOT_PRIVILEGED = 23, // Client not run as root 
+        EXTERNAL_APP_ERROR = 40, // Generic external application error 
+        TPM_ERROR = 41, // Encountered error with the TPM, log the TPM Return Code 
+        HW_COLLECTION_ERROR = 42, // Encountered error when gathering hardware details 
+        PROVISIONING_ERROR = 60, // Generic provisioning error | 
+        PASS_1_STATUS_FAIL = 61,
+        PASS_2_STATUS_FAIL = 62,
+        MAKE_CREDENTIAL_BLOB_MALFORMED = 63 // The TPM2_MakeCredential blob was not correct 
+    }
+}

--- a/HIRS_Provisioner.NET/hirs/src/config/Settings.cs
+++ b/HIRS_Provisioner.NET/hirs/src/config/Settings.cs
@@ -1,5 +1,4 @@
-﻿using CommandLine;
-using HardwareManifestPlugin;
+﻿using HardwareManifestPlugin;
 using HardwareManifestPluginManager;
 using Microsoft.Extensions.Configuration;
 using Serilog;
@@ -7,8 +6,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Collections.Generic;
 
 namespace hirs {
@@ -192,13 +189,15 @@ namespace hirs {
                     if (!File.Exists(paccor_output_file)) {
                         paccor_output_file = null;
                         Log.Warning(Options.paccor_output_file.ToString() + ": " + paccor_output_file + " does not exist.");
-                    } else if (hardwareManifests.Count > 0) {
+                    } else if (HasHardwareManifestPlugins()) {
                         Log.Warning("The settings file specified hardware manifest collectors and a paccor output file. Fresh data is preferred over data from a file. If you want to use the file data, clear the collectors field from the settings file.");
                     } else {
-                        Log.Debug("Retrieving JSON-formatted components from " + Options.paccor_output_file.ToString() + ".");
+                        Log.Debug("Retrieving components from " + Options.paccor_output_file.ToString() + ".");
                         paccor_output = File.ReadAllText(paccor_output_file);
                         if (string.IsNullOrWhiteSpace(paccor_output)) {
                             Log.Warning(Options.paccor_output_file.ToString() + " Paccor output was empty. Cannot perform Platform Attribute validation.");
+                        } else {
+                            Log.Debug("Output file contains:\n" + paccor_output);
                         }
                     }
                 }
@@ -449,6 +448,9 @@ namespace hirs {
         }
         #endregion
 
+        public bool HasHardwareManifestPlugins() {
+            return hardwareManifests.Count > 0;
+        }
         public bool HasPaccorOutputFromFile() {
             return !string.IsNullOrEmpty(paccor_output);
         }

--- a/HIRS_Provisioner.NET/hirs/src/config/Settings.cs
+++ b/HIRS_Provisioner.NET/hirs/src/config/Settings.cs
@@ -287,7 +287,7 @@ namespace hirs {
                         }
                     }
                 }
-                if (files.Count() > 0) { // if none found, don't initialize platformCerts
+                if (files.Count > 0) { // if none found, don't initialize platformCerts
                     // At least one base platform cert found
                     platformCerts = new List<byte[]>();
                     foreach (FileInfo file in files) {

--- a/HIRS_Provisioner.NET/hirs/src/deviceInfo/ClassicDeviceInfoCollector.cs
+++ b/HIRS_Provisioner.NET/hirs/src/deviceInfo/ClassicDeviceInfoCollector.cs
@@ -19,7 +19,7 @@ namespace hirs {
         public ClassicDeviceInfoCollector() {
         }
 
-        public string fileToString(string path, string def) {
+        public string FileToString(string path, string def) {
             string result;
             try {
                 result = File.ReadAllText(path).Trim();
@@ -32,21 +32,21 @@ namespace hirs {
             return result;
         }
 
-        public DeviceInfo collectDeviceInfo(string acaAddress) {
-            DeviceInfo dv = new DeviceInfo();
-            dv.Fw = collectFirmwareInfo();
-            dv.Hw = collectHardwareInfo();
-            dv.Nw = collectNetworkInfo(acaAddress);
-            dv.Os = collectOsInfo();
+        public DeviceInfo CollectDeviceInfo(string acaAddress) {
+            DeviceInfo dv = new();
+            dv.Fw = CollectFirmwareInfo();
+            dv.Hw = CollectHardwareInfo();
+            dv.Nw = CollectNetworkInfo(acaAddress);
+            dv.Os = CollectOsInfo();
             return dv;
         }
 
-        public FirmwareInfo collectFirmwareInfo() {
-            FirmwareInfo fw = new FirmwareInfo();
+        public FirmwareInfo CollectFirmwareInfo() {
+            FirmwareInfo fw = new();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                ManagementScope myScope = new ManagementScope("root\\CIMV2");
-                ManagementObjectSearcher s = new ManagementObjectSearcher("SELECT * FROM Win32_BIOS");
+                ManagementScope myScope = new("root\\CIMV2");
+                ManagementObjectSearcher s = new("SELECT * FROM Win32_BIOS");
                 fw.BiosVendor = NOT_SPECIFIED;
                 fw.BiosVersion = NOT_SPECIFIED;
                 fw.BiosReleaseDate = NOT_SPECIFIED;
@@ -60,9 +60,9 @@ namespace hirs {
                     break;
                 }
             } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-                fw.BiosVendor = fileToString("/sys/class/dmi/id/bios_vendor", NOT_SPECIFIED);
-                fw.BiosVersion = fileToString("/sys/class/dmi/id/bios_version", NOT_SPECIFIED);
-                fw.BiosReleaseDate = fileToString("/sys/class/dmi/id/bios_date", NOT_SPECIFIED);
+                fw.BiosVendor = FileToString("/sys/class/dmi/id/bios_vendor", NOT_SPECIFIED);
+                fw.BiosVersion = FileToString("/sys/class/dmi/id/bios_version", NOT_SPECIFIED);
+                fw.BiosReleaseDate = FileToString("/sys/class/dmi/id/bios_date", NOT_SPECIFIED);
             } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
                 // tbd
             } else {
@@ -78,12 +78,12 @@ namespace hirs {
 
         
 
-        public HardwareInfo collectHardwareInfo() {
-            HardwareInfo hw = new HardwareInfo();
+        public HardwareInfo CollectHardwareInfo() {
+            HardwareInfo hw = new();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-                ManagementScope myScope = new ManagementScope("root\\CIMV2");
-                ManagementObjectSearcher s = new ManagementObjectSearcher("SELECT * FROM Win32_ComputerSystemProduct");
+                ManagementScope myScope = new("root\\CIMV2");
+                ManagementObjectSearcher s = new("SELECT * FROM Win32_ComputerSystemProduct");
                 hw.Manufacturer = NOT_SPECIFIED;
                 hw.ProductName = NOT_SPECIFIED;
                 hw.ProductVersion = NOT_SPECIFIED;
@@ -100,10 +100,10 @@ namespace hirs {
                     break;
                 }
             } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-                hw.Manufacturer = fileToString("/sys/class/dmi/id/sys_vendor", NOT_SPECIFIED);
-                hw.ProductName = fileToString("/sys/class/dmi/id/product_name", NOT_SPECIFIED);
-                hw.ProductVersion = fileToString("/sys/class/dmi/id/product_version", NOT_SPECIFIED);
-                hw.SystemSerialNumber = fileToString("/sys/class/dmi/id/product_serial", NOT_SPECIFIED);
+                hw.Manufacturer = FileToString("/sys/class/dmi/id/sys_vendor", NOT_SPECIFIED);
+                hw.ProductName = FileToString("/sys/class/dmi/id/product_name", NOT_SPECIFIED);
+                hw.ProductVersion = FileToString("/sys/class/dmi/id/product_version", NOT_SPECIFIED);
+                hw.SystemSerialNumber = FileToString("/sys/class/dmi/id/product_serial", NOT_SPECIFIED);
             } else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
                 // tbd
             } else {
@@ -118,8 +118,8 @@ namespace hirs {
             return hw;
         }
 
-        public NetworkInfo collectNetworkInfo(string acaAddress) {
-            NetworkInfo nw = new NetworkInfo();
+        public NetworkInfo CollectNetworkInfo(string acaAddress) {
+            NetworkInfo nw = new();
             nw.Hostname = Dns.GetHostName();
 
             NetworkInterface iface = NetworkInterface
@@ -132,9 +132,9 @@ namespace hirs {
             nw.ClearIpAddress();
             // First attempt to find local ip by connecting ACA
             if (string.IsNullOrWhiteSpace(acaAddress)) {
-                Uri uri = new Uri(acaAddress);
+                Uri uri = new(acaAddress);
                 try {
-                    using (Socket socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, 0)) {
+                    using (Socket socket = new(AddressFamily.InterNetwork, SocketType.Dgram, 0)) {
                         socket.Connect(uri.Host, uri.Port);
                         IPEndPoint endPoint = socket.LocalEndPoint as IPEndPoint;
                         nw.IpAddress = endPoint.Address.ToString();
@@ -160,8 +160,8 @@ namespace hirs {
             return nw;
         }
 
-        public OsInfo collectOsInfo() {
-            OsInfo info = new OsInfo();
+        public OsInfo CollectOsInfo() {
+            OsInfo info = new();
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                 info.OsName = OSPlatform.Windows.ToString();

--- a/HIRS_Provisioner.NET/hirs/src/deviceInfo/IHirsDeviceInfoCollector.cs
+++ b/HIRS_Provisioner.NET/hirs/src/deviceInfo/IHirsDeviceInfoCollector.cs
@@ -5,6 +5,6 @@ using System.Text;
 
 namespace hirs {
     public interface IHirsDeviceInfoCollector {
-        DeviceInfo collectDeviceInfo(string address);
+        DeviceInfo CollectDeviceInfo(string address);
     }
 }

--- a/HIRS_Provisioner.NET/hirs/src/provisioner/IHirsProvisioner.cs
+++ b/HIRS_Provisioner.NET/hirs/src/provisioner/IHirsProvisioner.cs
@@ -5,11 +5,11 @@ using System.Threading.Tasks;
 
 namespace hirs {
     public interface IHirsProvisioner {
-        void setSettings(Settings settings);
-        void setCLI(CLI cli);
-        IHirsAcaTpm connectTpm();
-        void setClient(IHirsAcaClient clientWithAddress);
-        void setDeviceInfoCollector(IHirsDeviceInfoCollector collector);
-        Task<int> provision(IHirsAcaTpm tpm);
+        void SetSettings(Settings settings);
+        void SetCLI(CLI cli);
+        IHirsAcaTpm ConnectTpm();
+        void SetClient(IHirsAcaClient clientWithAddress);
+        void SetDeviceInfoCollector(IHirsDeviceInfoCollector collector);
+        Task<int> Provision(IHirsAcaTpm tpm);
     }
 }

--- a/HIRS_Provisioner.NET/hirs/src/provisioner/Provisioner.cs
+++ b/HIRS_Provisioner.NET/hirs/src/provisioner/Provisioner.cs
@@ -1,17 +1,10 @@
-﻿using CommandLine;
-using Google.Protobuf;
+﻿using Google.Protobuf;
 using Hirs.Pb;
-using Microsoft.Extensions.Configuration;
-using Newtonsoft.Json;
 using Serilog;
 using System;
 using System.Collections.Generic;
-using System.Data.Common;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace hirs {
@@ -26,38 +19,38 @@ namespace hirs {
         }
 
         public Provisioner(Settings settings, CLI cli) {
-            setSettings(settings);
-            setCLI(cli);
+            SetSettings(settings);
+            SetCLI(cli);
         }
 
-        public void setSettings(Settings settings) {
+        public void SetSettings(Settings settings) {
             if (settings == null) {
                 Log.Error("Unknown error. Settings were supposed to have been parsed.");
             }
             this.settings = settings;
         }
 
-        public void setCLI(CLI cli) {
+        public void SetCLI(CLI cli) {
             if (cli == null) {
                 Log.Error("Unknown error. CLI arguments were supposed to have been parsed.");
             }
             this.cli = cli;
         }
 
-        public IHirsAcaTpm connectTpm() {
+        public IHirsAcaTpm ConnectTpm() {
             IHirsAcaTpm tpm = null;
             // If tpm device type is set on the command line
-            if (cli.nix) {
+            if (cli.Nix) {
                 tpm = new CommandTpm(CommandTpm.Devices.NIX);
-            } else if (cli.tcp && cli.ip != null) {
-                string[] split = cli.ip.Split(":");
+            } else if (cli.Tcp && cli.Ip != null) {
+                string[] split = cli.Ip.Split(":");
                 if (split.Length == 2) {
-                    tpm = new CommandTpm(cli.sim, split[0], Int32.Parse(split[1]));
-                    Log.Debug("Connected to TPM via TCP at " + cli.ip);
+                    tpm = new CommandTpm(cli.Sim, split[0], Int32.Parse(split[1]));
+                    Log.Debug("Connected to TPM via TCP at " + cli.Ip);
                 } else {
-                    Log.Error("ip input should have the format servername:port. The given input was '" + cli.ip + "'.");
+                    Log.Error("ip input should have the format servername:port. The given input was '" + cli.Ip + "'.");
                 }
-            } else if (cli.win) {
+            } else if (cli.Win) {
                 tpm = new CommandTpm(CommandTpm.Devices.WIN);
             }
 
@@ -67,16 +60,16 @@ namespace hirs {
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                     try {
                         tpm = new CommandTpm(CommandTpm.Devices.WIN);
-                        Log.Warning("Auto Detect found a WIN TPM Device.");
+                        Log.Debug("Auto Detect found a WIN TPM Device.");
                     } catch (Exception) {
-                        Log.Warning("No WIN TPM Device found by auto detect.");
+                        Log.Debug("No WIN TPM Device found by auto detect.");
                     }
                 } else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
                     try {
                         tpm = new CommandTpm(CommandTpm.Devices.NIX);
-                        Log.Warning("Auto Detect found a Linux TPM Device.");
+                        Log.Debug("Auto Detect found a Linux TPM Device.");
                     } catch (Exception) {
-                        Log.Warning("No Linux TPM Device found by auto detect.");
+                        Log.Debug("No Linux TPM Device found by auto detect.");
                     }
                 }
 
@@ -85,13 +78,13 @@ namespace hirs {
                     try {
                         string[] split = CommandTpm.DefaultSimulatorNamePort.Split(":");
                         tpm = new CommandTpm(true, split[0], Int32.Parse(split[1]));
-                        Log.Warning("Auto Detect found a TPM simulator at " + CommandTpm.DefaultSimulatorNamePort + ".");
+                        Log.Debug("Auto Detect found a TPM simulator at " + CommandTpm.DefaultSimulatorNamePort + ".");
                     } catch (Exception) {
-                        Log.Warning("No TPM simulator found by auto detect.");
+                        Log.Debug("No TPM simulator found by auto detect.");
                     }
                 }
             } else if ((tpm != null) && settings.IsAutoDetectTpmEnabled()) {
-                Log.Warning("Auto detect TPM was enabled in settings, but command line options were also given. Using command line options.");
+                Log.Debug("Auto detect TPM was enabled in settings, but command line options were also given. Using command line options.");
             }
             
             // If TPM is still not set up, offer help message
@@ -106,54 +99,59 @@ namespace hirs {
             return tpm;
         }
 
-        public void useBuiltInClient(string addr) {
+        public void UseBuiltInClient(string addr) {
             acaClient = new Client(addr);
         }
 
-        public void setClient(IHirsAcaClient client) {
+        public void SetClient(IHirsAcaClient client) {
             acaClient = client;
         }
 
-        public void useClassicDeviceInfoCollector() {
+        public void UseClassicDeviceInfoCollector() {
             deviceInfoCollector = new ClassicDeviceInfoCollector();
         }
 
-        public void setDeviceInfoCollector(IHirsDeviceInfoCollector collector) {
+        public void SetDeviceInfoCollector(IHirsDeviceInfoCollector collector) {
             if (collector == null) {
-                useClassicDeviceInfoCollector();
+                UseClassicDeviceInfoCollector();
             } else {
                 deviceInfoCollector = collector;
             }
         }
 
-        public async Task<int> provision(IHirsAcaTpm tpm) {
-            int result = 0;
+        public async Task<int> Provision(IHirsAcaTpm tpm) {
+            ClientExitCodes result = ClientExitCodes.SUCCESS;
             if (tpm != null) {
+                Log.Information("--> Provisioning");
+                Log.Information("----> Gathering Endorsement Key Certificate.");
+                byte[] ekc = tpm.GetCertificateFromNvIndex(CommandTpm.DefaultEkcNvIndex);
+                Log.Debug("Checking EK PUBLIC");
+                tpm.CreateEndorsementKey(CommandTpm.DefaultEkHandle); // Will not create key if obj already exists at handle
+                byte[] ekPublicArea = tpm.ReadPublicArea(CommandTpm.DefaultEkHandle, out byte[] name, out byte[] qualifiedName);
+
+                Log.Information("----> " + (cli.ReplaceAK ? "Creating new" : "Verifying existence of") + " Attestation Key.");
+                tpm.CreateAttestationKey(CommandTpm.DefaultEkHandle, CommandTpm.DefaultAkHandle, cli.ReplaceAK);
+
+                Log.Debug("Gathering AK PUBLIC.");
+                byte[] akPublicArea = tpm.ReadPublicArea(CommandTpm.DefaultAkHandle, out name, out qualifiedName);
+
                 List<byte[]> pcs = null, baseRims = null, supportRimELs = null, supportRimPCRs = null;
                 if (settings.HasEfiPrefix()) {
-                    Log.Debug("Gathering artifacts from EFI.");
+                    Log.Information("----> Gathering artifacts from EFI.");
                     pcs = settings.gatherPlatformCertificatesFromEFI();
                     baseRims = settings.gatherRIMBasesFromEFI();
                     supportRimELs = settings.gatherSupportRIMELsFromEFI();
                     supportRimPCRs = settings.gatherSupportRIMPCRsFromEFI();
                 }
-                
-                Log.Debug("Gathering EK Certificate.");
-                byte[] name = null, qualifiedName = null, ekPublicArea = null;
-                byte[] ekc = tpm.GetCertificateFromNvIndex(CommandTpm.DefaultEkcNvIndex);
-                Log.Debug("Checking EK PUBLIC");
-                tpm.CreateEndorsementKey(CommandTpm.DefaultEkHandle); // Will not create key if obj already exists at handle
-                ekPublicArea = tpm.ReadPublicArea(CommandTpm.DefaultEkHandle, out name, out qualifiedName);
 
-                Log.Debug(cli.replaceAK ? "Creating AK." : "Verifying AK.");
-                tpm.CreateAttestationKey(CommandTpm.DefaultEkHandle, CommandTpm.DefaultAkHandle, cli.replaceAK);
-
-                Log.Debug("Gathering AK PUBLIC.");
-                byte[] akPublicArea = tpm.ReadPublicArea(CommandTpm.DefaultAkHandle, out name, out qualifiedName);
-
-                Log.Debug("Gather Device Info");
+                Log.Debug("Setting up the Client.");
                 Uri acaAddress = settings.aca_address_port;
-                DeviceInfo dv = deviceInfoCollector.collectDeviceInfo(acaAddress.AbsoluteUri);
+                if (acaClient == null) {
+                    UseBuiltInClient(acaAddress.AbsoluteUri);
+                }
+
+                Log.Information("----> Collecting device information.");
+                DeviceInfo dv = deviceInfoCollector.CollectDeviceInfo(acaAddress.AbsoluteUri);
                 if (baseRims != null) {
                     foreach (byte[] baseRim in baseRims) {
                         dv.Swidfile.Add(ByteString.CopyFrom(baseRim));
@@ -170,7 +168,18 @@ namespace hirs {
                     }
                 }
 
-                Log.Debug("Gather Event log");
+                Log.Debug("Gathering hardware component information:");
+                string manifest = "";
+                if (settings.HasHardwareManifestPlugins()) {
+                    manifest = settings.RunHardwareManifestCollectors();
+                } else if (settings.HasPaccorOutputFromFile()) {
+                    manifest = settings.paccor_output;
+                } else {
+                    Log.Warning("No hardware collectors nor paccor output file were identified.");
+                }
+                Log.Debug("Hardware component information that will be sent to the ACA: " + manifest);
+
+                Log.Debug("Gathering the event log.");
                 byte[] eventLog;
                 if (settings.HasEventLogFromFile()) {
                     Log.Debug("  Using the event log identified in settings.");
@@ -181,22 +190,11 @@ namespace hirs {
                 }
                     
                 if (eventLog != null) {
+                    Log.Debug("Event log gathered is " + eventLog.Length + " bytes.");
                     dv.Livelog = ByteString.CopyFrom(eventLog);
                 }
 
-                Log.Debug("Set up Client.");
-                if (acaClient == null) {
-                    useBuiltInClient(acaAddress.AbsoluteUri);
-                }
-
-                Log.Debug("Gathering hardware information:");
-                string manifest = settings.RunHardwareManifestCollectors();
-                if (manifest == null && settings.HasPaccorOutputFromFile()) {
-                    manifest = settings.paccor_output;
-                }
-                Log.Debug(manifest);
-
-                Log.Debug("Gather PCR List.");
+                Log.Debug("Gathering PCR data from the TPM.");
                 string pcrsList, pcrsSha1, pcrsSha256;
                 CommandTpm.FormatPcrValuesForAca(tpm.GetPcrList(Tpm2Lib.TpmAlgId.Sha1), "sha1", out pcrsSha1);
                 CommandTpm.FormatPcrValuesForAca(tpm.GetPcrList(Tpm2Lib.TpmAlgId.Sha256), "sha256", out pcrsSha256);
@@ -206,75 +204,81 @@ namespace hirs {
                 dv.Pcrslist = ByteString.CopyFromUtf8(pcrsList);
 
                 Log.Debug("Create identity claim");
-                IdentityClaim idClaim = acaClient.createIdentityClaim(dv, akPublicArea, ekPublicArea, ekc, pcs, manifest);
+                IdentityClaim idClaim = acaClient.CreateIdentityClaim(dv, akPublicArea, ekPublicArea, ekc, pcs, manifest);
 
-                Log.Debug("Communicate identity claim to the ACA.");
-                //Task<IdentityClaimResponse> task = Task.Run(() => client.postIdentityClaim(idClaim));
-                //task.Wait();
-                IdentityClaimResponse icr = await acaClient.postIdentityClaim(idClaim); // task.Result;
-                Log.Debug("Response received from the ACA regarding the identity claim.");
+                Log.Information("----> Sending identity claim to Attestation CA");
+                IdentityClaimResponse icr = await acaClient.PostIdentityClaim(idClaim);
+                Log.Information("----> Received response. Attempting to decrypt nonce");
+                if (icr.Status == ResponseStatus.Pass) {
+                    Log.Debug("The ACA accepted the identity claim.");
+                } else {
+                    Log.Debug("The ACA did not accept the identity claim. See details on the ACA.");
+                    result = ClientExitCodes.PASS_1_STATUS_FAIL;
+                }
 
                 byte[] integrityHMAC = null, encIdentity = null, encryptedSecret = null;
-                if (icr.HasCredentialBlob) {
-                    byte[] credentialBlob = icr.CredentialBlob.ToByteArray(); // contains nonce
+                if (icr.Status == ResponseStatus.Pass && icr.HasCredentialBlob) {
+                    byte[] credentialBlob = icr.CredentialBlob.ToByteArray(); // look for the nonce
                     Log.Debug("ACA delivered IdentityClaimResponse credentialBlob " + BitConverter.ToString(credentialBlob));
-                    int credentialBlobLen = credentialBlob[0] | (credentialBlob[1] << 8); // The size value does not include the 2 blob len bytes
-                    int integrityHmacLen = ((credentialBlob[2] << 8) | credentialBlob[3]);// + 2; // +2 for the integrityHMAC Digest size bytes
+                    int credentialBlobLen = credentialBlob[0] | (credentialBlob[1] << 8); 
+                    int integrityHmacLen = (credentialBlob[2] << 8) | credentialBlob[3]; 
                     integrityHMAC = new byte[integrityHmacLen];
                     Array.Copy(credentialBlob, 4, integrityHMAC, 0, integrityHmacLen);
                     int encIdentityLen = credentialBlobLen - integrityHmacLen - 2;
                     encIdentity = new byte[encIdentityLen];
                     Array.Copy(credentialBlob, 4 + integrityHmacLen, encIdentity, 0, encIdentityLen);
                     // The following offsets are bound tightly to the way makecredential is implemented on the ACA.
-                    int encryptedSecretLen = (credentialBlob[134] | (credentialBlob[135] << 8));// + 2; // +2 because the size bytes are to be included
+                    int encryptedSecretLen = credentialBlob[134] | (credentialBlob[135] << 8);
                     encryptedSecret = new byte[encryptedSecretLen];
                     Array.Copy(credentialBlob, 136, encryptedSecret, 0, encryptedSecretLen);
                     Log.Debug("Prepared values to give to activateCredential.");
                     Log.Debug("    integrityHMAC: " + BitConverter.ToString(integrityHMAC));
                     Log.Debug("    encIdentity: " + BitConverter.ToString(encIdentity));
                     Log.Debug("    encryptedSecret: " + BitConverter.ToString(encryptedSecret));
-                } else if (result == 0) {
-                    result = 102;
-                    Log.Error("The response from the ACA did not contain a CredentialBlob. Look at the ACA logs.");
+                } else {
+                    result = ClientExitCodes.MAKE_CREDENTIAL_BLOB_MALFORMED;
+                    Log.Error("The response from the ACA did not contain a CredentialBlob.");
                 }
 
                 if (integrityHMAC != null && encIdentity != null && encryptedSecret != null) {
                     Log.Debug("Executing activateCredential.");
                     byte[] recoveredSecret = tpm.ActivateCredential(CommandTpm.DefaultAkHandle, CommandTpm.DefaultEkHandle, integrityHMAC, encIdentity, encryptedSecret);
-                    CommandTpmQuoteResponse ctqr;
                     Log.Debug("Gathering quote.");
                     uint[] selectPcrs = null;
                     if (icr.HasPcrMask) {
                         // For now, the ACA will send a comma separated selection of PCRs as a string
                         try {
-                            selectPcrs = (uint[])icr.PcrMask.Split(',').Select(uint.Parse).ToList().ToArray();
+                            selectPcrs = icr.PcrMask.Split(',').Select(uint.Parse).ToList().ToArray();
                         } catch (Exception) {
                             Log.Warning("PcrMask was included in the IdentityClaimResponse, but could not be parsed." +
                                         "Collecting quote over default PCR selection.");
                             Log.Debug("This PcrMask could not be parsed: " + icr.PcrMask);
                         }
                     }
-                    tpm.GetQuote(CommandTpm.DefaultAkHandle, Tpm2Lib.TpmAlgId.Sha256, recoveredSecret, out ctqr, selectPcrs);
-                    Log.Debug("Create certificate request and include recovered secret");
-                    CertificateRequest akCertReq = acaClient.createAkCertificateRequest(recoveredSecret, ctqr);
+                    tpm.GetQuote(CommandTpm.DefaultAkHandle, Tpm2Lib.TpmAlgId.Sha256, recoveredSecret, out CommandTpmQuoteResponse ctqr, selectPcrs);
+                    Log.Information("----> Nonce successfully decrypted. Sending attestation certificate request");
+                    CertificateRequest akCertReq = acaClient.CreateAkCertificateRequest(recoveredSecret, ctqr);
                     byte[] certificate;
                     Log.Debug("Communicate certificate request to the ACA.");
-                    //var task2 = Task.Run(() => client.postCertificateRequest(akCertReq));
-                    //task2.Wait();
-                    CertificateResponse cr = await acaClient.postCertificateRequest(akCertReq); //task2.Result;
+                    CertificateResponse cr = await acaClient.PostCertificateRequest(akCertReq);
                     Log.Debug("Response received from the ACA regarding the certificate request.");
-
-                    certificate = cr.Certificate.ToByteArray(); // contains certificate
-
-                    Log.Debug("issued certificate: " + BitConverter.ToString(certificate));
-                } else if (result == 0) {
-                    result = 103;
-                    Log.Error("Credential elements could not be extracted from the ACA's response. Ensure your acaAddress is accurate and the ACA is the expected version. Submit a bug report.");
+                    if (cr.Status == ResponseStatus.Pass) {
+                        Log.Debug("ACA returned a positive response to the Certificate Request.");
+                        certificate = cr.Certificate.ToByteArray(); // contains certificate
+                        Log.Debug("Printing attestation key certificate: " + BitConverter.ToString(certificate));
+                    } else {
+                        Log.Debug("The ACA did not return any certificates. See details on the ACA.");
+                        result = ClientExitCodes.PASS_2_STATUS_FAIL;
+                    }
+                } else {
+                    result = ClientExitCodes.MAKE_CREDENTIAL_BLOB_MALFORMED;
+                    Log.Error("Credential elements could not be extracted from the ACA's response.");
                 }
             } else {
-                result = 104;
+                result = ClientExitCodes.TPM_ERROR;
+                Log.Error("Could not provision because the TPM object was null.");
             }
-            return result;
+            return (int)result;
         }
 
     }

--- a/HIRS_Provisioner.NET/hirs/src/tpm/CommandTpm.cs
+++ b/HIRS_Provisioner.NET/hirs/src/tpm/CommandTpm.cs
@@ -49,7 +49,11 @@ namespace hirs {
             switch (dev) {
                 case Devices.NIX:
                     // LinuxTpmDevice will first try to connect tpm2-abrmd and second try to connect directly to device
+                    StringWriter writer = new();
+                    Console.SetOut(writer);
                     tpmDevice = new LinuxTpmDevice();
+                    //writer.Flush();
+                    Console.SetOut(new StreamWriter(Console.OpenStandardOutput()));
                     break;
                 case Devices.WIN:
                     tpmDevice = new TbsDevice();
@@ -73,7 +77,7 @@ namespace hirs {
 
         public byte[] GetCertificateFromNvIndex(uint index) {
             Log.Debug("GetCertificateFromNvIndex 0x" + index.ToString("X"));
-            byte[] certificate = null;
+            byte[] certificate = Array.Empty<byte>();
             
             TpmHandle nvHandle = new(index);
             try {
@@ -86,16 +90,16 @@ namespace hirs {
                         if (certificate != null) {
                             Log.Debug("GetCertificateFromNvIndex: Read: " + BitConverter.ToString(certificate));
                         } else {
-                            Log.Warning("GetCertificateFromNvIndex: No certificate found within data at index.");
+                            Log.Debug("GetCertificateFromNvIndex: No certificate found within data at index.");
                         }
                     } else {
-                        Log.Warning("GetCertificateFromNvIndex: Could not read any data.");
+                        Log.Debug("GetCertificateFromNvIndex: Could not read any data.");
                     }
                 } else {
-                    Log.Warning("GetCertificateFromNvIndex: Nothing found at index: " + DefaultEkcNvIndex);
+                    Log.Debug("GetCertificateFromNvIndex: Nothing found at index: " + DefaultEkcNvIndex);
                 }
             } catch (TpmException e) {
-                Log.Error(e, "GetCertificateFromNvIndex TPM error");
+                Log.Debug(e, "GetCertificateFromNvIndex TPM error");
             }
             return certificate;
         }

--- a/HIRS_Provisioner.NET/hirs/src/tpm/CommandTpm.cs
+++ b/HIRS_Provisioner.NET/hirs/src/tpm/CommandTpm.cs
@@ -51,8 +51,10 @@ namespace hirs {
                     // LinuxTpmDevice will first try to connect tpm2-abrmd and second try to connect directly to device
                     StringWriter writer = new();
                     Console.SetOut(writer);
+                    // The LinuxTpmDevice will print to Console/Stdout an error when it cannot find a resource manager
+                    // This will redirect the Console messages
                     tpmDevice = new LinuxTpmDevice();
-                    //writer.Flush();
+                    // Reset the Console messages
                     Console.SetOut(new StreamWriter(Console.OpenStandardOutput()));
                     break;
                 case Devices.WIN:

--- a/HIRS_Provisioner.NET/hirsTest/hirsTest.csproj
+++ b/HIRS_Provisioner.NET/hirsTest/hirsTest.csproj
@@ -13,15 +13,13 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/HIRS_Provisioner.NET/hirsTest/src/client/ClientTests.cs
+++ b/HIRS_Provisioner.NET/hirsTest/src/client/ClientTests.cs
@@ -1,20 +1,15 @@
 ﻿using hirs;
 using Hirs.Pb;
-using FakeItEasy;
-using System;
+using NUnit.Framework;
 using System.Collections.Generic;
-using System.Net;
-using System.Net.Http;
 using System.Text;
-using Xunit;
-using System.Threading.Tasks;
 using Tpm2Lib;
 
 namespace hirsTest {
     public class ClientTests {
         public static readonly string localhost = "https://127.0.0.1:8443/";
 
-        [Fact]
+        [Test]
         public void TestCreateIdentityClaim() {
             IHirsAcaClient client = new Client(ClientTests.localhost);
 
@@ -26,17 +21,18 @@ namespace hirsTest {
             pcs.Add(new byte[] { });
             string componentList= "";
 
-            IdentityClaim obj = client.createIdentityClaim(dv, akPub, ekPub, ekc, pcs, componentList);
-
-            Assert.NotNull(obj.Dv);
-            Assert.True(obj.HasAkPublicArea);
-            Assert.True(obj.HasEkPublicArea);
-            Assert.True(obj.HasEndorsementCredential);
-            Assert.Single(obj.PlatformCredential);
-            Assert.True(obj.HasPaccorOutput);
+            IdentityClaim obj = client.CreateIdentityClaim(dv, akPub, ekPub, ekc, pcs, componentList);
+            Assert.Multiple(() => {
+                Assert.That(obj.Dv, Is.Not.Null);
+                Assert.That(obj.HasAkPublicArea, Is.True);
+                Assert.That(obj.HasEkPublicArea, Is.True);
+                Assert.That(obj.HasEndorsementCredential, Is.True);
+                Assert.That(obj.PlatformCredential, Has.Count.EqualTo(1));
+                Assert.That(obj.HasPaccorOutput, Is.True);
+            });
         }
 
-        [Fact]
+        [Test]
         public void TestCreateAkCertificateRequest() {
             IHirsAcaClient client = new Client(ClientTests.localhost);
 
@@ -47,10 +43,11 @@ namespace hirsTest {
 
             CommandTpmQuoteResponse ctqr = new CommandTpmQuoteResponse(quoted, signature, pcrValues);
 
-            CertificateRequest obj = client.createAkCertificateRequest(secret, ctqr);
-
-            Assert.True(obj.HasNonce);
-            Assert.True(obj.HasQuote);
+            CertificateRequest obj = client.CreateAkCertificateRequest(secret, ctqr);
+            Assert.Multiple(() => {
+                Assert.That(obj.HasNonce, Is.True);
+                Assert.That(obj.HasQuote, Is.True);
+            });
         }
     }
 }


### PR DESCRIPTION
Also hides the error that is written to console when the TSS library can't find the resource management daemon.