### PR TITLE
[#490] Fixing a typo in the build Docker image workflow

### DIFF
--- a/.github/workflows/build_aca_image.yml
+++ b/.github/workflows/build_aca_image.yml
@@ -53,7 +53,7 @@ jobs:
       uses: macbre/push-to-ghcr@master
       with:
         image_name: nsacyber/hirs/aca-centos7
-        github_token: ${{ secrets.GHCR_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         dockerfile: "./.ci/docker/Dockerfile.acaimage"
     - name: Build and publish a Docker image for ${{ github.repository }}
       if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
A small typo error in the build_aca_image.yml