### PR TITLE
Add Ubuntu support for V3

### DIFF
--- a/.ci/docker/Dockerfile.ubuntu22ci
+++ b/.ci/docker/Dockerfile.ubuntu22ci
@@ -1,0 +1,19 @@
+FROM ubuntu:22.04
+
+RUN apt-get update -y && apt-get upgrade -y && apt-get clean -y
+
+# Install packages for building HIRS ACA
+RUN apt-get -y install openjdk-17-jdk  mariadb-server
+RUN apt-get -y install git curl nano cron
+
+# Ports needed for system-level tests
+EXPOSE 8080
+EXPOSE 8443
+
+# Checkout HIRS main branch and run gradlew to install gradlew dependencies, then delete HIRS
+# Use '--depth=1' so as to not download the history of all commits
+RUN git clone -b main --depth=1 https://github.com/nsacyber/HIRS.git /hirsTemp
+WORKDIR "/hirsTemp"
+RUN /bin/bash -c './gradlew clean build'
+WORKDIR "/"
+RUN rm -rf /hirsTemp

--- a/HIRS_AttestationCAPortal/build.gradle
+++ b/HIRS_AttestationCAPortal/build.gradle
@@ -94,16 +94,16 @@ ospackage {
     }
 
     // Post Install
-    postInstall 'sh /opt/hirs/aca/scripts/aca/aca_setup.sh -u'
+    postInstall 'bash /opt/hirs/aca/scripts/aca/aca_setup.sh -u'
     // add chrontab to run ACA at boot
     postInstall 'echo "@reboot root /opt/hirs/aca/scripts/aca/aca_bootRun.sh -w" >> /etc/crontab'
     // run ACA after install
     postInstall '/opt/hirs/aca/scripts/aca/aca_bootRun.sh -w &'
     postInstall 'chmod +x /opt/hirs/aca/scripts/aca/*'
-    postInstall 'sh /opt/hirs/aca/scripts/aca/check_for_aca.sh'
+    postInstall 'bash /opt/hirs/aca/scripts/aca/check_for_aca.sh'
 
     // Uninstall
-    preUninstall 'sh /opt/hirs/aca/scripts/aca/aca_remove_setup.sh'
+    preUninstall 'bash /opt/hirs/aca/scripts/aca/aca_remove_setup.sh'
     postUninstall 'rm -rf /etc/hirs'
 
     buildRpm {
@@ -111,6 +111,7 @@ ospackage {
     }
 
     buildDeb {
+        packageName = 'hirs-attestationca'
         arch = 'amd64'
     }
 }

--- a/package/scripts/aca/aca_check_setup.sh
+++ b/package/scripts/aca/aca_check_setup.sh
@@ -82,7 +82,7 @@ echo "Checking HIRS ACA Setup on this device..."
      rpm -q --quiet HIRS_AttestationCA
     elif [ $ID = 'ubuntu' ]; then
      echo "Ubuntu distro detected"
-     dpkg -l "HIRS_AttestationCA" > /dev/null
+     dpkg -l "hirs-attestationca" > /dev/null
    else
     echo "Unsupported OS Distro encountered"
   fi

--- a/package/scripts/aca/aca_remove_setup.sh
+++ b/package/scripts/aca/aca_remove_setup.sh
@@ -22,7 +22,7 @@ check_mysql_root
 
 # remove the hrs-db and hirs_db user
 pushd $SCRIPT_DIR/../db/  &>/dev/null
-sh db_drop.sh $DB_ADMIN_PWD
+./db_drop.sh $DB_ADMIN_PWD
 popd  &>/dev/null
 
 # remove pki files and config files if not installed by rpm

--- a/package/scripts/aca/aca_setup.sh
+++ b/package/scripts/aca/aca_setup.sh
@@ -25,7 +25,7 @@ help () {
   echo "     -u  | --unattended   Run unattended"
   echo "     -h  | --help   Print this Help."
   echo "     -sp | --skip-pki run the setup without pki setup."
-  echo "     -sb | --skip-db run the setup without database setup."
+  echo "     -sd | --skip-db run the setup without database setup."
   echo
 }
 
@@ -97,7 +97,7 @@ if [ -z $HIRS_PKI_PWD ]; then
 fi
 
 if [ -z "${ARG_SKIP_PKI}" ]; then
-   sh ../pki/pki_setup.sh $LOG_FILE $PKI_PASS $ARG_UNATTEND
+   ../pki/pki_setup.sh $LOG_FILE $PKI_PASS $ARG_UNATTEND
    if [ $? -eq 0 ]; then 
         echo "ACA PKI  setup complete" | tee -a "$LOG_FILE"
       else
@@ -109,7 +109,7 @@ if [ -z "${ARG_SKIP_PKI}" ]; then
 fi
 
 if [ -z "${ARG_SKIP_DB}" ]; then
-   sh ../db/db_create.sh $LOG_FILE $PKI_PASS $ARG_UNATTEND
+   ../db/db_create.sh $LOG_FILE $PKI_PASS $ARG_UNATTEND
    if [ $? -eq 0 ]; then
       echo "ACA database setup complete" | tee -a "$LOG_FILE"
     else

--- a/package/scripts/db/db_create.sh
+++ b/package/scripts/db/db_create.sh
@@ -8,6 +8,7 @@
 ################################################################################
 
 LOG_FILE=$1
+DB_LOG_FILE="/var/log/mariadb/mariadb.log"
 PKI_PASS=$2
 UNATTENDED=$3
 RSA_PATH=rsa_3k_sha384_certs
@@ -29,10 +30,6 @@ SSL_DB_CLIENT_CHAIN="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_rsa_3k
 SSL_DB_CLIENT_CERT="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_db_client_rsa_3k_sha384.pem"; 
 SSL_DB_CLIENT_KEY="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_db_client_rsa_3k_sha384.key";
 
-touch $ACA_PROP_FILE
-touch $LOG_FILE
-touch $DB_SRV_CONF
-
 # Make sure required paths exist
 mkdir -p /etc/hirs/aca/
 mkdir -p /var/log/hirs/
@@ -45,12 +42,17 @@ source /etc/os-release
 if [ $ID = "ubuntu" ]; then 
    DB_SRV_CONF="/etc/mysql/mariadb.conf.d/50-server.cnf"
    DB_CLIENT_CONF="/etc/mysql/mariadb.conf.d/50-client.cnf"
+   mkdir -p /var/log/mariadb >> /dev/null
    if [[ $(cat "$DB_SRV_CONF" | grep -c "log-error") < 1 ]]; then
-       echo log-error=/var/log/mysql/mysqld.log >> $DB_SRV_CONF
-       echo "ssl-cipher=TLSv1.3" >> $DB_SRV_CONF
-       echo "ssl=on" >> $DB_SRV_CONF
+       echo "log_error=/var/log/mariadb/mariadb.log" >> $DB_SRV_CONF
+       echo "tls_version = TLSv1.2,TLSv1.3" >> $DB_SRV_CONF
   fi
 fi
+
+touch $ACA_PROP_FILE
+touch $LOG_FILE
+touch $DB_SRV_CONF
+touch $DB_LOG_FILE
 
 check_mysql_root_pwd () {
   # Check if DB root password needs to be obtained

--- a/package/scripts/db/db_drop.sh
+++ b/package/scripts/db/db_drop.sh
@@ -1,18 +1,25 @@
 #!/bin/bash
 
-SRV_CNF=/etc/my.cnf.d/mariadb-server.cnf
-CLIENT_CNF=/etc/my.cnf.d/client.cnf
+DB_SRV_CONF=/etc/my.cnf.d/mariadb-server.cnf
+DB_CLIENT_CONF=/etc/my.cnf.d/client.cnf
 SCRIPT_DIR=$( dirname -- "$( readlink -f -- "$0"; )";)
 LOG_FILE=/dev/null
 DB_ADMIN_PWD=$1
 
 #source /etc/hirs/aca/aca.properties;
 source $SCRIPT_DIR/mysql_util.sh
+source /etc/os-release 
 
 # Check for sudo or root user, not actually needed but a good idea 
 if [ "$EUID" -ne 0 ]
      then echo "This script requires root.  Please run as root" 
      exit 1
+fi
+
+# Setup distro specifc paths and variables
+if [ $ID = "ubuntu" ]; then 
+   DB_SRV_CONF="/etc/mysql/mariadb.conf.d/50-server.cnf"
+   DB_CLIENT_CONF="/etc/mysql/mariadb.conf.d/50-client.cnf"
 fi
 
 if [ -d /opt/hirs/scripts/db ]; then
@@ -44,8 +51,8 @@ fi
 # Remove key , cert and truststore entries from client.cnf andf mariadb.cnf
 
 echo "Removing hirs cert references from mariadb configuration files"
-grep -v "hirs" $SRV_CNF > tmpfile && mv tmpfile $SRV_CNF
-grep -v "hirs" $CLIENT_CNF > tmpfile && mv tmpfile $CLIENT_CNF
+grep -v "hirs" $DB_SRV_CONF > tmpfile && mv tmpfile $DB_SRV_CONF
+grep -v "hirs" $DB_CLIENT_CONF > tmpfile && mv tmpfile $DB_CLIENT_CONF
 
 echo "restarting mariadb"
 

--- a/package/scripts/db/mysql_util.sh
+++ b/package/scripts/db/mysql_util.sh
@@ -12,7 +12,7 @@ SQL_SERVICE="mariadb"
 check_for_container () {
   PRINT_STATUS=$1
   # Check if we're in a Docker container
-  if [[ $(cat /proc/1/sched | head -n 1) == *"bash"* ]]; then  
+  if [[ $(cat /proc/1/cgroup | head -n 1) == *"docker"* ]]; then  
   #if [ -f /.dockerenv ]; then
     DOCKER_CONTAINER=true
     if [[ $PRINT_STATUS == "-p" ]]; then echo "ACA is running in a container..." | tee -a "$LOG_FILE"; fi

--- a/package/scripts/db/mysql_util.sh
+++ b/package/scripts/db/mysql_util.sh
@@ -57,7 +57,7 @@ start_mysqlsd () {
            chown -R mysql:mysql /var/lib/mysql/ >> "$LOG_FILE"
          fi
          if [[ $PRINT_STATUS == "-p" ]]; then echo "Starting mysql..."; fi
-         /usr/bin/mysqld_safe  --skip-syslog & >> "$LOG_FILE"; 
+         /usr/bin/mysqld_safe  --skip-syslog  >> "$LOG_FILE" &
          chown -R mysql:mysql /var/lib/mysql/ >> "$LOG_FILE"
          echo "Attempting to start mariadb"
          else #not a container
@@ -89,7 +89,7 @@ check_mysql () {
        if [[ $(pgrep -c -u mysql $PROCESS ) -eq 0 ]]; then
           echo "mariadb not running , attempting to restart"
           chown mysql:mysql /var/log/mariadb/mariadb.log >> "$LOG_FILE";
-          /usr/bin/mysqld_safe  --skip-syslog & >> "$LOG_FILE"
+          /usr/bin/mysqld_safe  --skip-syslog  >> "$LOG_FILE" &
        fi
   else  # not in a contianer
     DB_STATUS=$(systemctl status mysql |grep 'running' | wc -l )
@@ -179,5 +179,5 @@ mysqld_reboot () {
   mysql -u root --password=$DB_ADMIN_PWD -e "SHUTDOWN"
   sleep 2
   check_for_container
-  start_mysqlsd
+  start_mysqlsd >> "$LOG_FILE";
 }

--- a/package/scripts/db/mysql_util.sh
+++ b/package/scripts/db/mysql_util.sh
@@ -79,9 +79,15 @@ start_mysqlsd () {
 
 # Basic check for marai db status, attempts restart if not running
 check_mysql () {
+ PROCESS="mysqld"
+   source /etc/os-release 
+   if [ $ID = "ubuntu" ]; then 
+       PROCESS="mariadb"
+   fi
+
  echo "Checking mysqld status..."
   if [ $DOCKER_CONTAINER  = true ]; then
-       if [[ $(pgrep -c -u mysql mysqld) -eq 0 ]]; then
+       if [[ $(pgrep -c -u mysql $PROCESS ) -eq 0 ]]; then
           echo "mariadb not running , attempting to restart"
           /usr/bin/mysqld_safe & >> "$LOG_FILE"
        fi
@@ -96,7 +102,7 @@ check_mysql () {
 
 # Wait for mysql to start before continuing.
   count=1;
-  if [[ $PRINT_STATUS == "-p" ]]; then  echo "Checking mysqld status..."| tee -a "$LOG_FILE"; fi
+  if [[ $PRINT_STATUS == "-p" ]]; then  echo "Testing mysqld connection..."| tee -a "$LOG_FILE"; fi
 
   until mysqladmin ping -h "localhost" --silent ; do
   ((count++))

--- a/package/scripts/pki/pki_chain_gen.sh
+++ b/package/scripts/pki/pki_chain_gen.sh
@@ -225,6 +225,9 @@ create_cert_chain () {
          -srcstorepass $PASS -destkeystore $DB_CLIENT.jks -deststoretype JKS -deststorepass $PASS >> "$LOG_FILE" 2>&1
 }
 
+# Needed for older versions of openssl
+   #openssl rand -writerand .rnd
+
 if [ "$ASYM_ALG" == "rsa" ]; then
    # Create Root CA key pair and self signed cert
    echo "Generating RSA Root CA ...." | tee -a "$LOG_FILE"

--- a/package/scripts/pki/pki_setup.sh
+++ b/package/scripts/pki/pki_setup.sh
@@ -33,8 +33,8 @@ if [ -z "$2" ]; then
 fi
 
 # Check for sudo or root user 
-if [ "$EUID" -ne 0 ]
-        then echo "This script requires root.  Please run as root" | tee -a "$LOG_FILE"
+if [ "$EUID" -ne 0 ]; then 
+   echo "This script requires root.  Please run as root" | tee -a "$LOG_FILE"
         exit 1
 fi
 
@@ -52,8 +52,8 @@ if [ ! -d "/etc/hirs/certificates" ]; then
 
   pushd  /etc/hirs/certificates/ &> /dev/null
   cp $PKI_SETUP_DIR/ca.conf .
-  sh $PKI_SETUP_DIR/pki_chain_gen.sh "HIRS" "rsa" "3072" "sha384" "$PKI_PASS" "$LOG_FILE"
-  sh $PKI_SETUP_DIR/pki_chain_gen.sh "HIRS" "ecc" "512" "sha384" "$PKI_PASS" "$LOG_FILE"
+    $PKI_SETUP_DIR/pki_chain_gen.sh "HIRS" "rsa" "3072" "sha384" "$PKI_PASS" "$LOG_FILE"
+    $PKI_SETUP_DIR/pki_chain_gen.sh "HIRS" "ecc" "512" "sha384" "$PKI_PASS" "$LOG_FILE"
   popd &> /dev/null
 
   echo "hirs_pki_password="$PKI_PASS >>  $ACA_PROP

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,0 @@
-echo "
-# *** ACA Directories ***
-aca.directories.root         = /etc/hirs/
-aca.prop.file=aca.directories.root/aca.properties
-aca.directories.certificates = root/certificates" 


### PR DESCRIPTION
Adds a docker file for ubuntu 22 and makes adjustments to ACA setup scripts for Ubuntu.
To build an install file:
./gradlew bootWar
./gradlew buildDeb
package will be written to HISRS_AttestationCAPortal/build/distributions/

for Ubuntu the package name needed to be lower case with a dash in the first part of the name. 
Package name will be: hirs-attestationca_ver.date.commit.el8-1_amd64.deb

To install deb file use dpkg -i. Example
dpkg -i HIRS_AttestationCAPortal/build/distributions/hirs-attestationca_2.1.3.1697051798.d968080a.el8-1_amd64.deb

Note: to run setup scripts use bash vs sh on an Ubuntu terminal:
bash package/scripts/aca/aca_check_setup.sh

closes: #598 