### PR TITLE
bootRun and bootWar 

### DIFF
--- a/HIRS_AttestationCAPortal/build.gradle
+++ b/HIRS_AttestationCAPortal/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'commons-fileupload:commons-fileupload:1.5'
     implementation 'org.junit.jupiter:junit-jupiter:5.4.2'
     implementation 'org.junit.jupiter:junit-jupiter:5.4.2'
+    implementation 'org.apache.tomcat.embed:tomcat-embed-jasper:10.1.5'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
@@ -56,13 +57,13 @@ dependencies {
     testImplementation libs.testng
 }
 
-war {
-    from(buildDir) {
-        include 'VERSION'
-        into 'WEB-INF/classes'
-    }
-    archiveFileName = 'HIRS_AttestationCAPortal.war'
-}
+//war {
+//    from(buildDir) {
+//        include 'VERSION'
+//        into 'WEB-INF/classes'
+//    }
+//    archiveFileName = 'HIRS_AttestationCAPortal.war'
+//}
 
 ospackage {
     packageName = 'HIRS_AttestationCA'

--- a/HIRS_AttestationCAPortal/build.gradle
+++ b/HIRS_AttestationCAPortal/build.gradle
@@ -22,6 +22,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    all*.exclude module: 'spring-boot-starter-logging'
 }
 
 repositories {
@@ -42,6 +43,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+    implementation 'org.apache.logging.log4j:log4j-spring-boot'
     implementation 'org.projectlombok:lombok'
     implementation 'commons-fileupload:commons-fileupload:1.5'
     implementation 'org.junit.jupiter:junit-jupiter:5.4.2'

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/HIRSApplication.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/HIRSApplication.java
@@ -15,26 +15,27 @@ import org.springframework.web.servlet.DispatcherServlet;
 import java.util.Collections;
 
 @SpringBootApplication
-@EnableAutoConfiguration
-@Log4j2
-public class HIRSApplication extends SpringBootServletInitializer {
+//@EnableAutoConfiguration
+//@Log4j2
+public class HIRSApplication {//extends SpringBootServletInitializer {
 
-    @Override
-    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
-        return application.sources(HIRSApplication.class);
-    }
+//    @Override
+//    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
+//        return application.sources(HIRSApplication.class);
+//    }
 
-    @Override
-    public void onStartup(ServletContext servletContext) throws ServletException {
-        ServletRegistration.Dynamic appServlet = servletContext.addServlet("mvc", new DispatcherServlet(
-                new GenericWebApplicationContext()));
+//    @Override
+//    public void onStartup(ServletContext servletContext) throws ServletException {
+//        ServletRegistration.Dynamic appServlet = servletContext.addServlet("mvc", new DispatcherServlet(
+//                new GenericWebApplicationContext()));
 
-        appServlet.setLoadOnStartup(1);
-    }
+//        appServlet.setLoadOnStartup(1);
+//    }
 
     public static void main(String[] args) {
-        SpringApplication springApplication = new SpringApplication(HIRSApplication.class);
-        springApplication.setDefaultProperties(Collections.singletonMap("server.servlet.context-path", "/portal"));
-        springApplication.run(args);
+//        SpringApplication springApplication = new SpringApplication(HIRSApplication.class);
+//        springApplication.setDefaultProperties(Collections.singletonMap("server.servlet.context-path", "/portal"));
+//        springApplication.run(args);
+        SpringApplication.run(HIRSApplication.class, args);
     }
 }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/HIRSApplication.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/HIRSApplication.java
@@ -16,9 +16,9 @@ import java.util.Collections;
 
 @SpringBootApplication
 //@EnableAutoConfiguration
-//@Log4j2
+@Log4j2
 public class HIRSApplication {//extends SpringBootServletInitializer {
-
+//      private static final Logger LOGGER = LogManager.getLogger(HIRSApplication.class);
 //    @Override
 //    protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
 //        return application.sources(HIRSApplication.class);

--- a/HIRS_AttestationCAPortal/src/main/resources/application.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.properties
@@ -1,9 +1,10 @@
 
-server.error.path=/error
-spring.mvc.view.prefix=/WEB-INF/jsp/
-spring.mvc.view.suffix=.jsp
+#server.error.path=/error
+#spring.mvc.view.prefix=/WEB-INF/jsp/
+#spring.mvc.view.suffix=.jsp
 
 logging.level.org.springframework=INFO
+logging.level.org.apache.catalina=DEBUG
 spring.jpa.hibernate.ddl-auto=update
 spring.datasource.url=jdbc:mariadb://localhost:3306/hirs_db?autoReconnect=true&useSSL=false
 spring.datasource.username=hirs_db
@@ -20,6 +21,10 @@ server.tomcat.accesslog.file-date-format=yyyy-MM-dd
 server.tomcat.accesslog.prefix=access_log
 server.tomcat.accesslog.suffix=.log
 server.tomcat.accesslog.rotate=true
+
+server.tomcat.basedir=/opt/embeddedtomcat
+server.servlet.register-default-servlet=true
+server.servlet.context-path=/HIRS_AttestationCAPortal/portal
 
 #jdbc.driverClassName = com.mysql.cj.jdbc.Driver
 #jdbc.url = jdbc:mysql://localhost:3306/hirs_db?autoReconnect=true&useSSL=false

--- a/HIRS_AttestationCAPortal/src/main/resources/application.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.properties
@@ -24,7 +24,8 @@ server.tomcat.accesslog.rotate=true
 
 server.tomcat.basedir=/opt/embeddedtomcat
 server.servlet.register-default-servlet=true
-server.servlet.context-path=/HIRS_AttestationCAPortal/portal
+server.servlet.context-path=/HIRS_AttestationCAPortal
+spring.mvc.servlet.path=/portal
 
 #jdbc.driverClassName = com.mysql.cj.jdbc.Driver
 #jdbc.url = jdbc:mysql://localhost:3306/hirs_db?autoReconnect=true&useSSL=false

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/tags/page.tag
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/tags/page.tag
@@ -13,7 +13,7 @@
 <c:set var="icons" value="${images}/icons" scope="session" />
 <c:set var="common" value="${baseURL}/common" scope="session" />
 <c:set var="lib" value="${baseURL}/lib" scope="session" />
-<c:set var="portal" value="${baseURL}" scope="session" />
+<c:set var="portal" value="${baseURL}/portal" scope="session" />
 <c:set var="pagePath" value="${portal}/${page.prefixPath}${page.viewName}" scope="session" />
 <c:set var="certificateRequest" value="${portal}/certificate-request" scope="session" />
 

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/tags/page.tag
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/tags/page.tag
@@ -13,7 +13,7 @@
 <c:set var="icons" value="${images}/icons" scope="session" />
 <c:set var="common" value="${baseURL}/common" scope="session" />
 <c:set var="lib" value="${baseURL}/lib" scope="session" />
-<c:set var="portal" value="${baseURL}/portal" scope="session" />
+<c:set var="portal" value="${baseURL}" scope="session" />
 <c:set var="pagePath" value="${portal}/${page.prefixPath}${page.viewName}" scope="session" />
 <c:set var="certificateRequest" value="${portal}/certificate-request" scope="session" />
 


### PR DESCRIPTION
```./gradlew bootRun``` will build the ACA and launch it with an embedded tomcat 
<br/>
```./gradlew bootWar``` will generate an executable war file. This war can be executed on any system with Java 17, including on Windows or Mac.
<br/>
When using either of these options,<br/>
* Once fully launched, the portal is accessible at localhost:8080.
* TLS is not available yet.
* The database must be set up prior to attempting to launch the ACA. The db_create.sh script under package/scripts/db can be used to set up an installed mariadb on Linux. On other systems, or if direct set up of the database is desired, the last 3 lines of that script contain mysql statements. Those 3 statements are all that are needed to get the db ready.

closes #538 