### PR TITLE
[#594] Moved connector uri to application.properties

### DIFF
--- a/HIRS_AttestationCAPortal/build.gradle
+++ b/HIRS_AttestationCAPortal/build.gradle
@@ -73,6 +73,15 @@ ospackage {
     addParentDirs = true
     createDirectoryEntry true 
 
+    // copy json tables
+    into ('/etc/hirs/aca/default-properties') {
+         from '../HIRS_AttestationCA/src/main/resources/component-class.json'
+         from '../HIRS_AttestationCA/src/main/resources/vendor-table.json'
+    }
+    // copy springboot property file
+    into ('/etc/hirs/aca/') {
+         from '../HIRS_AttestationCAPortal/src/main/resources/application.properties'
+    }
     // copy setup scripts to /opt/hirs/aca
     into ('/opt/hirs/aca/scripts/') {
          from '../package/scripts/'
@@ -89,11 +98,13 @@ ospackage {
     // add chrontab to run ACA at boot
     postInstall 'echo "@reboot root /opt/hirs/aca/scripts/aca/aca_bootRun.sh -w" >> /etc/crontab'
     // run ACA after install
-    postInstall '/opt/hirs/aca/scripts/aca/aca_bootRun.sh -w'
+    postInstall '/opt/hirs/aca/scripts/aca/aca_bootRun.sh -w &'
     postInstall 'chmod +x /opt/hirs/aca/scripts/aca/*'
+    postInstall 'sh /opt/hirs/aca/scripts/aca/check_for_aca.sh'
 
     // Uninstall
     preUninstall 'sh /opt/hirs/aca/scripts/aca/aca_remove_setup.sh'
+    postUninstall 'rm -rf /etc/hirs'
 
     buildRpm {
         arch = X86_64

--- a/HIRS_AttestationCAPortal/src/main/resources/hibernate.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/hibernate.properties
@@ -1,4 +1,4 @@
-#hibernate.connection.url=jdbc:mariadb://localhost:3306/hirs_db?autoReconnect=true&useSSL=false
+hibernate.connection.url=jdbc:mariadb://localhost:3306/hirs_db?autoReconnect=true&sslMode=DISABLED
 #hibernate.connection.username=hirs_db
 #hibernate.connection.password=hirs_db
 hibernate.connection.driver_class=org.mariadb.jdbc.Driver

--- a/package/scripts/aca/aca_bootRun.sh
+++ b/package/scripts/aca/aca_bootRun.sh
@@ -6,7 +6,7 @@
 #
 #####################################################################################
 
-CONFIG_FILE="/etc/hirs/aca/application.properties"
+SPRING_PROP_FILE="/etc/hirs/aca/application.properties"
 ALG=RSA
 RSA_PATH=rsa_3k_sha384_certs
 ECC_PATH=ecc_512_sha384_certs
@@ -108,7 +108,7 @@ source /etc/hirs/aca/aca.properties;
 
 # Run the embedded tomcat server with Web TLS enabled and database client TLS enabled by overrding critical parameters
 # Note "&" is a sub parameter continuation, space represents a new parameter. Spaces and quotes matter.
-# hibernate.connection.url is used for the DB connector which established DB TLS connectivity
+# hibernate.connection.url is used fo    r the DB connector which established DB TLS connectivity
 # server.ssl arguments support the embeded tomcats use of TLS for the ACA Portal
 CONNECTOR_PARAMS="--hibernate.connection.url=jdbc:mariadb://localhost:3306/hirs_db?autoReconnect=true&\
 user=$hirs_db_username&\
@@ -127,8 +127,10 @@ WEB_TLS_PARAMS="--server.ssl.key-store-password=$hirs_pki_password \
 
 if [ -z "$USE_WAR" ]; then
   echo "Booting the ACA from local build..."
-  ./gradlew bootRun --args="$CONNECTOR_PARAMS$WEB_TLS_PARAMS"
+ # ./gradlew bootRun --args="$CONNECTOR_PARAMS$WEB_TLS_PARAMS"
+ ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE"
 else 
   echo "Booting the ACA from a war file..."
-  java -jar $WAR_PATH $CONNECTOR_PARAMS$WEB_TLS_PARAMS &
+ # java -jar $WAR_PATH $CONNECTOR_PARAMS$WEB_TLS_PARAMS &
+java -jar  $WAR_PATH --spring.config.location=$SPRING_PROP_FILE
 fi

--- a/package/scripts/aca/aca_remove_setup.sh
+++ b/package/scripts/aca/aca_remove_setup.sh
@@ -25,9 +25,11 @@ pushd $SCRIPT_DIR/../db/  &>/dev/null
 sh db_drop.sh $DB_ADMIN_PWD
 popd  &>/dev/null
 
-# remove pki files and config files
+# remove pki files and config files if not installed by rpm
 echo "Removing certificates and config files..."
-rm -rf /etc/hirs
+if [ ! -d /opt/hirs/aca ]; then 
+    rm -rf /etc/hirs
+fi
 
 # Remove crontab and current ACA process
 echo "Removing the ACA crontab"

--- a/package/scripts/aca/aca_setup.sh
+++ b/package/scripts/aca/aca_setup.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
+#####################################################################################
+#
+# Script to create ACA setup files and configure the hirs_db database.
+# 
+#
+#####################################################################################
 # Capture location of the script to allow from invocation from any location
 SCRIPT_DIR=$( dirname -- "$( readlink -f -- "$0"; )"; )
 HIRS_CONF_DIR=/etc/hirs/aca
 LOG_FILE_NAME="hirs_aca_install_"$(date +%Y-%m-%d).log 
 LOG_DIR="/var/log/hirs/"
 LOG_FILE="$LOG_DIR$LOG_FILE_NAME"
-HIRS_PROP_DIR="/opt/hirs/default-properties"
 HIRS_JSON_DIR="/etc/hirs/aca/default-properties"
+ACA_PROP_FILE="/etc/hirs/aca/aca.properties"
+SPRING_PROP_FILE="/etc/hirs/aca/application.properties"
+PROP_FILE='../../../HIRS_AttestationCAPortal/src/main/resources/application.properties'
 COMP_JSON='../../../HIRS_AttestationCA/src/main/resources/component-class.json'
 VENDOR_TABLE='../../../HIRS_AttestationCA/src/main/resources/vendor-table.json'
 
@@ -58,10 +66,16 @@ done
 
 set -- "${POSITIONAL_ARGS[@]}" # restore positional parameters
 
-mkdir -p $HIRS_CONF_DIR $LOG_DIR $HIRS_PROP_DIR $HIRS_JSON_DIR
+mkdir -p $HIRS_CONF_DIR $LOG_DIR $HIRS_JSON_DIR
+touch "$LOG_FILE"
 
-cp -n $COMP_JSON $HIRS_JSON_DIR/
-cp -n $VENDOR_TABLE $HIRS_JSON_DIR/
+pushd $SCRIPT_DIR &>/dev/null
+# Check if build environment is being used and set up property files
+if [ -f  $PROP_FILE ]; then
+   cp -n $PROP_FILE $HIRS_CONF_DIR/
+   cp -n $COMP_JSON $HIRS_JSON_DIR/
+   cp -n $VENDOR_TABLE $HIRS_JSON_DIR/
+fi
 
 echo "ACA setup log file is $LOG_FILE"
 
@@ -70,10 +84,7 @@ if [ "$EUID" -ne 0 ]
       exit 1
 fi
 
-touch "$LOG_FILE"
 echo "HIRS ACA Setup initiated on $(date +%Y-%m-%d)" >> "$LOG_FILE"
-
-pushd $SCRIPT_DIR &>/dev/null
 
 # Set HIRS PKI  password
 if [ -z $HIRS_PKI_PWD ]; then
@@ -98,7 +109,7 @@ if [ -z "${ARG_SKIP_PKI}" ]; then
 fi
 
 if [ -z "${ARG_SKIP_DB}" ]; then
-   sh ../db/db_create.sh $LOG_FILE $ARG_UNATTEND
+   sh ../db/db_create.sh $LOG_FILE $PKI_PASS $ARG_UNATTEND
    if [ $? -eq 0 ]; then
       echo "ACA database setup complete" | tee -a "$LOG_FILE"
     else

--- a/package/scripts/aca/check_for_aca.sh
+++ b/package/scripts/aca/check_for_aca.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+########################################################################################
+# Checks for ACA portal page on the local device
+# Waits for tomcat (ACA) to respond or times out after 20 seconds
+#
+#########################################################################################
+
+ACA_URL="https://localhost:8443/HIRS_AttestationCAPortal/portal/index"
+echo "Waiting for tomcat..."
+  count=0
+  until [ "`curl --silent --connect-timeout 1 --insecure -I  $ACA_URL | grep -c 'Date'`" == 1 ] || [[ $count -gt 20 ]]; do
+        ((count++))
+        sleep 1
+  done
+   if [[ $count -gt 20 ]]; then
+     echo "Timed out waiting for tomcat to respond"
+   else
+     echo "Tomcat (ACA) started"
+  fi

--- a/package/scripts/pki/pki_setup.sh
+++ b/package/scripts/pki/pki_setup.sh
@@ -8,6 +8,7 @@
 
 #PROP_FILE=/etc/hirs/aca/application.properties
 ACA_PROP=/etc/hirs/aca/aca.properties
+SPRING_PROP_FILE="/etc/hirs/aca/application.properties"
 LOG_FILE=$1
 PKI_PASS=$2
 UNATTENDED=$3
@@ -56,6 +57,8 @@ if [ ! -d "/etc/hirs/certificates" ]; then
   popd &> /dev/null
 
   echo "hirs_pki_password="$PKI_PASS >>  $ACA_PROP
+  echo "server.ssl.key-store-password="$PKI_PASS >> $SPRING_PROP_FILE
+  echo "server.ssl.trust-store-password="$PKI_PASS >> $SPRING_PROP_FILE
 else 
   echo "/etc/hirs/certificates exists, skipping" | tee -a "$LOG_FILE"
 fi


### PR DESCRIPTION
Changes aca_bootRun.sh to use an external application.properties (spring boot) file.
Minor changes:
* Fixes an issue when using an rpm with the vendor-table.json and component-class.json
* Adds a wait statement in the ACA rpm install for tomcat to launch the CA portal before the install completes 

closes #594