### PR TITLE
[#536] Create filter for Github actions to trigger

### DIFF
--- a/.github/workflows/hirs_unit_tests.yml
+++ b/.github/workflows/hirs_unit_tests.yml
@@ -4,8 +4,9 @@ name: HIRS Build and Unit Test
 
 on:
   push:
-    - '*v2*'
-    - 'master'
+    branches:
+      - '*v2*'
+      - 'master'
    # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/hirs_unit_tests.yml
+++ b/.github/workflows/hirs_unit_tests.yml
@@ -4,6 +4,8 @@ name: HIRS Build and Unit Test
 
 on:
   push:
+    - '*v2*'
+    - 'master'
    # allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/package_centos.yml
+++ b/.github/workflows/package_centos.yml
@@ -1,8 +1,9 @@
 name: HIRS packages for centos
 on:
   push:
-    - '*v2*'
-    - 'master'
+    branches:
+      - '*v2*'
+      - 'master'
   workflow_dispatch:
   
 jobs:

--- a/.github/workflows/package_centos.yml
+++ b/.github/workflows/package_centos.yml
@@ -1,6 +1,8 @@
 name: HIRS packages for centos
 on:
   push:
+    - '*v2*'
+    - 'master'
   workflow_dispatch:
   
 jobs:

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -3,8 +3,9 @@
 name: HIRS System Tests
 on: 
   push:
-    - '*v2*'
-    - 'master'
+    branches:
+      - '*v2*'
+      - 'master'
   workflow_dispatch:
 env:
   TEST_STATUS: 0

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -3,6 +3,8 @@
 name: HIRS System Tests
 on: 
   push:
+    - '*v2*'
+    - 'master'
   workflow_dispatch:
 env:
   TEST_STATUS: 0


### PR DESCRIPTION
Any code intended for the master branch should use a branch name with a lower case "v2" in the name.
The "main" branch will be used as the target branch for the migration effort and not currently trigger these actions.
Any code intended for the main branch should use a branch name with a lower case "v3" in the name.
This would effect the following actions:
* HIRS Build and Unit Test
* HIRS packages for centos
* HIRS System Tests

closes: 536