### PR TITLE
Fix to build.gradle on Eclipse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,11 +26,12 @@ def buildTime = { ->
 }
 
 def gitHash = { ->
-    def gitProcess = 'git rev-parse --short HEAD'.execute();
-    gitProcess.waitFor();
-    def shortHash = gitProcess.text.trim();
-    def gitHash = shortHash.substring(0, shortHash.length() - 2);
-    return gitHash;
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'rev-parse', '--short', 'HEAD'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
 }
 
 project.ext["jarVersion"] = "${projectVersion}.${buildTime}.${gitHash}"


### PR DESCRIPTION
Converts command in `build.gradle` to use `ByteArrayOutputStream` in order for it the git command to work properly in Eclipse.

Fixes issue #531.