### PR TITLE
New context mappings for the index page.

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/IndexPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/IndexPageController.java
@@ -14,7 +14,7 @@ import org.springframework.web.servlet.ModelAndView;
  */
 @Controller
 @Log4j2
-@RequestMapping("/HIRS_AttestationCAPortal/portal/index")
+@RequestMapping(value={"/", "/HIRS_AttestationCAPortal", "/HIRS_AttestationCAPortal/", "/HIRS_AttestationCAPortal/portal/index"})
 public class IndexPageController extends PageController<NoPageParams> {
 
     /**


### PR DESCRIPTION
With the [recent context changes](https://github.com/nsacyber/HIRS/commit/a56fd3a8fa16c0ff20f5881b71e46019a742342b) redirects from the base url were not working. This change will make the following paths reach the ACA index page:
/
/HIRS_AttestationCAPortal
/HIRS_AttestationCAPortal/portal/index