### PR TITLE
[#501] Add namespaces to resolve failing schema validation

### DIFF
--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
@@ -76,13 +76,14 @@ public class SwidTagConstants {
     public static final String TCG_NS = "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model";
     public static final String RFC3852_NS = "https://www.ietf.org/rfc/rfc3852.txt";
     public static final String RFC3339_NS = "https://www.ietf.org/rfc/rfc3339.txt";
-    public static final String HIRS_NS = "https://hirs.gov";
+    public static final String PCRIM_NS = "https://trustedcomputinggroup.org/resource/" +
+            "tcg-pc-client-reference-integrity-manifest-specification/";
 
     public static final String N8060_PFX = "n8060";
     public static final String RIM_PFX = "rim";
     public static final String RFC3852_PFX = "rcf3852";
     public static final String RFC3339_PFX = "rcf3339";
-    public static final String HIRS_PFX = "hirs";
+    public static final String PCRIM_PFX = "pcRim";
 
     public static final QName _SHA256_HASH = new QName(
             "http://www.w3.org/2001/04/xmlenc#sha256", HASH, "SHA256");
@@ -135,7 +136,7 @@ public class SwidTagConstants {
     public static final QName _N8060_PATHSEPARATOR = new QName(
             NIST_NS, "pathSeparator", N8060_PFX);
     public static final QName _SOFTWARE_IDENTITY_ID = new QName(
-            HIRS_NS, "id", HIRS_PFX);
+            PCRIM_NS, "id", PCRIM_PFX);
 
     public static final String CA_ISSUERS = "1.3.6.1.5.5.7.48.2";
 }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
@@ -76,11 +76,13 @@ public class SwidTagConstants {
     public static final String TCG_NS = "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model";
     public static final String RFC3852_NS = "https://www.ietf.org/rfc/rfc3852.txt";
     public static final String RFC3339_NS = "https://www.ietf.org/rfc/rfc3339.txt";
+    public static final String HIRS_NS = "https://hirs.gov";
 
     public static final String N8060_PFX = "n8060";
     public static final String RIM_PFX = "rim";
     public static final String RFC3852_PFX = "rcf3852";
     public static final String RFC3339_PFX = "rcf3339";
+    public static final String HIRS_PFX = "hirs";
 
     public static final QName _SHA256_HASH = new QName(
             "http://www.w3.org/2001/04/xmlenc#sha256", HASH, "SHA256");
@@ -132,6 +134,8 @@ public class SwidTagConstants {
             NIST_NS, "envVarSuffix", N8060_PFX);
     public static final QName _N8060_PATHSEPARATOR = new QName(
             NIST_NS, "pathSeparator", N8060_PFX);
+    public static final QName _SOFTWARE_IDENTITY_ID = new QName(
+            HIRS_NS, "id", HIRS_PFX);
 
     public static final String CA_ISSUERS = "1.3.6.1.5.5.7.48.2";
 }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -656,7 +656,7 @@ public class SwidTagGateway {
 
         Document detachedSignature = db.newDocument();
         DOMSignContext context = new DOMSignContext(privateKey, detachedSignature);
-        context.setIdAttributeNS(softwareIdentity, null, SwidTagConstants.HIRS_PFX + ":id");
+        context.setIdAttributeNS(softwareIdentity, null, SwidTagConstants.PCRIM_PFX + ":id");
         XMLSignature signature = sigFactory.newXMLSignature(signedInfo, keyinfo);
         try {
             signature.sign(context);

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -316,7 +316,7 @@ public class SwidTagGateway {
             if (!tagId.isEmpty()) {
                 swidTag.setTagId(tagId);
             }
-            swidTag.getOtherAttributes().put(new QName("id"), tagId);
+            swidTag.getOtherAttributes().put(SwidTagConstants._SOFTWARE_IDENTITY_ID, tagId);
             swidTag.setTagVersion(new BigInteger(
                     jsonObject.getString(SwidTagConstants.TAGVERSION, "0")));
             swidTag.setVersion(jsonObject.getString(SwidTagConstants.VERSION, "0.0"));
@@ -598,8 +598,6 @@ public class SwidTagGateway {
         }
         Element softwareIdentity = (Element) swidTag.getElementsByTagName(
                     SwidTagConstants.SOFTWARE_IDENTITY).item(0);
-        String softwareIdentityId = softwareIdentity.getAttributes()
-                    .getNamedItem("id").getNodeValue();
 
         //Create signature with a reference to SoftwareIdentity id
         XMLSignatureFactory sigFactory = null;
@@ -658,7 +656,7 @@ public class SwidTagGateway {
 
         Document detachedSignature = db.newDocument();
         DOMSignContext context = new DOMSignContext(privateKey, detachedSignature);
-        context.setIdAttributeNS(softwareIdentity, null, "id");
+        context.setIdAttributeNS(softwareIdentity, null, SwidTagConstants.HIRS_PFX + ":id");
         XMLSignature signature = sigFactory.newXMLSignature(signedInfo, keyinfo);
         try {
             signature.sign(context);
@@ -784,10 +782,12 @@ public class SwidTagGateway {
      * @return an XMLObject containing the timestamp element
      */
     private XMLObject createXmlTimestamp(Document doc, XMLSignatureFactory sigFactory) {
-        Element timeStampElement = doc.createElement("TimeStamp");
+        Element timeStampElement = null;
         switch (timestampFormat.toUpperCase()) {
             case "RFC3852":
                 try {
+                    timeStampElement =
+                            doc.createElement(SwidTagConstants.RFC3852_PFX + ":timestamp");
                     byte[] counterSignature = Base64.getEncoder().encode(
                             Files.readAllBytes(Paths.get(timestampArgument)));
                     timeStampElement.setAttributeNS("http://www.w3.org/2000/xmlns/",
@@ -801,6 +801,8 @@ public class SwidTagGateway {
                 }
                 break;
             case "RFC3339":
+                timeStampElement =
+                        doc.createElement(SwidTagConstants.RFC3339_PFX + ":timestamp");
                 timeStampElement.setAttributeNS("http://www.w3.org/2000/xmlns/",
                         "xmlns:" + SwidTagConstants.RFC3339_PFX,
                         SwidTagConstants.RFC3339_NS);

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagValidator.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagValidator.java
@@ -534,6 +534,7 @@ public class SwidTagValidator {
             System.out.println("Error setting schema for validation!");
         } catch (UnmarshalException e) {
             System.out.println("Error validating swidtag file!");
+            e.printStackTrace();
         } catch (IllegalArgumentException e) {
             System.out.println("Input file empty.");
         } catch (JAXBException e) {

--- a/tools/tcg_rim_tool/src/test/java/hirs/swid/TestSwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/test/java/hirs/swid/TestSwidTagGateway.java
@@ -178,6 +178,7 @@ public class TestSwidTagGateway {
             validator.validateSwidTag(DEFAULT_OUTPUT, "DEFAULT");
         } catch (Exception e) {
             e.printStackTrace();
+            Assert.fail();
         }
     }
 

--- a/tools/tcg_rim_tool/src/test/resources/generated_default_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_default_cert.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" xmlns:pcRim="https://trustedcomputinggroup.org/resource/tcg-pc-client-reference-integrity-manifest-specification/" corpus="false" name="Example.com BIOS" patch="false" pcRim:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
+        <DigestValue>9pLMfQcXsZKTNXd03a4djOUV6YofZJgtqZssSGf1ZGk=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>A3pJKDMdEtJ9u7b9lcDnMfRhGqDuZyUx2aZF3AuAkTV5NcXJcEp4lf1K+nNhA8SDdDj2hvkGpcY5&#13;
-34oYRtyUPXCHss+v+JMj5Bw4yF+yOCc0ApI8bChjVqShMaUKm2+JB6U5l7/GTWSJri8CVyHLyFf8&#13;
-Mef5+0x5OH6hEjRYlk4da05yC73rH7Mf20k0rgWV3Lya8DQYE7+eHtkKORvfR3ThSP6a1T0E4rKm&#13;
-cghxSCAJCxcFFzyiHjrHW7k5NO4idKwMZnGLam/ymfGg6lCGdMQyGibd46f607Mt2vlanscz96Y8&#13;
-98MDW0W2gZIxetfbCZdkfQBPQPBFUHWNzs9RZw==</SignatureValue>
+    <SignatureValue>d1lbsuwLrCC6WMmdRHi2VUn7h6y5dX/sAD+LpRv2wD5IYnIsL+MLgIuiTIblb1xKrbpznMmnpJYG&#13;
+jiGwx0PgD10pdaPX2P04/kJbv4MYqfx30TEwNXWKWPxJ1ChOKalqJ0olV/NxA3gX686rzxaoNSQN&#13;
+ucwwrKMvZOy+1ZVyX9ewpHXIDRDDdZ8cB7b1SKsY/XQL6+Kel7va608fDn4WvHfpXd3meNePFg7Y&#13;
+ORSR5fhElU/YLKkHesIVksfcodKG+I2N4z5yLOFEo8dHWcwKrhtXm2FP1zzLj9qKex9ZVpFJXVsz&#13;
+XCgdZu0AhF2T4IJ+NN/3YGHb/JS2p5Z5GrbeFw==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>

--- a/tools/tcg_rim_tool/src/test/resources/generated_default_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_default_cert.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>f3ulvid12X4b4EqgAQrriXwqvqlNd1GXoSf/wI+zf2A=</DigestValue>
+        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>GbvVCBhCDBa1Oz0HereVan1VzqFnkhQbG/QvYAtaPwWCpqtVqSTla0dvEW8LFKJtoLpE8ZQopshx&#13;
-se53rd9Z4aR2ok7VKfhtFV6LCNseyvmzWypqzCvLaG0net7EpMCixj8i0A5e4zaAEgt5Jqg1Acew&#13;
-hAY8XSnz9/e0EuzC3s9QlWSZHBtSvqlWUhsSVThf9KyHE3F/bwUGmEg6QdtREAr3c2jNK+LEN5MF&#13;
-hx64fG/WLRaAkw0lEWnBbjCdiB1ao+1G/c9yzxUQ82EriJdRBYjuRVmMlIOFRtYqe7oc5148pAAY&#13;
-qhol4MYlrmdjg9aW+2nv4KHHSDIhVgAAwRNJoQ==</SignatureValue>
+    <SignatureValue>A3pJKDMdEtJ9u7b9lcDnMfRhGqDuZyUx2aZF3AuAkTV5NcXJcEp4lf1K+nNhA8SDdDj2hvkGpcY5&#13;
+34oYRtyUPXCHss+v+JMj5Bw4yF+yOCc0ApI8bChjVqShMaUKm2+JB6U5l7/GTWSJri8CVyHLyFf8&#13;
+Mef5+0x5OH6hEjRYlk4da05yC73rH7Mf20k0rgWV3Lya8DQYE7+eHtkKORvfR3ThSP6a1T0E4rKm&#13;
+cghxSCAJCxcFFzyiHjrHW7k5NO4idKwMZnGLam/ymfGg6lCGdMQyGibd46f607Mt2vlanscz96Y8&#13;
+98MDW0W2gZIxetfbCZdkfQBPQPBFUHWNzs9RZw==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>

--- a/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3339.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3339.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" xmlns:pcRim="https://trustedcomputinggroup.org/resource/tcg-pc-client-reference-integrity-manifest-specification/" corpus="false" name="Example.com BIOS" patch="false" pcRim:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,18 +17,18 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
+        <DigestValue>9pLMfQcXsZKTNXd03a4djOUV6YofZJgtqZssSGf1ZGk=</DigestValue>
       </Reference>
       <Reference URI="#TST">
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>w9S075RBh56XQspLmVPFxpCV9FPkYTC3WUknwUD4e0U=</DigestValue>
+        <DigestValue>t4Csphwg9wOeclu4aD1noVk7FtRKCDPfUsu6ZP8WNmw=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>PvUU66294BZNd0vwj0i37lX3Ghlw2L65ukqCCs5xulButgEebPpjPbxjaOAjzg9IHap+z+vEevXP&#13;
-zlW51R3/5xWYuu2mmxmidwjLkIKE6qIuCclv4GMsSrgQtHB/9KZSmFm9AQUETOs7IL/YWs349Rgm&#13;
-mJ1ncGMhFKEggGim2LhAwVxWAMmuo9JpYlmxs9jOi1oKJELavXdWOZePCeaclbHfnVD9YliZBf0y&#13;
-2wpSOCB25Y/vqynm6q1n9eUtkkGBYgyFEAUpUY6tn+NoGnalo3KjB+Z20NY34Et0Gz2gj6BY/UZ0&#13;
-xvnSnzuxSk8JXwDIxgBWHEuO0KkgJl+RN1SOoQ==</SignatureValue>
+    <SignatureValue>Hvx/nVnCcuMPApoaHH+nQWvOtwWRKyAubsoYaNqJVwj2pvyptqo6CePbt0a90ZEZDhkv0nUt56Ky&#13;
+VtuHVWK9i7m4JfL/vziZ2AfFkWhWFBD0cc2YxvEGs9pRZCNcYFpkXGXNs/g0ZHJSvFUyo6SgtGvo&#13;
+K1i+QJ97HYX0X0BEpXuOKyb5IVsiST3maGwMbdYxWyYWmKqwWALYE6wb+gD/g0gWjsP2EIrTTmOl&#13;
+d165CXPGspuCDbfEh51UUqjoqm7cWn/A6L+epFT3bB3G4i3JfSwnLbQvWdNfgukWafAkr5jOUWtG&#13;
+3y0ZQd635dDz4cMOWXNWUpB+FRwuV0l/bmRdMQ==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>

--- a/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3339.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3339.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,25 +17,25 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>f3ulvid12X4b4EqgAQrriXwqvqlNd1GXoSf/wI+zf2A=</DigestValue>
+        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
       </Reference>
       <Reference URI="#TST">
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>j8sqX9NGt8DAPOvbhXKAT648BGdPnQnblai1PYDUryE=</DigestValue>
+        <DigestValue>w9S075RBh56XQspLmVPFxpCV9FPkYTC3WUknwUD4e0U=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>RvpLLE0rAaZrj54xy3Ki1GJ3csJI5lzshcpQQz7M5dn56Wo1ShfQR7OqGN1ZMULAtYsR0vtt9UFk&#13;
-3JuB1/tsA1KuT5sNTR6ZbOCaMGfV448ufbY48Vbk8Bs+2N0mZuuD3IUwARlbjXxZwb/k1GnkGVKS&#13;
-jneEK2dJ6Ktk8+XOLhoFd1JZqpz9Qv7s53GMtQc/QC18vrmUZDW5HABMCtZRpylGjBsP/Mabakb4&#13;
-Nr4veMqhEMGVm2UpYY3171nTCjerxrf0jXsLZoTbJdJtyjo9ihCbjzYUOG361liQ3k63jVfPQbDl&#13;
-460jU4v+45L/sWNRUi29VBtgia7xAkQ3IdmSPA==</SignatureValue>
+    <SignatureValue>PvUU66294BZNd0vwj0i37lX3Ghlw2L65ukqCCs5xulButgEebPpjPbxjaOAjzg9IHap+z+vEevXP&#13;
+zlW51R3/5xWYuu2mmxmidwjLkIKE6qIuCclv4GMsSrgQtHB/9KZSmFm9AQUETOs7IL/YWs349Rgm&#13;
+mJ1ncGMhFKEggGim2LhAwVxWAMmuo9JpYlmxs9jOi1oKJELavXdWOZePCeaclbHfnVD9YliZBf0y&#13;
+2wpSOCB25Y/vqynm6q1n9eUtkkGBYgyFEAUpUY6tn+NoGnalo3KjB+Z20NY34Et0Gz2gj6BY/UZ0&#13;
+xvnSnzuxSk8JXwDIxgBWHEuO0KkgJl+RN1SOoQ==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>
     <Object>
       <SignatureProperties>
         <SignatureProperty Id="TST" Target="RimSignature">
-          <TimeStamp xmlns:rcf3339="https://www.ietf.org/rfc/rfc3339.txt" dateTime="2023-01-01T00:00:00Z"/>
+          <rcf3339:timestamp xmlns:rcf3339="https://www.ietf.org/rfc/rfc3339.txt" dateTime="2023-01-01T00:00:00Z"/>
         </SignatureProperty>
       </SignatureProperties>
     </Object>

--- a/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3852.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3852.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,25 +17,25 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>f3ulvid12X4b4EqgAQrriXwqvqlNd1GXoSf/wI+zf2A=</DigestValue>
+        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
       </Reference>
       <Reference URI="#TST">
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>KC51x7iXfEjDYEieFP1lktWNGP6eCWpXe5/sr3V8PlU=</DigestValue>
+        <DigestValue>tXo0jnt5p+vph3Uak5KuolHFfHGQyLqTuLP9BBXFGVo=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>kXHqmvPCDdlUrgxKVKNXy9xmYmrMiIunv/Rc4gaho2Cm6G46BYBcjfBFkKtvvKxt+iRwk2d0JxLA&#13;
-+4oACcnUqrvfsP8WLUttrZmWvVWFcZ0WjVaqp06NVLK4for/XpJ0SQQQdO+PmEEgLzyZtydYl8n0&#13;
-tdFe9jAmIQD+DZmuHPE/abHvzCmCHgbfogHpkcoeDzT0FQu7Tvxyvae92F3jr2E/Tnt2pF9plxa0&#13;
-WZ+5WDmQ4gI+8DXETGxBhSMaR3GOvN+eFOyOUq/OzLs+T7UaOHLtmZHWKYWdBQa3j49VUREGu601&#13;
-qOAHjj9sJYSVuyrzDka6brY756ib6e7f1xwphw==</SignatureValue>
+    <SignatureValue>G4YPYyfKovSALnJXmZ0HwBC6CrikMQfYjE06oqmHmeHCEBuJaNGBx0SglJaGOXHPcLZxQDJjKm5r&#13;
+U9plTCi1WdWhOd2m+azQfwZMTR/G9pfT0iLuE0KRDUsh/1pmvh/mKqwbTfLf2vhpUPxneVqSPIf5&#13;
+9LiEfTqcf9hhZ8aZ3+RobMSJ0a5xGkbwCZtq+VEzamfNhY3fp0u21i4D/tZumm0CC5QNWPLKXnoz&#13;
+X5b/9Ar2pO5rNTzzmExPTVubjYSaV7HOAvUz82NbFAvjefnSgD8h6edCGW6bBBT6cYj5tdMs5PKA&#13;
+DHFuJNz2SgrPVviy/xp92WShhypFGN3keqkzuA==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>
     <Object>
       <SignatureProperties>
         <SignatureProperty Id="TST" Target="RimSignature">
-          <TimeStamp xmlns:rcf3852="https://www.ietf.org/rfc/rfc3852.txt" dateTime="dGVzdAo="/>
+          <rcf3852:timestamp xmlns:rcf3852="https://www.ietf.org/rfc/rfc3852.txt" dateTime="dGVzdAo="/>
         </SignatureProperty>
       </SignatureProperties>
     </Object>

--- a/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3852.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3852.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" xmlns:pcRim="https://trustedcomputinggroup.org/resource/tcg-pc-client-reference-integrity-manifest-specification/" corpus="false" name="Example.com BIOS" patch="false" pcRim:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,18 +17,18 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
+        <DigestValue>9pLMfQcXsZKTNXd03a4djOUV6YofZJgtqZssSGf1ZGk=</DigestValue>
       </Reference>
       <Reference URI="#TST">
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>tXo0jnt5p+vph3Uak5KuolHFfHGQyLqTuLP9BBXFGVo=</DigestValue>
+        <DigestValue>Sv8QDWUUwrxCoUwFj0veh3oFqG/8XVscoqUDd96GL6Q=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>G4YPYyfKovSALnJXmZ0HwBC6CrikMQfYjE06oqmHmeHCEBuJaNGBx0SglJaGOXHPcLZxQDJjKm5r&#13;
-U9plTCi1WdWhOd2m+azQfwZMTR/G9pfT0iLuE0KRDUsh/1pmvh/mKqwbTfLf2vhpUPxneVqSPIf5&#13;
-9LiEfTqcf9hhZ8aZ3+RobMSJ0a5xGkbwCZtq+VEzamfNhY3fp0u21i4D/tZumm0CC5QNWPLKXnoz&#13;
-X5b/9Ar2pO5rNTzzmExPTVubjYSaV7HOAvUz82NbFAvjefnSgD8h6edCGW6bBBT6cYj5tdMs5PKA&#13;
-DHFuJNz2SgrPVviy/xp92WShhypFGN3keqkzuA==</SignatureValue>
+    <SignatureValue>bCet0/jmRLoKnSicKKjkIQCox0gxZv48mOe0PcPU3FRBHbyZc4zzGeeanisz4/HwR4VbE1yKp1M4&#13;
+O2swiUih6iqNQwirQJVMks69fx9ueonPTUfJnQ/I+XLzCWRWivMM4gPs6Ubuvim+81I4Hjv2uIE2&#13;
+bqAWcixIvXvSaUL+O3BnTy9ykgRQrG9easHjEFV/Jrfb0s33WtvmjuV0kqDgHtvG96RitYOLG0Tr&#13;
+naEe2zNgB8+44IyWwGzEkYjG7JIVOW9QqlSKn4Gc2SVATw8eFnIRQYDh3kLG+IcaX8b94BabTiaX&#13;
+OH3ezftPeYay9H3f3nuApQZ5ujmqoORcTJxXcA==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>

--- a/tools/tcg_rim_tool/src/test/resources/generated_truststore_embed.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_truststore_embed.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>f3ulvid12X4b4EqgAQrriXwqvqlNd1GXoSf/wI+zf2A=</DigestValue>
+        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>GbvVCBhCDBa1Oz0HereVan1VzqFnkhQbG/QvYAtaPwWCpqtVqSTla0dvEW8LFKJtoLpE8ZQopshx&#13;
-se53rd9Z4aR2ok7VKfhtFV6LCNseyvmzWypqzCvLaG0net7EpMCixj8i0A5e4zaAEgt5Jqg1Acew&#13;
-hAY8XSnz9/e0EuzC3s9QlWSZHBtSvqlWUhsSVThf9KyHE3F/bwUGmEg6QdtREAr3c2jNK+LEN5MF&#13;
-hx64fG/WLRaAkw0lEWnBbjCdiB1ao+1G/c9yzxUQ82EriJdRBYjuRVmMlIOFRtYqe7oc5148pAAY&#13;
-qhol4MYlrmdjg9aW+2nv4KHHSDIhVgAAwRNJoQ==</SignatureValue>
+    <SignatureValue>A3pJKDMdEtJ9u7b9lcDnMfRhGqDuZyUx2aZF3AuAkTV5NcXJcEp4lf1K+nNhA8SDdDj2hvkGpcY5&#13;
+34oYRtyUPXCHss+v+JMj5Bw4yF+yOCc0ApI8bChjVqShMaUKm2+JB6U5l7/GTWSJri8CVyHLyFf8&#13;
+Mef5+0x5OH6hEjRYlk4da05yC73rH7Mf20k0rgWV3Lya8DQYE7+eHtkKORvfR3ThSP6a1T0E4rKm&#13;
+cghxSCAJCxcFFzyiHjrHW7k5NO4idKwMZnGLam/ymfGg6lCGdMQyGibd46f607Mt2vlanscz96Y8&#13;
+98MDW0W2gZIxetfbCZdkfQBPQPBFUHWNzs9RZw==</SignatureValue>
     <KeyInfo>
       <X509Data>
         <X509SubjectName>CN=example.RIM.signer,OU=PCClient,O=Example,ST=VA,C=US</X509SubjectName>

--- a/tools/tcg_rim_tool/src/test/resources/generated_truststore_embed.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_truststore_embed.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" xmlns:pcRim="https://trustedcomputinggroup.org/resource/tcg-pc-client-reference-integrity-manifest-specification/" corpus="false" name="Example.com BIOS" patch="false" pcRim:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
+        <DigestValue>9pLMfQcXsZKTNXd03a4djOUV6YofZJgtqZssSGf1ZGk=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>A3pJKDMdEtJ9u7b9lcDnMfRhGqDuZyUx2aZF3AuAkTV5NcXJcEp4lf1K+nNhA8SDdDj2hvkGpcY5&#13;
-34oYRtyUPXCHss+v+JMj5Bw4yF+yOCc0ApI8bChjVqShMaUKm2+JB6U5l7/GTWSJri8CVyHLyFf8&#13;
-Mef5+0x5OH6hEjRYlk4da05yC73rH7Mf20k0rgWV3Lya8DQYE7+eHtkKORvfR3ThSP6a1T0E4rKm&#13;
-cghxSCAJCxcFFzyiHjrHW7k5NO4idKwMZnGLam/ymfGg6lCGdMQyGibd46f607Mt2vlanscz96Y8&#13;
-98MDW0W2gZIxetfbCZdkfQBPQPBFUHWNzs9RZw==</SignatureValue>
+    <SignatureValue>d1lbsuwLrCC6WMmdRHi2VUn7h6y5dX/sAD+LpRv2wD5IYnIsL+MLgIuiTIblb1xKrbpznMmnpJYG&#13;
+jiGwx0PgD10pdaPX2P04/kJbv4MYqfx30TEwNXWKWPxJ1ChOKalqJ0olV/NxA3gX686rzxaoNSQN&#13;
+ucwwrKMvZOy+1ZVyX9ewpHXIDRDDdZ8cB7b1SKsY/XQL6+Kel7va608fDn4WvHfpXd3meNePFg7Y&#13;
+ORSR5fhElU/YLKkHesIVksfcodKG+I2N4z5yLOFEo8dHWcwKrhtXm2FP1zzLj9qKex9ZVpFJXVsz&#13;
+XCgdZu0AhF2T4IJ+NN/3YGHb/JS2p5Z5GrbeFw==</SignatureValue>
     <KeyInfo>
       <X509Data>
         <X509SubjectName>CN=example.RIM.signer,OU=PCClient,O=Example,ST=VA,C=US</X509SubjectName>

--- a/tools/tcg_rim_tool/src/test/resources/generated_user_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_user_cert.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" xmlns:pcRim="https://trustedcomputinggroup.org/resource/tcg-pc-client-reference-integrity-manifest-specification/" corpus="false" name="Example.com BIOS" patch="false" pcRim:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
+        <DigestValue>9pLMfQcXsZKTNXd03a4djOUV6YofZJgtqZssSGf1ZGk=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>A3pJKDMdEtJ9u7b9lcDnMfRhGqDuZyUx2aZF3AuAkTV5NcXJcEp4lf1K+nNhA8SDdDj2hvkGpcY5&#13;
-34oYRtyUPXCHss+v+JMj5Bw4yF+yOCc0ApI8bChjVqShMaUKm2+JB6U5l7/GTWSJri8CVyHLyFf8&#13;
-Mef5+0x5OH6hEjRYlk4da05yC73rH7Mf20k0rgWV3Lya8DQYE7+eHtkKORvfR3ThSP6a1T0E4rKm&#13;
-cghxSCAJCxcFFzyiHjrHW7k5NO4idKwMZnGLam/ymfGg6lCGdMQyGibd46f607Mt2vlanscz96Y8&#13;
-98MDW0W2gZIxetfbCZdkfQBPQPBFUHWNzs9RZw==</SignatureValue>
+    <SignatureValue>d1lbsuwLrCC6WMmdRHi2VUn7h6y5dX/sAD+LpRv2wD5IYnIsL+MLgIuiTIblb1xKrbpznMmnpJYG&#13;
+jiGwx0PgD10pdaPX2P04/kJbv4MYqfx30TEwNXWKWPxJ1ChOKalqJ0olV/NxA3gX686rzxaoNSQN&#13;
+ucwwrKMvZOy+1ZVyX9ewpHXIDRDDdZ8cB7b1SKsY/XQL6+Kel7va608fDn4WvHfpXd3meNePFg7Y&#13;
+ORSR5fhElU/YLKkHesIVksfcodKG+I2N4z5yLOFEo8dHWcwKrhtXm2FP1zzLj9qKex9ZVpFJXVsz&#13;
+XCgdZu0AhF2T4IJ+NN/3YGHb/JS2p5Z5GrbeFw==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
       <KeyValue>

--- a/tools/tcg_rim_tool/src/test/resources/generated_user_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_user_cert.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>f3ulvid12X4b4EqgAQrriXwqvqlNd1GXoSf/wI+zf2A=</DigestValue>
+        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>GbvVCBhCDBa1Oz0HereVan1VzqFnkhQbG/QvYAtaPwWCpqtVqSTla0dvEW8LFKJtoLpE8ZQopshx&#13;
-se53rd9Z4aR2ok7VKfhtFV6LCNseyvmzWypqzCvLaG0net7EpMCixj8i0A5e4zaAEgt5Jqg1Acew&#13;
-hAY8XSnz9/e0EuzC3s9QlWSZHBtSvqlWUhsSVThf9KyHE3F/bwUGmEg6QdtREAr3c2jNK+LEN5MF&#13;
-hx64fG/WLRaAkw0lEWnBbjCdiB1ao+1G/c9yzxUQ82EriJdRBYjuRVmMlIOFRtYqe7oc5148pAAY&#13;
-qhol4MYlrmdjg9aW+2nv4KHHSDIhVgAAwRNJoQ==</SignatureValue>
+    <SignatureValue>A3pJKDMdEtJ9u7b9lcDnMfRhGqDuZyUx2aZF3AuAkTV5NcXJcEp4lf1K+nNhA8SDdDj2hvkGpcY5&#13;
+34oYRtyUPXCHss+v+JMj5Bw4yF+yOCc0ApI8bChjVqShMaUKm2+JB6U5l7/GTWSJri8CVyHLyFf8&#13;
+Mef5+0x5OH6hEjRYlk4da05yC73rH7Mf20k0rgWV3Lya8DQYE7+eHtkKORvfR3ThSP6a1T0E4rKm&#13;
+cghxSCAJCxcFFzyiHjrHW7k5NO4idKwMZnGLam/ymfGg6lCGdMQyGibd46f607Mt2vlanscz96Y8&#13;
+98MDW0W2gZIxetfbCZdkfQBPQPBFUHWNzs9RZw==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
       <KeyValue>

--- a/tools/tcg_rim_tool/src/test/resources/generated_user_cert_embed.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_user_cert_embed.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>f3ulvid12X4b4EqgAQrriXwqvqlNd1GXoSf/wI+zf2A=</DigestValue>
+        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>GbvVCBhCDBa1Oz0HereVan1VzqFnkhQbG/QvYAtaPwWCpqtVqSTla0dvEW8LFKJtoLpE8ZQopshx&#13;
-se53rd9Z4aR2ok7VKfhtFV6LCNseyvmzWypqzCvLaG0net7EpMCixj8i0A5e4zaAEgt5Jqg1Acew&#13;
-hAY8XSnz9/e0EuzC3s9QlWSZHBtSvqlWUhsSVThf9KyHE3F/bwUGmEg6QdtREAr3c2jNK+LEN5MF&#13;
-hx64fG/WLRaAkw0lEWnBbjCdiB1ao+1G/c9yzxUQ82EriJdRBYjuRVmMlIOFRtYqe7oc5148pAAY&#13;
-qhol4MYlrmdjg9aW+2nv4KHHSDIhVgAAwRNJoQ==</SignatureValue>
+    <SignatureValue>A3pJKDMdEtJ9u7b9lcDnMfRhGqDuZyUx2aZF3AuAkTV5NcXJcEp4lf1K+nNhA8SDdDj2hvkGpcY5&#13;
+34oYRtyUPXCHss+v+JMj5Bw4yF+yOCc0ApI8bChjVqShMaUKm2+JB6U5l7/GTWSJri8CVyHLyFf8&#13;
+Mef5+0x5OH6hEjRYlk4da05yC73rH7Mf20k0rgWV3Lya8DQYE7+eHtkKORvfR3ThSP6a1T0E4rKm&#13;
+cghxSCAJCxcFFzyiHjrHW7k5NO4idKwMZnGLam/ymfGg6lCGdMQyGibd46f607Mt2vlanscz96Y8&#13;
+98MDW0W2gZIxetfbCZdkfQBPQPBFUHWNzs9RZw==</SignatureValue>
     <KeyInfo>
       <X509Data>
         <X509SubjectName>CN=example.RIM.signer,OU=PCClient,O=Example,ST=VA,C=US</X509SubjectName>

--- a/tools/tcg_rim_tool/src/test/resources/generated_user_cert_embed.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_user_cert_embed.swidtag
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:hirs="https://hirs.gov" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" hirs:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" xmlns:pcRim="https://trustedcomputinggroup.org/resource/tcg-pc-client-reference-integrity-manifest-specification/" corpus="false" name="Example.com BIOS" patch="false" pcRim:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
   <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>I1c15EG4XjWL8a8JL4MDFyPqY7+wpQmC8dwSJTQXGMg=</DigestValue>
+        <DigestValue>9pLMfQcXsZKTNXd03a4djOUV6YofZJgtqZssSGf1ZGk=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>A3pJKDMdEtJ9u7b9lcDnMfRhGqDuZyUx2aZF3AuAkTV5NcXJcEp4lf1K+nNhA8SDdDj2hvkGpcY5&#13;
-34oYRtyUPXCHss+v+JMj5Bw4yF+yOCc0ApI8bChjVqShMaUKm2+JB6U5l7/GTWSJri8CVyHLyFf8&#13;
-Mef5+0x5OH6hEjRYlk4da05yC73rH7Mf20k0rgWV3Lya8DQYE7+eHtkKORvfR3ThSP6a1T0E4rKm&#13;
-cghxSCAJCxcFFzyiHjrHW7k5NO4idKwMZnGLam/ymfGg6lCGdMQyGibd46f607Mt2vlanscz96Y8&#13;
-98MDW0W2gZIxetfbCZdkfQBPQPBFUHWNzs9RZw==</SignatureValue>
+    <SignatureValue>d1lbsuwLrCC6WMmdRHi2VUn7h6y5dX/sAD+LpRv2wD5IYnIsL+MLgIuiTIblb1xKrbpznMmnpJYG&#13;
+jiGwx0PgD10pdaPX2P04/kJbv4MYqfx30TEwNXWKWPxJ1ChOKalqJ0olV/NxA3gX686rzxaoNSQN&#13;
+ucwwrKMvZOy+1ZVyX9ewpHXIDRDDdZ8cB7b1SKsY/XQL6+Kel7va608fDn4WvHfpXd3meNePFg7Y&#13;
+ORSR5fhElU/YLKkHesIVksfcodKG+I2N4z5yLOFEo8dHWcwKrhtXm2FP1zzLj9qKex9ZVpFJXVsz&#13;
+XCgdZu0AhF2T4IJ+NN/3YGHb/JS2p5Z5GrbeFw==</SignatureValue>
     <KeyInfo>
       <X509Data>
         <X509SubjectName>CN=example.RIM.signer,OU=PCClient,O=Example,ST=VA,C=US</X509SubjectName>


### PR DESCRIPTION
The unit tests were failing to validate because `<SoftwareIdentity id=...` and `<Timestamp>` must be in unique namespaces from the SWID schema.  In order to pass validation these changes add the following custom namespaces:

- `<SoftwareIdentity pcRim:id=...`
- `<rfc####:timestamp .....>`


Unit tests have been updated accordingly.

Closes #501 