### PR TITLE
[#485] Event log spdm prep

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent.java
@@ -121,9 +121,10 @@ public class TpmPcrEvent {
      * This can be SHA1 for older event structures or any algorithm for newer structure.
      *
      * @param digestData cryptographic hash
+     * @param digestLength length of the cryptographic hash
      */
     protected void setEventDigest(final byte[] digestData, final int digestLength) {
-    	digest = new byte[digestLength];
+        digest = new byte[digestLength];
         System.arraycopy(digestData, 0, digest, 0, digestLength);
     }
 
@@ -138,7 +139,7 @@ public class TpmPcrEvent {
         System.arraycopy(digest, 0, digestCopy, 0, this.digestLength);
         return digestCopy;
     }
-    
+
     /**
      * Returns a hex representation of the event digest.
      * @return hex string
@@ -469,6 +470,7 @@ public class TpmPcrEvent {
      * @param event        the byte array holding the event data.
      * @param eventContent the byte array holding the event content.
      * @param eventNumber  event position within the event log.
+     * @param hashName     name of the hash algorithm used by the event log
      * @return String description of the event.
      * @throws CertificateException     if the event contains an event that cannot be processed.
      * @throws NoSuchAlgorithmException if an event contains an unsupported algorithm.
@@ -485,11 +487,11 @@ public class TpmPcrEvent {
         description += "\n";
         if (hashName.compareToIgnoreCase("TPM_ALG_SHA1") == 0) {   // Digest
             description += "digest (SHA-1): " + Hex.encodeHexString(this.digest);
-        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA256") == 0) {   // Digest 
+        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA256") == 0) {   // Digest
         	description += "digest (SHA256): " + Hex.encodeHexString(this.digest);
-        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA384") == 0) {   // Digest 
+        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA384") == 0) {   // Digest
         	description += "digest (SHA384): " + Hex.encodeHexString(this.digest);
-        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA512") == 0) {   // Digest 
+        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA512") == 0) {   // Digest
         	description += "digest (SHA512): " + Hex.encodeHexString(this.digest);
         } else {
         	description += "Unsupported Hash Algorithm encoutered";

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent.java
@@ -477,7 +477,7 @@ public class TpmPcrEvent {
      * @throws IOException              if the event cannot be parsed.
      */
     public String processEvent(final byte[] event, final byte[] eventContent, final int eventNumber,
-    		                        final String hashName)
+                                    final String hashName)
            throws CertificateException, NoSuchAlgorithmException, IOException {
         int eventID = (int) eventType;
         this.eventNumber = eventNumber;

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent.java
@@ -122,9 +122,9 @@ public class TpmPcrEvent {
      *
      * @param digestData cryptographic hash
      */
-    protected void setEventDigest(final byte[] digestData) {
-        digest = new byte[digestLength];
-        System.arraycopy(digestData, 0, digest, 0, this.digestLength);
+    protected void setEventDigest(final byte[] digestData, final int digestLength) {
+    	digest = new byte[digestLength];
+        System.arraycopy(digestData, 0, digest, 0, digestLength);
     }
 
     /**
@@ -138,7 +138,7 @@ public class TpmPcrEvent {
         System.arraycopy(digest, 0, digestCopy, 0, this.digestLength);
         return digestCopy;
     }
-
+    
     /**
      * Returns a hex representation of the event digest.
      * @return hex string
@@ -474,18 +474,25 @@ public class TpmPcrEvent {
      * @throws NoSuchAlgorithmException if an event contains an unsupported algorithm.
      * @throws IOException              if the event cannot be parsed.
      */
-    public String processEvent(final byte[] event, final byte[] eventContent, final int eventNumber)
-            throws CertificateException, NoSuchAlgorithmException, IOException {
+    public String processEvent(final byte[] event, final byte[] eventContent, final int eventNumber,
+    		                        final String hashName)
+           throws CertificateException, NoSuchAlgorithmException, IOException {
         int eventID = (int) eventType;
         this.eventNumber = eventNumber;
         description += "Event# " + eventNumber + ": ";
         description += "Index PCR[" + getPcrIndex() + "]\n";
         description += "Event Type: 0x" + Long.toHexString(eventType) + " " + eventString(eventID);
         description += "\n";
-        if (logFormat == 1) {   // Digest
+        if (hashName.compareToIgnoreCase("TPM_ALG_SHA1") == 0) {   // Digest
             description += "digest (SHA-1): " + Hex.encodeHexString(this.digest);
+        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA256") == 0) {   // Digest 
+        	description += "digest (SHA256): " + Hex.encodeHexString(this.digest);
+        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA384") == 0) {   // Digest 
+        	description += "digest (SHA384): " + Hex.encodeHexString(this.digest);
+        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA512") == 0) {   // Digest 
+        	description += "digest (SHA512): " + Hex.encodeHexString(this.digest);
         } else {
-            description += "digest (SHA256): " + Hex.encodeHexString(this.digest);
+        	description += "Unsupported Hash Algorithm encoutered";
         }
         if (eventID != UefiConstants.SIZE_4) {
             description += "\n";

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent.java
@@ -488,13 +488,13 @@ public class TpmPcrEvent {
         if (hashName.compareToIgnoreCase("TPM_ALG_SHA1") == 0) {   // Digest
             description += "digest (SHA-1): " + Hex.encodeHexString(this.digest);
         } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA256") == 0) {   // Digest
-        	description += "digest (SHA256): " + Hex.encodeHexString(this.digest);
+            description += "digest (SHA256): " + Hex.encodeHexString(this.digest);
         } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA384") == 0) {   // Digest
-        	description += "digest (SHA384): " + Hex.encodeHexString(this.digest);
+            description += "digest (SHA384): " + Hex.encodeHexString(this.digest);
         } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA512") == 0) {   // Digest
-        	description += "digest (SHA512): " + Hex.encodeHexString(this.digest);
+            description += "digest (SHA512): " + Hex.encodeHexString(this.digest);
         } else {
-        	description += "Unsupported Hash Algorithm encoutered";
+            description += "Unsupported Hash Algorithm encoutered";
         }
         if (eventID != UefiConstants.SIZE_4) {
             description += "\n";

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent1.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent1.java
@@ -49,7 +49,7 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
         byte[] rawEventSize = new byte[UefiConstants.SIZE_4];
         byte[] eventDigest = new byte[EvConstants.SHA1_LENGTH];
         byte[] eventContent = null;
-        int digestSize= EvConstants.SHA1_LENGTH;
+        int digestSize = EvConstants.SHA1_LENGTH;
         int eventSize = 0;
         String hashName = "TPM_ALG_SHA1";
         if (is.available() > UefiConstants.SIZE_32) {

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent1.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent1.java
@@ -49,15 +49,16 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
         byte[] rawEventSize = new byte[UefiConstants.SIZE_4];
         byte[] eventDigest = new byte[EvConstants.SHA1_LENGTH];
         byte[] eventContent = null;
+        int digestSize= EvConstants.SHA1_LENGTH;
         int eventSize = 0;
-
+        String hashName = "TPM_ALG_SHA1";
         if (is.available() > UefiConstants.SIZE_32) {
             is.read(rawIndex);
             setPcrIndex(rawIndex);
             is.read(rawType);
             setEventType(rawType);
             is.read(eventDigest);
-            setEventDigest(eventDigest);
+            setEventDigest(eventDigest, digestSize);
             is.read(rawEventSize);
             eventSize = HexUtils.leReverseInt(rawEventSize);
             eventContent = new byte[eventSize];
@@ -78,7 +79,7 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
             offset += rawEventSize.length;
             setEventData(event);
             //System.arraycopy(eventContent, 0, event, offset, eventContent.length);
-            this.processEvent(event, eventContent, eventNumber);
+            this.processEvent(event, eventContent, eventNumber, hashName);
         }
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent2.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent2.java
@@ -78,12 +78,14 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
         setDigestLength(EvConstants.SHA256_LENGTH);
         setLogFormat(2);
         /**  Event data. */
+        int eventDigestLength = 0;
+        String hashName = "";
         byte[] event;
         byte[] rawIndex = new byte[UefiConstants.SIZE_4];
         byte[] algCountBytes = new byte[UefiConstants.SIZE_4];
         byte[] rawType = new byte[UefiConstants.SIZE_4];
         byte[] rawEventSize = new byte[UefiConstants.SIZE_4];
-        byte[] eventDigest = new byte[EvConstants.SHA256_LENGTH];
+        byte[] eventDigest = null;
         byte[] eventContent = null;
         TcgTpmtHa hashAlg = null;
         int eventSize = 0;
@@ -99,11 +101,12 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
             // Process TPMT_HA,
             for (int i = 0; i < algCount; i++) {
                 hashAlg = new TcgTpmtHa(is);
+                hashName = hashAlg.getHashName();
                 hashlist.add(hashAlg);
-                if (hashAlg.getHashName().compareToIgnoreCase("TPM_ALG_SHA256") == 0) {
-                    setEventDigest(hashAlg.getDigest());
-                }
+                eventDigest = new byte[hashAlg.getHashLength()];
+                setEventDigest(hashAlg.getDigest(),hashAlg.getHashLength());
             }
+            
             is.read(rawEventSize);
             eventSize = HexUtils.leReverseInt(rawEventSize);
             eventContent = new byte[eventSize];
@@ -126,7 +129,8 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
             offset += rawEventSize.length;
             //System.arraycopy(eventContent, 0, event, offset, eventContent.length);
             setEventData(event);
-            this.processEvent(event, eventContent, eventNumber);
+            //setDigestLength(eventDigestLength);
+            this.processEvent(event, eventContent, eventNumber, hashName);
         }
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent2.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/TpmPcrEvent2.java
@@ -104,9 +104,8 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
                 hashName = hashAlg.getHashName();
                 hashlist.add(hashAlg);
                 eventDigest = new byte[hashAlg.getHashLength()];
-                setEventDigest(hashAlg.getDigest(),hashAlg.getHashLength());
+                setEventDigest(hashAlg.getDigest(), hashAlg.getHashLength());
             }
-            
             is.read(rawEventSize);
             eventSize = HexUtils.leReverseInt(rawEventSize);
             eventContent = new byte[eventSize];

--- a/HIRS_Utils/src/main/java/hirs/tpm/eventlog/events/EvConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/tpm/eventlog/events/EvConstants.java
@@ -21,6 +21,8 @@ public final class EvConstants {
     public static final int SHA1_LENGTH = 20;
     /**  Event Type (byte array). */
     public static final int SHA256_LENGTH = 32;
+    /**  Event Type (byte array). */
+    public static final int SHA384_LENGTH = 48;
     /** Each PCR bank holds 24 registers.  */
     public static final int PCR_COUNT = 24;
     // Event IDs

--- a/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Commander.java
+++ b/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Commander.java
@@ -75,7 +75,6 @@ public class Commander {
      */
     public final void parseArguments(final String[] args) {
         String tempValue;
-
         for (int i = 0; i < args.length; i++) {
             tempValue = args[i];
 


### PR DESCRIPTION
Adds support for SHA384 and SHA512 for TPM event logs. 

closes #485 