### PR TITLE
[#493] RFC3852 counter signature timestamp

### DIFF
--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -79,8 +79,11 @@ public class Main {
                         } else {
                             gateway.setRimEventLog(rimEventLog);
                         }
-                        if (commander.isRfc3852()) {
-                            gateway.setTimestampFormat("RFC3852");
+                        if (!commander.getRfc3852Filename().isEmpty() && commander.isRfc3339()) {
+                            System.out.println("Only one timestamp format can be specified");
+                            System.exit(1);
+                        } else if (!commander.getRfc3852Filename().isEmpty()) {
+                            //pass file to gateway
                         } else if (commander.isRfc3339()) {
                             gateway.setTimestampFormat("RFC3339");
                         }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -83,7 +83,7 @@ public class Main {
                         }
                         if (commander.isRfc3161()) {
                             gateway.setTimestampFormat("RFC3161");
-                        } else {
+                        } else if (commander.isRfc3339()) {
                             gateway.setTimestampFormat("RFC3339");
                         }
                         gateway.generateSwidTag(commander.getOutFile());

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -81,6 +81,11 @@ public class Main {
                         } else {
                             gateway.setRimEventLog(rimEventLog);
                         }
+                        if (commander.isRfc3161()) {
+                            gateway.setTimestampFormat("RFC3161");
+                        } else {
+                            gateway.setTimestampFormat("RFC3339");
+                        }
                         gateway.generateSwidTag(commander.getOutFile());
                         break;
                     default:

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -79,11 +79,13 @@ public class Main {
                         } else {
                             gateway.setRimEventLog(rimEventLog);
                         }
-                        if (!commander.getRfc3852Filename().isEmpty() && commander.isRfc3339()) {
+                        String filename = commander.getRfc3852Filename();
+                        if (!filename.isEmpty() && commander.isRfc3339()) {
                             System.out.println("Only one timestamp format can be specified");
                             System.exit(1);
-                        } else if (!commander.getRfc3852Filename().isEmpty()) {
-                            //pass file to gateway
+                        } else if (!filename.isEmpty()) {
+                            gateway.setTimestampFormat("RFC3852");
+                            gateway.setRfc3852Filename(filename);
                         } else if (commander.isRfc3339()) {
                             gateway.setTimestampFormat("RFC3339");
                         }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -3,8 +3,6 @@ package hirs.swid;
 import hirs.swid.utils.Commander;
 import com.beust.jcommander.JCommander;
 
-import java.io.IOException;
-
 public class Main {
 
     public static void main(String[] args) {
@@ -81,8 +79,8 @@ public class Main {
                         } else {
                             gateway.setRimEventLog(rimEventLog);
                         }
-                        if (commander.isRfc3161()) {
-                            gateway.setTimestampFormat("RFC3161");
+                        if (commander.isRfc3852()) {
+                            gateway.setTimestampFormat("RFC3852");
                         } else if (commander.isRfc3339()) {
                             gateway.setTimestampFormat("RFC3339");
                         }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
@@ -71,6 +71,7 @@ public class SwidTagConstants {
     public static final String TPM_PCR_ASSERTION = "TPM_PCR_Assertion";
     public static final String SUPPORT_RIM_FORMAT_MISSING = "supportRIMFormat missing";
     public static final String SUPPORT_RIM_URI_GLOBAL = "supportRIMURIGlobal";
+    public static final String DATETIME = "dateTime";
     
     public static final String NIST_NS = "http://csrc.nist.gov/ns/swid/2015-extensions/1.0";
     public static final String TCG_NS =  "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model";
@@ -79,8 +80,8 @@ public class SwidTagConstants {
     
     public static final String N8060_PFX = "n8060";
     public static final String RIM_PFX = "rim";
-    public static final String RCF3161_PFX = "rcf3161";
-    public static final String RCF3339_PFX = "rcf3339";
+    public static final String RFC3161_PFX = "rcf3161";
+    public static final String RFC3339_PFX = "rcf3339";
 
     public static final QName _SHA256_HASH = new QName(
             "http://www.w3.org/2001/04/xmlenc#sha256", HASH, "SHA256");
@@ -132,9 +133,6 @@ public class SwidTagConstants {
             NIST_NS, "envVarSuffix", N8060_PFX);
     public static final QName _N8060_PATHSEPARATOR = new QName(
             NIST_NS, "pathSeparator", N8060_PFX);
-/*
-    public static final QName = new QName();
-    public static final QName = new QName();
-*/
+
     public static final String CA_ISSUERS = "1.3.6.1.5.5.7.48.2";
 }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
@@ -71,82 +71,63 @@ public class SwidTagConstants {
     public static final String TPM_PCR_ASSERTION = "TPM_PCR_Assertion";
     public static final String SUPPORT_RIM_FORMAT_MISSING = "supportRIMFormat missing";
     public static final String SUPPORT_RIM_URI_GLOBAL = "supportRIMURIGlobal";
+    
+    public static final String NIST_NS = "http://csrc.nist.gov/ns/swid/2015-extensions/1.0";
+    public static final String TCG_NS =  "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model";
+    
+    public static final String N8060_PFX = "n8060";
+    public static final String RIM_PFX = "rim";
 
     public static final QName _SHA256_HASH = new QName(
-            "http://www.w3.org/2001/04/xmlenc#sha256",
-            "hash", "SHA256");
+            "http://www.w3.org/2001/04/xmlenc#sha256", HASH, "SHA256");
     public static final QName _COLLOQUIAL_VERSION = new QName(
-            "http://csrc.nist.gov/ns/swid/2015-extensions/1.0",
-            "colloquialVersion", "n8060");
+            NIST_NS, COLLOQUIAL_VERSION, N8060_PFX);
     public static final QName _EDITION = new QName(
-            "http://csrc.nist.gov/ns/swid/2015-extensions/1.0",
-            "edition", "n8060");
+            NIST_NS, EDITION, N8060_PFX);
     public static final QName _PRODUCT = new QName(
-            "http://csrc.nist.gov/ns/swid/2015-extensions/1.0",
-            "product", "n8060");
+            NIST_NS, PRODUCT, N8060_PFX);
     public static final QName _REVISION = new QName(
-            "http://csrc.nist.gov/ns/swid/2015-extensions/1.0",
-            "revision", "n8060");
+            NIST_NS, REVISION, N8060_PFX);
     public static final QName _PAYLOAD_TYPE = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "PayloadType", "rim");
+            TCG_NS, PAYLOAD_TYPE, RIM_PFX);
     public static final QName _PLATFORM_MANUFACTURER_STR = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "platformManufacturerStr", "rim");
+            TCG_NS, PLATFORM_MANUFACTURER_STR, RIM_PFX);
     public static final QName _PLATFORM_MANUFACTURER_ID = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "platformManufacturerId", "rim");
+            TCG_NS, PLATFORM_MANUFACTURER_ID, RIM_PFX);
     public static final QName _PLATFORM_MODEL = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "platformModel", "rim");
+            TCG_NS, PLATFORM_MODEL, RIM_PFX);
     public static final QName _PLATFORM_VERSION = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "platformVersion", "rim");
+            TCG_NS, PLATFORM_VERSION, RIM_PFX);
     public static final QName _FIRMWARE_MANUFACTURER_STR = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "firmwareManufacturerStr", "rim");
+            TCG_NS, FIRMWARE_MANUFACTURER_STR, RIM_PFX);
     public static final QName _FIRMWARE_MANUFACTURER_ID = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "firmwareManufacturerId", "rim");
+            TCG_NS, FIRMWARE_MANUFACTURER_ID, RIM_PFX);
     public static final QName _FIRMWARE_MODEL = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "firmwareModel", "rim");
+            TCG_NS, FIRMWARE_MODEL, RIM_PFX);
     public static final QName _FIRMWARE_VERSION = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "firmwareVersion", "rim");
+            TCG_NS, FIRMWARE_VERSION, RIM_PFX);
     public static final QName _BINDING_SPEC = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "BindingSpec", "rim");
+            TCG_NS, BINDING_SPEC, RIM_PFX);
     public static final QName _BINDING_SPEC_VERSION = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "BindingSpecVersion", "rim");
+            TCG_NS, BINDING_SPEC_VERSION, RIM_PFX);
     public static final QName _PC_URI_LOCAL = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "pcURILocal", "rim");
+            TCG_NS, PC_URI_LOCAL, RIM_PFX);
     public static final QName _PC_URI_GLOBAL = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "pcURIGlobal", "rim");
+            TCG_NS, PC_URI_GLOBAL, RIM_PFX);
     public static final QName _RIM_LINK_HASH  = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "rimLinkHash", "rim");
+            TCG_NS, RIM_LINK_HASH, RIM_PFX);
     public static final QName _SUPPORT_RIM_TYPE = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "supportRIMType", "rim");
+            TCG_NS, SUPPORT_RIM_TYPE, RIM_PFX);
     public static final QName _SUPPORT_RIM_FORMAT = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "supportRIMFormat", "rim");
+            TCG_NS, SUPPORT_RIM_FORMAT, RIM_PFX);
     public static final QName _SUPPORT_RIM_URI_GLOBAL = new QName(
-            "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model",
-            "supportRIMURIGlobal", "rim");
+            TCG_NS, SUPPORT_RIM_URI_GLOBAL, RIM_PFX);
     public static final QName _N8060_ENVVARPREFIX = new QName(
-            "http://csrc.nist.gov/ns/swid/2015-extensions/1.0",
-            "envVarPrefix", "n8060");
+            NIST_NS, "envVarPrefix", N8060_PFX);
     public static final QName _N8060_ENVVARSUFFIX = new QName(
-            "http://csrc.nist.gov/ns/swid/2015-extensions/1.0",
-            "envVarSuffix", "n8060");
+            NIST_NS, "envVarSuffix", N8060_PFX);
     public static final QName _N8060_PATHSEPARATOR = new QName(
-            "http://csrc.nist.gov/ns/swid/2015-extensions/1.0",
-            "pathSeparator", "n8060");
+            NIST_NS, "pathSeparator", N8060_PFX);
 
     public static final String CA_ISSUERS = "1.3.6.1.5.5.7.48.2";
 }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
@@ -75,12 +75,12 @@ public class SwidTagConstants {
     
     public static final String NIST_NS = "http://csrc.nist.gov/ns/swid/2015-extensions/1.0";
     public static final String TCG_NS =  "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model";
-    public static final String RFC3161_NS = "https://www.ietf.org/rfc/rfc3161.txt";
+    public static final String RFC3852_NS = "https://www.ietf.org/rfc/rfc3852.txt";
     public static final String RFC3339_NS = "https://www.ietf.org/rfc/rfc3339.txt";
     
     public static final String N8060_PFX = "n8060";
     public static final String RIM_PFX = "rim";
-    public static final String RFC3161_PFX = "rcf3161";
+    public static final String RFC3852_PFX = "rcf3852";
     public static final String RFC3339_PFX = "rcf3339";
 
     public static final QName _SHA256_HASH = new QName(

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
@@ -74,9 +74,13 @@ public class SwidTagConstants {
     
     public static final String NIST_NS = "http://csrc.nist.gov/ns/swid/2015-extensions/1.0";
     public static final String TCG_NS =  "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model";
+    public static final String RFC3161_NS = "https://www.ietf.org/rfc/rfc3161.txt";
+    public static final String RFC3339_NS = "https://www.ietf.org/rfc/rfc3339.txt";
     
     public static final String N8060_PFX = "n8060";
     public static final String RIM_PFX = "rim";
+    public static final String RCF3161_PFX = "rcf3161";
+    public static final String RCF3339_PFX = "rcf3339";
 
     public static final QName _SHA256_HASH = new QName(
             "http://www.w3.org/2001/04/xmlenc#sha256", HASH, "SHA256");
@@ -128,6 +132,9 @@ public class SwidTagConstants {
             NIST_NS, "envVarSuffix", N8060_PFX);
     public static final QName _N8060_PATHSEPARATOR = new QName(
             NIST_NS, "pathSeparator", N8060_PFX);
-
+/*
+    public static final QName = new QName();
+    public static final QName = new QName();
+*/
     public static final String CA_ISSUERS = "1.3.6.1.5.5.7.48.2";
 }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -9,6 +9,7 @@ import hirs.swid.xjc.ResourceCollection;
 import hirs.swid.xjc.SoftwareIdentity;
 import hirs.swid.xjc.SoftwareMeta;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import javax.json.Json;
 import javax.json.JsonException;
@@ -20,11 +21,15 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.crypto.MarshalException;
 import javax.xml.crypto.XMLStructure;
+import javax.xml.crypto.dom.DOMStructure;
 import javax.xml.crypto.dsig.CanonicalizationMethod;
 import javax.xml.crypto.dsig.DigestMethod;
 import javax.xml.crypto.dsig.Reference;
+import javax.xml.crypto.dsig.SignatureProperties;
+import javax.xml.crypto.dsig.SignatureProperty;
 import javax.xml.crypto.dsig.SignedInfo;
 import javax.xml.crypto.dsig.Transform;
+import javax.xml.crypto.dsig.XMLObject;
 import javax.xml.crypto.dsig.XMLSignature;
 import javax.xml.crypto.dsig.XMLSignatureException;
 import javax.xml.crypto.dsig.XMLSignatureFactory;
@@ -59,6 +64,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -523,8 +529,11 @@ public class SwidTagGateway {
     private Document signXMLDocument(JAXBElement<SoftwareIdentity> swidTag) throws Exception {
         Document doc = null;
         try {
+            doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            marshaller.marshal(swidTag, doc);
             XMLSignatureFactory sigFactory = XMLSignatureFactory.getInstance("DOM");
-            Reference reference = sigFactory.newReference(
+
+            Reference documentRef = sigFactory.newReference(
                     "",
                     sigFactory.newDigestMethod(DigestMethod.SHA256, null),
                     Collections.singletonList(sigFactory.newTransform(Transform.ENVELOPED,
@@ -532,12 +541,37 @@ public class SwidTagGateway {
                     null,
                     null
             );
+
+            //Create TimeStamp element
+            Element timeStampElement = doc.createElement("TimeStamp");
+            /*
+            This line is for demonstration purposes only!
+            Must be replaced with a call to a trusted timestamp authority (TSA).
+             */
+            timeStampElement.setAttribute("TimeStamp", LocalDateTime.now().toString());
+
+            DOMStructure timestampObject = new DOMStructure(timeStampElement);
+            SignatureProperty signatureProperty = sigFactory.newSignatureProperty(
+                    Collections.singletonList(timestampObject), "RimSignature", "TST"
+            );
+            SignatureProperties signatureProperties = sigFactory.newSignatureProperties(
+                    Collections.singletonList(signatureProperty), null);
+            XMLObject xmlObject = sigFactory.newXMLObject(
+                    Collections.singletonList(signatureProperties), null,null,null);
+            Reference timestampRef = sigFactory.newReference(
+                    "#TST",
+                    sigFactory.newDigestMethod(DigestMethod.SHA256, null)
+            );
+            List<Reference> refList = new ArrayList<Reference>();
+            refList.add(documentRef);
+            refList.add(timestampRef);
+
             SignedInfo signedInfo = sigFactory.newSignedInfo(
                     sigFactory.newCanonicalizationMethod(CanonicalizationMethod.INCLUSIVE,
                             (C14NMethodParameterSpec) null),
                     sigFactory.newSignatureMethod(SwidTagConstants.SIGNATURE_ALGORITHM_RSA_SHA256,
                             null),
-                    Collections.singletonList(reference)
+                    refList
             );
             List<XMLStructure> keyInfoElements = new ArrayList<XMLStructure>();
 
@@ -565,10 +599,14 @@ public class SwidTagGateway {
             }
             KeyInfo keyinfo = kiFactory.newKeyInfo(keyInfoElements);
 
-            doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
-            marshaller.marshal(swidTag, doc);
             DOMSignContext context = new DOMSignContext(privateKey, doc.getDocumentElement());
-            XMLSignature signature = sigFactory.newXMLSignature(signedInfo, keyinfo);
+            XMLSignature signature = sigFactory.newXMLSignature(
+                        signedInfo,
+                        keyinfo,
+                        Collections.singletonList(xmlObject),
+                        "RimSignature",
+                        null
+            );
             signature.sign(context);
         } catch (FileNotFoundException e) {
             System.out.println("Keystore not found! " + e.getMessage());

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -542,6 +542,8 @@ public class SwidTagGateway {
             doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
             marshaller.marshal(swidTag, doc);
             XMLSignatureFactory sigFactory = XMLSignatureFactory.getInstance("DOM");
+            List xmlObjectList = null;
+            String signatureId = null;
 
             Reference documentRef = sigFactory.newReference(
                     "",
@@ -552,13 +554,18 @@ public class SwidTagGateway {
                     null
             );
 
-            Reference timestampRef = sigFactory.newReference(
-                    "#TST",
-                    sigFactory.newDigestMethod(DigestMethod.SHA256, null)
-            );
             List<Reference> refList = new ArrayList<Reference>();
             refList.add(documentRef);
-            refList.add(timestampRef);
+
+            if (!timestampFormat.isEmpty()) {
+                Reference timestampRef = sigFactory.newReference(
+                        "#TST",
+                        sigFactory.newDigestMethod(DigestMethod.SHA256, null)
+                );
+                refList.add(timestampRef);
+                xmlObjectList = Collections.singletonList(createXmlTimestamp(doc, sigFactory));
+                signatureId = "RimSignature";
+            }
 
             SignedInfo signedInfo = sigFactory.newSignedInfo(
                     sigFactory.newCanonicalizationMethod(CanonicalizationMethod.INCLUSIVE,
@@ -595,11 +602,11 @@ public class SwidTagGateway {
 
             DOMSignContext context = new DOMSignContext(privateKey, doc.getDocumentElement());
             XMLSignature signature = sigFactory.newXMLSignature(
-                        signedInfo,
-                        keyinfo,
-                        Collections.singletonList(createXmlTimestamp(doc, sigFactory)),
-                        "RimSignature",
-                        null
+                    signedInfo,
+                    keyinfo,
+                    xmlObjectList,
+                    signatureId,
+                    null
             );
             signature.sign(context);
         } catch (FileNotFoundException e) {

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -548,7 +548,7 @@ public class SwidTagGateway {
             This line is for demonstration purposes only!
             Must be replaced with a call to a trusted timestamp authority (TSA).
              */
-            timeStampElement.setAttribute("TimeStamp", LocalDateTime.now().toString());
+            timeStampElement.setAttribute("dateTime", LocalDateTime.now().toString());
 
             DOMStructure timestampObject = new DOMStructure(timeStampElement);
             SignatureProperty signatureProperty = sigFactory.newSignatureProperty(

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -640,10 +640,10 @@ public class SwidTagGateway {
     private XMLObject createXmlTimestamp(Document doc, XMLSignatureFactory sigFactory) {
         Element timeStampElement = doc.createElement("TimeStamp");
         switch (timestampFormat) {
-            case "RFC3161":
+            case "RFC3852":
                 timeStampElement.setAttributeNS("http://www.w3.org/2000/xmlns/",
-                        "xmlns:" + SwidTagConstants.RFC3161_PFX,
-                        SwidTagConstants.RFC3161_NS);
+                        "xmlns:" + SwidTagConstants.RFC3852_PFX,
+                        SwidTagConstants.RFC3852_NS);
                 timeStampElement.setAttribute(SwidTagConstants.DATETIME,
                         "Base64 blob here");
                 break;

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -86,6 +86,7 @@ public class SwidTagGateway {
     private String pemCertificateFile;
     private boolean embeddedCert;
     private String rimEventLog;
+    private String timestampFormat;
     private String errorRequiredFields;
 
     /**
@@ -100,6 +101,7 @@ public class SwidTagGateway {
             pemCertificateFile = "";
             embeddedCert = false;
             rimEventLog = "";
+            timestampFormat = "";
             errorRequiredFields = "";
         } catch (JAXBException e) {
             System.out.println("Error initializing jaxbcontext: " + e.getMessage());
@@ -168,6 +170,14 @@ public class SwidTagGateway {
      */
     public void setRimEventLog(final String rimEventLog) {
         this.rimEventLog = rimEventLog;
+    }
+
+    /**
+     * Setter for timestamp format in XML signature
+     * @param timestampFormat
+     */
+    public void setTimestampFormat(String timestampFormat) {
+        this.timestampFormat = timestampFormat;
     }
 
     /**

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -45,6 +45,12 @@ public class Commander {
     @Parameter(names = {"-l", "--rimel <path>"}, order = 9,
             description = "The TCG eventlog file to use as a support RIM.")
     private String rimEventLog = "";
+    @Parameter(names = {"--rfc3161"}, order = 10,
+            description = "Add a timestamp to the signature that is compliant with RFC3161.")
+    private boolean rfc3161 = false;
+    @Parameter(names = {"--rfc3339"}, order = 11,
+            description = "Add a timestamp to the signature that is compliant with RFC3339.")
+    private boolean rfc3339 = false;
 
     public boolean isHelp() {
         return help;
@@ -81,6 +87,10 @@ public class Commander {
     public boolean isDefaultKey() { return defaultKey; }
 
     public String getRimEventLog() { return rimEventLog; }
+
+    public boolean isRfc3161() { return rfc3161; }
+
+    public boolean isRfc3339() { return rfc3339; }
 
     public String printHelpExamples() {
         StringBuilder sb = new StringBuilder();
@@ -123,6 +133,13 @@ public class Commander {
             sb.append("Signing credential: (none given)" + System.lineSeparator());
         }
         sb.append("Event log support RIM: " + this.getRimEventLog() + System.lineSeparator());
+        if (isRfc3161()) {
+            sb.append("Timestamp format: RFC3161");
+        } else if (isRfc3339()) {
+            sb.append("Timestamp format: RFC3339");
+        } else {
+            sb.append("Timestamp format: defaulting to RFC3339");
+        }
         return sb.toString();
     }
 }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -134,7 +134,7 @@ public class Commander {
         }
         sb.append("Event log support RIM: " + this.getRimEventLog() + System.lineSeparator());
         if (!this.getRfc3852Filename().isEmpty()) {
-            sb.append("Timestamp format: RFC3852");
+            sb.append("Timestamp format: RFC3852, " + this.getRfc3852Filename());
         } else if (this.isRfc3339()) {
             sb.append("Timestamp format: RFC3339");
         } else {

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -46,7 +46,7 @@ public class Commander {
             description = "The TCG eventlog file to use as a support RIM.")
     private String rimEventLog = "";
     @Parameter(names = {"--rfc3852"}, order = 10,
-            description = "Add a timestamp to the signature that is compliant with RFC3852.")
+            description = "Add a placeholder for a base 64-encoded RFC3852 countersignature.")
     private boolean rfc3852 = false;
     @Parameter(names = {"--rfc3339"}, order = 11,
             description = "Add a timestamp to the signature that is compliant with RFC3339.")

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -45,9 +45,9 @@ public class Commander {
     @Parameter(names = {"-l", "--rimel <path>"}, order = 9,
             description = "The TCG eventlog file to use as a support RIM.")
     private String rimEventLog = "";
-    @Parameter(names = {"--rfc3161"}, order = 10,
-            description = "Add a timestamp to the signature that is compliant with RFC3161.")
-    private boolean rfc3161 = false;
+    @Parameter(names = {"--rfc3852"}, order = 10,
+            description = "Add a timestamp to the signature that is compliant with RFC3852.")
+    private boolean rfc3852 = false;
     @Parameter(names = {"--rfc3339"}, order = 11,
             description = "Add a timestamp to the signature that is compliant with RFC3339.")
     private boolean rfc3339 = false;
@@ -88,7 +88,7 @@ public class Commander {
 
     public String getRimEventLog() { return rimEventLog; }
 
-    public boolean isRfc3161() { return rfc3161; }
+    public boolean isRfc3852() { return rfc3852; }
 
     public boolean isRfc3339() { return rfc3339; }
 
@@ -133,8 +133,8 @@ public class Commander {
             sb.append("Signing credential: (none given)" + System.lineSeparator());
         }
         sb.append("Event log support RIM: " + this.getRimEventLog() + System.lineSeparator());
-        if (isRfc3161()) {
-            sb.append("Timestamp format: RFC3161");
+        if (isRfc3852()) {
+            sb.append("Timestamp format: RFC3852");
         } else if (isRfc3339()) {
             sb.append("Timestamp format: RFC3339");
         } else {

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -138,7 +138,7 @@ public class Commander {
         } else if (isRfc3339()) {
             sb.append("Timestamp format: RFC3339");
         } else {
-            sb.append("Timestamp format: defaulting to RFC3339");
+            sb.append("No timestamp included");
         }
         return sb.toString();
     }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -47,7 +47,7 @@ public class Commander {
     private String rimEventLog = "";
     @Parameter(names = {"--rfc3852"}, order = 10,
             description = "Add a placeholder for a base 64-encoded RFC3852 countersignature.")
-    private boolean rfc3852 = false;
+    private String rfc3852Filename = "";
     @Parameter(names = {"--rfc3339"}, order = 11,
             description = "Add a timestamp to the signature that is compliant with RFC3339.")
     private boolean rfc3339 = false;
@@ -88,7 +88,7 @@ public class Commander {
 
     public String getRimEventLog() { return rimEventLog; }
 
-    public boolean isRfc3852() { return rfc3852; }
+    public String getRfc3852Filename() { return rfc3852Filename; }
 
     public boolean isRfc3339() { return rfc3339; }
 
@@ -133,12 +133,12 @@ public class Commander {
             sb.append("Signing credential: (none given)" + System.lineSeparator());
         }
         sb.append("Event log support RIM: " + this.getRimEventLog() + System.lineSeparator());
-        if (isRfc3852()) {
+        if (!this.getRfc3852Filename().isEmpty()) {
             sb.append("Timestamp format: RFC3852");
-        } else if (isRfc3339()) {
+        } else if (this.isRfc3339()) {
             sb.append("Timestamp format: RFC3339");
         } else {
-            sb.append("No timestamp included");
+            sb.append("No timestamp specified");
         }
         return sb.toString();
     }

--- a/tools/tcg_rim_tool/src/test/resources/generated_default_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_default_cert.swidtag
@@ -2,7 +2,7 @@
 <SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:BindingSpec="PC Client RIM" rim:BindingSpecVersion="1.2" rim:PayloadType="direct" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURILocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
+  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
   <Payload>
     <Directory name="rim">
       <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.BIOS.01.rimel" size="7549"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>K3XoBeYvgJBAKl8z273sL7z38qLLVBKLfUPt/gPUzBI=</DigestValue>
+        <DigestValue>DJMc0n3VHHwU+F3HNpiY/l3EMcjRZAQOYlrjhD5v9qE=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>cIl1gPsUyEj2gDv3HTWNFDVxtcBjz4Revxxf2LJejtOXQW8mGepZH8CnvgO7zCAbZYlYUZXjYZ9M&#13;
-jONVv8dcsAjVHRnP6YHywFfmSm8LUCwxsfuZQqn5jClqzu5VaqLzBhuJYvCpiEdIDJwDINQuORUB&#13;
-nzul1CWc3Sm1Ms2wjlIq5ctWWJcddhdyIOjl8/oD4EC5E2rOSfNcRMZxldXtie9iinFGVbr0YNE+&#13;
-+lQ7hAU+SyV8RMx9tGnnsO8otwV4ddF+OfemcbzWGYBenLs3A8ZqWZyTvWphCgGqDUbOLssYciCC&#13;
-mnYm5QOeh4QcE9H2kqTgZvcyCgPL/hDC7xhyjQ==</SignatureValue>
+    <SignatureValue>ojJ6v8ToxLWWekCKmBoZ+Yg2V4MYMPbKB9FjDs/QG/AMP+LKjnb55Z7FSLhC8+CvvShKPAoS9mv1&#13;
+QepwI17NEqbfnC1U4WH0u578A3J6wiHMXIDnIQqKAAXb8v2c/wjMDArzFl8CXmDA7HUDIt+3C4VC&#13;
+tA598YY7o0Hf6hK5qO8oWGQxXUKfpUwvtGLxHpbDWYFuVSPa+uk6OTzutt/QyzTERzxyO9Le1i6K&#13;
+nrpzh4lgHn6EfGs6HR1ffdHQ069q0bE61zDx0VC18nK9DmszW6p6FlMzApiTVW/4PiVt+dSFeVGR&#13;
+9///OdtxcoBCeofDDFPRyO+s+kY1pXd92Q3nfg==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>

--- a/tools/tcg_rim_tool/src/test/resources/generated_user_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_user_cert.swidtag
@@ -2,7 +2,7 @@
 <SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:BindingSpec="PC Client RIM" rim:BindingSpecVersion="1.2" rim:PayloadType="direct" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURILocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
+  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
   <Payload>
     <Directory name="rim">
       <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.BIOS.01.rimel" size="7549"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>K3XoBeYvgJBAKl8z273sL7z38qLLVBKLfUPt/gPUzBI=</DigestValue>
+        <DigestValue>DJMc0n3VHHwU+F3HNpiY/l3EMcjRZAQOYlrjhD5v9qE=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>cIl1gPsUyEj2gDv3HTWNFDVxtcBjz4Revxxf2LJejtOXQW8mGepZH8CnvgO7zCAbZYlYUZXjYZ9M&#13;
-jONVv8dcsAjVHRnP6YHywFfmSm8LUCwxsfuZQqn5jClqzu5VaqLzBhuJYvCpiEdIDJwDINQuORUB&#13;
-nzul1CWc3Sm1Ms2wjlIq5ctWWJcddhdyIOjl8/oD4EC5E2rOSfNcRMZxldXtie9iinFGVbr0YNE+&#13;
-+lQ7hAU+SyV8RMx9tGnnsO8otwV4ddF+OfemcbzWGYBenLs3A8ZqWZyTvWphCgGqDUbOLssYciCC&#13;
-mnYm5QOeh4QcE9H2kqTgZvcyCgPL/hDC7xhyjQ==</SignatureValue>
+    <SignatureValue>ojJ6v8ToxLWWekCKmBoZ+Yg2V4MYMPbKB9FjDs/QG/AMP+LKjnb55Z7FSLhC8+CvvShKPAoS9mv1&#13;
+QepwI17NEqbfnC1U4WH0u578A3J6wiHMXIDnIQqKAAXb8v2c/wjMDArzFl8CXmDA7HUDIt+3C4VC&#13;
+tA598YY7o0Hf6hK5qO8oWGQxXUKfpUwvtGLxHpbDWYFuVSPa+uk6OTzutt/QyzTERzxyO9Le1i6K&#13;
+nrpzh4lgHn6EfGs6HR1ffdHQ069q0bE61zDx0VC18nK9DmszW6p6FlMzApiTVW/4PiVt+dSFeVGR&#13;
+9///OdtxcoBCeofDDFPRyO+s+kY1pXd92Q3nfg==</SignatureValue>
     <KeyInfo>
       <KeyValue>
         <RSAKeyValue>

--- a/tools/tcg_rim_tool/src/test/resources/generated_user_cert_embed.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_user_cert_embed.swidtag
@@ -2,7 +2,7 @@
 <SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:BindingSpec="PC Client RIM" rim:BindingSpecVersion="1.2" rim:PayloadType="direct" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURILocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
+  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
   <Payload>
     <Directory name="rim">
       <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.BIOS.01.rimel" size="7549"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>K3XoBeYvgJBAKl8z273sL7z38qLLVBKLfUPt/gPUzBI=</DigestValue>
+        <DigestValue>DJMc0n3VHHwU+F3HNpiY/l3EMcjRZAQOYlrjhD5v9qE=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>cIl1gPsUyEj2gDv3HTWNFDVxtcBjz4Revxxf2LJejtOXQW8mGepZH8CnvgO7zCAbZYlYUZXjYZ9M&#13;
-jONVv8dcsAjVHRnP6YHywFfmSm8LUCwxsfuZQqn5jClqzu5VaqLzBhuJYvCpiEdIDJwDINQuORUB&#13;
-nzul1CWc3Sm1Ms2wjlIq5ctWWJcddhdyIOjl8/oD4EC5E2rOSfNcRMZxldXtie9iinFGVbr0YNE+&#13;
-+lQ7hAU+SyV8RMx9tGnnsO8otwV4ddF+OfemcbzWGYBenLs3A8ZqWZyTvWphCgGqDUbOLssYciCC&#13;
-mnYm5QOeh4QcE9H2kqTgZvcyCgPL/hDC7xhyjQ==</SignatureValue>
+    <SignatureValue>ojJ6v8ToxLWWekCKmBoZ+Yg2V4MYMPbKB9FjDs/QG/AMP+LKjnb55Z7FSLhC8+CvvShKPAoS9mv1&#13;
+QepwI17NEqbfnC1U4WH0u578A3J6wiHMXIDnIQqKAAXb8v2c/wjMDArzFl8CXmDA7HUDIt+3C4VC&#13;
+tA598YY7o0Hf6hK5qO8oWGQxXUKfpUwvtGLxHpbDWYFuVSPa+uk6OTzutt/QyzTERzxyO9Le1i6K&#13;
+nrpzh4lgHn6EfGs6HR1ffdHQ069q0bE61zDx0VC18nK9DmszW6p6FlMzApiTVW/4PiVt+dSFeVGR&#13;
+9///OdtxcoBCeofDDFPRyO+s+kY1pXd92Q3nfg==</SignatureValue>
     <KeyInfo>
       <X509Data>
         <X509SubjectName>CN=example.RIM.signer,OU=PCClient,O=Example,ST=VA,C=US</X509SubjectName>


### PR DESCRIPTION
These changes provide support for timestamping base RIMs with RC3852-compliant counter signature data.  A flat file containing the counter signature is passed in with the `--rfc3852 <file>` command line option, and its base64 encoding is placed in the Timestamp element of the resulting RIM.

This PR addresses #493 together with #494.
