### PR TITLE
Updated ComponentClass TypeId equals

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentClass.java
+++ b/HIRS_Utils/src/main/java/hirs/data/persist/certificate/attributes/ComponentClass.java
@@ -252,7 +252,7 @@ public class ComponentClass {
             for (Member member : components) {
                 typeID = verifyComponentValue(member.getName());
 
-                if (component.equals(typeID)) {
+                if (component.equalsIgnoreCase(typeID)) {
                     componentStr = member.getValue().asString();
                 }
             }


### PR DESCRIPTION
Do to hash conversions, the alphanumeric format of the component type comes out lowercase, modified equals clause to ignore case.