### PR TITLE
Supporting buildRpm alongside bootRun/bootWar

### DIFF
--- a/HIRS_AttestationCAPortal/build.gradle
+++ b/HIRS_AttestationCAPortal/build.gradle
@@ -60,13 +60,13 @@ dependencies {
     testImplementation libs.testng
 }
 
-//war {
-//    from(buildDir) {
-//        include 'VERSION'
-//        into 'WEB-INF/classes'
-//    }
-//    archiveFileName = 'HIRS_AttestationCAPortal.war'
-//}
+war {
+    from(buildDir) {
+        include 'VERSION'
+        into 'WEB-INF/classes'
+    }
+    archiveFileName = 'HIRS_AttestationCAPortal.war'
+}
 
 ospackage {
     packageName = 'HIRS_AttestationCA'


### PR DESCRIPTION
These commands should work as expected:
```./gradlew buildRpm```: Creates plain war: HIRS_AttestationCAPortal/build/libs/HIRS_AttestationCAPortal.war and an rpm: HIRS_AttestationCAPortal/build/distributions/HIRS_AttestationCAPortal*.rpm
```./gradlew bootRun```: Launches the ACA in an embedded tomcat.
```./gradlew bootWar```: Creates a bootable war: HIRS_AttestationCAPortal/build/libs/HIRS_AttestationCAPortal.war

The name of the war file matters when given to tomcat. If it includes any other characters, the portal url will include those extra characters.

This command will cause issues with gradle:
```./gradlew bootWar buildRpm```