### PR TITLE
Uploading Platform Credential IllegalStateException Fix

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
@@ -842,6 +842,12 @@ public class CertificatePageController extends PageController<NoPageParams> {
             log.error(failMessage, iaEx);
             messages.addError(failMessage + iaEx.getMessage());
             return null;
+        } catch (IllegalStateException isEx) {
+            final String failMessage = String.format(
+                    "Unexpected object while parsing %s ", fileName);
+            log.error(failMessage, isEx);
+            messages.addError(failMessage + isEx.getMessage());
+            return null;
         }
     }
 


### PR DESCRIPTION
I tested manually uploading a series of certificates to test the list pages functionality when it comes to sorting and other visual aspects of the data table.  I encountered a certificate that caused the ACA to throw a 500 error.  This was due to an IllegalStateException while parsing a certificate that contained an 'unexpected object'.  Since this is a bouncy castle error, it is hard to parse out what the object actually is that is causing the error to be thrown.  For now, the parsing method in the certificate page controller is being updated to catch the exception, at least, so that the ACA doesn't crash. The platform in question is a Dell Power Edge R640 base SCV.

The Error: `java.lang.IllegalStateException: unexpected object: org.bouncycastle.asn1.ASN1Integer`