### PR TITLE
[#566] Fix failing testCreateTimestampRfc2315

### DIFF
--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -815,6 +815,8 @@ public class SwidTagGateway {
         switch (timestampFormat.toUpperCase()) {
             case "RFC2315":
                 try {
+                    timeStampElement =
+                            doc.createElement(SwidTagConstants.RFC2315_PFX + ":timestamp");
                     byte[] counterSignature = Base64.getEncoder().encode(
                             Files.readAllBytes(Paths.get(timestampArgument)));
                     timeStampElement.setAttributeNS("http://www.w3.org/2000/xmlns/",

--- a/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc2315.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc2315.swidtag
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" id="94f6b457-9ac9-4d35-9b3f-78804173b65as" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" xmlns:pcRim="https://trustedcomputinggroup.org/resource/tcg-pc-client-reference-integrity-manifest-specification/" corpus="false" name="Example.com BIOS" patch="false" pcRim:id="94f6b457-9ac9-4d35-9b3f-78804173b65as" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
   <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
   <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
+  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:payloadType="direct" rim:pcUriGlobal="https://Example.com/support/ProductA/" rim:pcUriLocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
   <Payload>
     <Directory name="rim">
       <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.BIOS.01.rimel" size="7549"/>
@@ -17,25 +17,25 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>f3ulvid12X4b4EqgAQrriXwqvqlNd1GXoSf/wI+zf2A=</DigestValue>
+        <DigestValue>6Zw06t03HhtT/RdeEnhzyMl3L7kl99jh31JLDl5UqXA=</DigestValue>
       </Reference>
       <Reference URI="#TST">
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>ibBq+F0kVcZzamIb0aN2cfyexARJYg0zGFA/T+fZvFY=</DigestValue>
+        <DigestValue>m0fuWtrx9hhNHkPIUc1zvapyR4gSwNvktf37PeTZHgU=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>RYidnj7kzYjZxy22BKR9bjHktaxaKf8XgzvdKX5aG/x4Ieuu9XFDphDahoD1gkWG0WnJzaPZAoXn&#13;
-+TU25X9As7MTo2CVIcbg09ZRJIg735GlYX28dFphmiYUCEwoJ6bloSdJbt8u/GgrW/dVkldySpci&#13;
-88Y3dQoqXio2i2R7R5hIBEEdCmuQL8SmPNsAtD9pJRe5YoP8sfHo3IAL9AkYqW/+U4GkqOJyNI8G&#13;
-/Kxy4TWdzuOz2N6zqNCsDQ2FyzRUVyhQgvsHSDbaJL3IXIobxBpAUHemfVI0tO8MsTS0+v1uNypQ&#13;
-MvAQALhV43eoBKQyzmFlKHYSGlj8AC0zktXTlg==</SignatureValue>
+    <SignatureValue>ZP9zUjnii1Vwd4Rc4v7Q1smyXOZBUmGj/bNRtW//0+j3stknH2jLBOIs6tfcxzseyCjr5Urj0vme&#13;
+ppWJLAEUa8YqBi9mirsueoIv+DUEOTFqDkqULvNm2eczxjExsdcWs8lYPyEsBV0T8ms87SNyNmdX&#13;
+Nhf1iaM3ymtwoorQkTEnE6V0osqkpT0VNHkpN5+b+LSleeapSsdW/Zh1Zc4gJ6u+voKE+4y95hun&#13;
+0SnzSFqOucpvCrXTFfT0yo6H5IJljz/QNirevj9pYyA0gL1mTXT4skkvnifBynj62LpMr2K5ee32&#13;
+h3nHwNs+vlFg5yXMX9xIwiohTOga9z3rm3pJKA==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>
     <Object>
       <SignatureProperties>
         <SignatureProperty Id="TST" Target="RimSignature">
-          <TimeStamp xmlns:rcf2315="https://www.ietf.org/rfc/rfc2315.txt" dateTime="dGVzdAo="/>
+          <rcf2315:timestamp xmlns:rcf2315="https://www.ietf.org/rfc/rfc2315.txt" dateTime="dGVzdAo="/>
         </SignatureProperty>
       </SignatureProperties>
     </Object>


### PR DESCRIPTION
Assign a value to the timestamp object to avoid the NPE thrown.  Update the test pattern file to incorporate latest updates.

Closes #566 