### PR TITLE
Reference Digest value UI Update

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceDigestValueRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceDigestValueRepository.java
@@ -13,12 +13,11 @@ public interface ReferenceDigestValueRepository extends JpaRepository<ReferenceD
 
     @Query(value = "SELECT * FROM ReferenceDigestValue", nativeQuery = true)
     List<ReferenceDigestValue> listAll();
-    @Query(value = "SELECT * FROM ReferenceDigestValue WHERE model = ?1", nativeQuery = true)
-    List<ReferenceDigestValue> listByModel(String model);
-    @Query(value = "SELECT * FROM ReferenceDigestValue WHERE manufacturer = ?1", nativeQuery = true)
-    List<ReferenceDigestValue> listByManufacturer(String manufacturer);
+    List<ReferenceDigestValue> findByModel(String model);
+    List<ReferenceDigestValue> findByManufacturer(String manufacturer);
     @Query(value = "SELECT * FROM ReferenceDigestValue WHERE baseRimId = '?1' OR supportRimId = '?1'", nativeQuery = true)
     List<ReferenceDigestValue> getValuesByRimId(UUID associatedRimId);
     @Query(value = "SELECT * FROM ReferenceDigestValue WHERE supportRimId = '?1'", nativeQuery = true)
-    List<ReferenceDigestValue> getValuesBySupportRimId(UUID supportRimId);
+    List<ReferenceDigestValue> findBySupportRimId(UUID supportRimId);
+    List<ReferenceDigestValue> findBySupportRimHash(String supportRimHash);
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceManifestRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceManifestRepository.java
@@ -14,14 +14,12 @@ import java.util.UUID;
 @Repository
 public interface ReferenceManifestRepository extends JpaRepository<ReferenceManifest, UUID> {
 
-    @Query(value = "SELECT * FROM ReferenceManifest WHERE hexDecHash = ?1", nativeQuery = true)
-    ReferenceManifest findByHash(String rimHash);
-    @Query(value = "SELECT * FROM ReferenceManifest WHERE hexDecHash = ?1 AND rimType = ?2", nativeQuery = true)
-    ReferenceManifest findByHash(String rimHash, String rimType);
+    ReferenceManifest findByHexDecHash(String hexDecHash);
+    ReferenceManifest findByHexDecHashAndRimType(String hexDecHash, String rimType);
     @Query(value = "SELECT * FROM ReferenceManifest WHERE platformManufacturer = ?1 AND platformModel = ?2 AND rimType = 'Base'", nativeQuery = true)
     List<BaseReferenceManifest> getBaseByManufacturerModel(String manufacturer, String model);
     @Query(value = "SELECT * FROM ReferenceManifest WHERE platformManufacturer = ?1 AND DTYPE = ?2", nativeQuery = true)
-    List<ReferenceManifest> getByManufacturer(String manufacturer, String dType);
+    ReferenceManifest getByManufacturer(String manufacturer, String dType);
     @Query(value = "SELECT * FROM ReferenceManifest WHERE platformModel = ?1 AND DTYPE = ?2", nativeQuery = true)
     ReferenceManifest getByModel(String model, String dType);
     @Query(value = "SELECT * FROM ReferenceManifest WHERE DTYPE = 'BaseReferenceManifest'", nativeQuery = true)

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/EventLogMeasurements.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/EventLogMeasurements.java
@@ -3,8 +3,6 @@ package hirs.attestationca.persist.entity.userdefined.rim;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import hirs.attestationca.persist.entity.userdefined.ReferenceManifest;
 import hirs.attestationca.persist.enums.AppraisalStatus;
-import hirs.attestationca.persist.service.ReferenceManifestServiceImpl;
-import hirs.attestationca.persist.service.selector.ReferenceManifestSelector;
 import hirs.utils.tpm.eventlog.TCGEventLog;
 import hirs.utils.tpm.eventlog.TpmPcrEvent;
 import jakarta.persistence.Column;
@@ -42,66 +40,6 @@ public class EventLogMeasurements extends ReferenceManifest {
     private AppraisalStatus.Status overallValidationResult = AppraisalStatus.Status.FAIL;
 
     /**
-     * This class enables the retrieval of SupportReferenceManifest by their attributes.
-     */
-    public static class Selector extends ReferenceManifestSelector<EventLogMeasurements> {
-        /**
-         * Construct a new ReferenceManifestSelector that
-         * will use the given (@link ReferenceManifestService}
-         * to retrieve one or may SupportReferenceManifest.
-         *
-         * @param referenceManifestManager the reference manifest manager to be used to retrieve
-         * reference manifests.
-         */
-        public Selector(final ReferenceManifestServiceImpl referenceManifestManager) {
-            super(referenceManifestManager, EventLogMeasurements.class, false);
-        }
-
-        /**
-         * Specify the platform manufacturer that rims must have to be considered
-         * as matching.
-         * @param manufacturer string for the manufacturer
-         * @return this instance
-         */
-        public Selector byManufacturer(final String manufacturer) {
-            setFieldValue(PLATFORM_MANUFACTURER, manufacturer);
-            return this;
-        }
-
-        /**
-         * Specify the platform model that rims must have to be considered
-         * as matching.
-         * @param model string for the model
-         * @return this instance
-         */
-        public Selector byModel(final String model) {
-            setFieldValue(PLATFORM_MODEL, model);
-            return this;
-        }
-
-        /**
-         * Specify the device name that rims must have to be considered
-         * as matching.
-         * @param deviceName string for the deviceName
-         * @return this instance
-         */
-        public Selector byDeviceName(final String deviceName) {
-            setFieldValue("deviceName", deviceName);
-            return this;
-        }
-
-        /**
-         * Specify the RIM hash associated with the Event Log.
-         * @param hexDecHash the hash of the file associated with the rim
-         * @return this instance
-         */
-        public Selector byHexDecHash(final String hexDecHash) {
-            setFieldValue(HEX_DEC_HASH_FIELD, hexDecHash);
-            return this;
-        }
-    }
-
-    /**
      * Support constructor for the RIM object.
      *
      * @param rimBytes byte array representation of the RIM
@@ -133,17 +71,6 @@ public class EventLogMeasurements extends ReferenceManifest {
     protected EventLogMeasurements() {
         super();
         this.pcrHash = 0;
-    }
-
-    /**
-     * Get a Selector for use in retrieving ReferenceManifest.
-     *
-     * @param rimMan the ReferenceManifestService to be used to retrieve
-     * persisted RIMs
-     * @return a Selector instance to use for retrieving RIMs
-     */
-    public static Selector select(final ReferenceManifestServiceImpl rimMan) {
-        return new Selector(rimMan);
     }
 
     /**

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/ReferenceDigestValue.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/ReferenceDigestValue.java
@@ -1,6 +1,6 @@
 package hirs.attestationca.persist.entity.userdefined.rim;
 
-import hirs.attestationca.persist.entity.ArchivableEntity;
+import hirs.attestationca.persist.entity.AbstractEntity;
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
@@ -26,7 +26,7 @@ import java.util.UUID;
 @EqualsAndHashCode(callSuper=false)
 @Table(name = "ReferenceDigestValue")
 @Access(AccessType.FIELD)
-public class ReferenceDigestValue extends ArchivableEntity {
+public class ReferenceDigestValue extends AbstractEntity {
 
     @JdbcTypeCode(java.sql.Types.VARCHAR)
     @Column
@@ -42,6 +42,8 @@ public class ReferenceDigestValue extends ArchivableEntity {
     private int pcrIndex;
     @Column(nullable = false)
     private String digestValue;
+    @Column(nullable = false)
+    private String supportRimHash;
     @Column(nullable = false)
     private String eventType;
     @Column(columnDefinition = "blob", nullable = true)
@@ -64,6 +66,7 @@ public class ReferenceDigestValue extends ArchivableEntity {
         this.model = "";
         this.pcrIndex = -1;
         this.digestValue = "";
+        this.supportRimHash = "";
         this.eventType = "";
         this.matchFail = false;
         this.patched = false;
@@ -79,6 +82,7 @@ public class ReferenceDigestValue extends ArchivableEntity {
      * @param model the specific device type
      * @param pcrIndex the event number
      * @param digestValue the key digest value
+     * @param supportRimHash the support file's hash value
      * @param eventType the event type to store
      * @param matchFail the status of the baseline check
      * @param patched the status of the value being updated to patch
@@ -88,6 +92,7 @@ public class ReferenceDigestValue extends ArchivableEntity {
     public ReferenceDigestValue(final UUID baseRimId, final UUID supportRimId,
                                 final String manufacturer, final String model,
                                 final int pcrIndex, final String digestValue,
+                                final String supportRimHash,
                                 final String eventType, final boolean matchFail,
                                 final boolean patched, final boolean updated,
                                 final byte[] contentBlob) {
@@ -97,6 +102,7 @@ public class ReferenceDigestValue extends ArchivableEntity {
         this.model = model;
         this.pcrIndex = pcrIndex;
         this.digestValue = digestValue;
+        this.supportRimHash = supportRimHash;
         this.eventType = eventType;
         this.matchFail = matchFail;
         this.patched = patched;


### PR DESCRIPTION
This PR fixes issues with displaying associated measurement events for the Reference Manifest support file.  If the support file is deleted, it now removes all associated events.  Also the repository calls are updated and the main referencing will be done by file hash instead of UUID.

This PR fixes issues associated with item 7 in #534 