### PR TITLE
Use protobuf-gradle-plugin to replace a system dependency

### DIFF
--- a/HIRS_AttestationCA/build.gradle
+++ b/HIRS_AttestationCA/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java'
     id 'io.spring.dependency-management' version '1.1.0'
+    id 'com.google.protobuf' version '0.9.4'
 }
 
 java {
@@ -50,13 +51,18 @@ dependencies {
     annotationProcessor libs.lombok
 }
 
-task generateProtoBuf(type:Exec) {
-    workingDir 'config'
-
-    commandLine './genJavaProtoBuf.sh'
+protobuf {
+  protoc {
+    artifact = 'com.google.protobuf:protoc:3.24.3'
+  }
 }
-
-compileJava.dependsOn generateProtoBuf
+sourceSets {
+  main {
+    proto {
+      srcDir '../HIRS_ProvisionerTPM2/src'
+    }
+  }
+}
 
 test {
     useJUnitPlatform()


### PR DESCRIPTION
Spring boot allows us to build v3 on any system that supports Java. Calling genJavaProtoBuf.sh introduces a dependency on bash. We'd need to support a powershell script to avoid problems building on Windows.

I found google produces a protobuf gradle plugin that looks portable to other systems. https://github.com/google/protobuf-gradle-plugin The CI tests seem to pass, and I've tested successfully on Linux and Windows. Using the plugin should also remove a requirement to install the protobuf compiler prior to building.

I was not able to test effects on different IDEs. Posting this as a PR to see if the team finds any issues with using this plugin.