### PR TITLE
V3 server UI fixes

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/ArchivableEntity.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/ArchivableEntity.java
@@ -3,6 +3,7 @@ package hirs.attestationca.persist.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
@@ -20,6 +21,11 @@ public abstract class ArchivableEntity extends AbstractEntity {
      * Defining the size of a message field for error display.
      */
     public static final int MAX_MESSAGE_LENGTH = 2400;
+
+    @Getter
+    @Setter
+    @Column(nullable = false)
+    private boolean archiveFlag = false;
 
     @Column(name = "archived_time")
     private Date archivedTime;
@@ -54,6 +60,7 @@ public abstract class ArchivableEntity extends AbstractEntity {
      *      false is archived time is already set, signifying the entity has been archived.
      */
     public final boolean archive() {
+        this.archiveFlag = !archiveFlag;
         if (this.archivedTime == null) {
             this.archivedTime = new Date();
             return true;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/ArchivableEntity.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/ArchivableEntity.java
@@ -60,9 +60,10 @@ public abstract class ArchivableEntity extends AbstractEntity {
      *      false is archived time is already set, signifying the entity has been archived.
      */
     public final boolean archive() {
-        this.archiveFlag = !archiveFlag;
+        this.archiveFlag = false;
         if (this.archivedTime == null) {
             this.archivedTime = new Date();
+            archiveFlag = true;
             return true;
         }
         return false;
@@ -112,6 +113,7 @@ public abstract class ArchivableEntity extends AbstractEntity {
         if (this.archivedTime != null) {
             this.archivedTime = null;
             this.archivedDescription = null;
+            archiveFlag = false;
             return true;
         }
         return false;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/ArchivableEntity.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/ArchivableEntity.java
@@ -13,7 +13,6 @@ import java.util.Date;
  * An abstract archivable entity that can be deleted.
  */
 @ToString
-@Getter
 @MappedSuperclass
 public abstract class ArchivableEntity extends AbstractEntity {
 
@@ -76,6 +75,21 @@ public abstract class ArchivableEntity extends AbstractEntity {
             return true;
         } else {
             return false;
+        }
+    }
+
+    /**
+     * Returns the timestamp of when the entity was archived if applicable. If the
+     * entity has not been resolved, then null is returned.
+     *
+     * @return archivedTime
+     *      If entity was archived, timestamp of the occurrence, null otherwise.
+     */
+    public final Date getArchivedTime() {
+        if (archivedTime == null) {
+            return null;
+        } else {
+            return (Date) archivedTime.clone();
         }
     }
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/CACredentialRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/CACredentialRepository.java
@@ -1,8 +1,9 @@
 package hirs.attestationca.persist.entity.manager;
 
 import hirs.attestationca.persist.entity.userdefined.certificate.CertificateAuthorityCredential;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,9 +12,8 @@ import java.util.UUID;
 @Repository
 public interface CACredentialRepository extends JpaRepository<CertificateAuthorityCredential, UUID> {
 
-    @Query(value = "SELECT * FROM Certificate WHERE DTYPE='CertificateAuthorityCredential' AND archiveFlag=false", nativeQuery = true)
-    @Override
-    List<CertificateAuthorityCredential> findAll();
+    List<CertificateAuthorityCredential> findByArchiveFlag(boolean archiveFlag);
+    Page<CertificateAuthorityCredential> findByArchiveFlag(boolean archiveFlag, Pageable pageable);
     List<CertificateAuthorityCredential> findBySubject(String subject);
     List<CertificateAuthorityCredential> findBySubjectSorted(String subject);
     CertificateAuthorityCredential findBySubjectKeyIdentifier(byte[] subjectKeyIdentifier);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/CACredentialRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/CACredentialRepository.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Repository
 public interface CACredentialRepository extends JpaRepository<CertificateAuthorityCredential, UUID> {
 
-    @Query(value = "SELECT * FROM Certificate where DTYPE='CertificateAuthorityCredential'", nativeQuery = true)
+    @Query(value = "SELECT * FROM Certificate WHERE DTYPE='CertificateAuthorityCredential' AND archiveFlag=false", nativeQuery = true)
     @Override
     List<CertificateAuthorityCredential> findAll();
     List<CertificateAuthorityCredential> findBySubject(String subject);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/CertificateRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/CertificateRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Repository
-public interface CertificateRepository<T extends Certificate> extends JpaRepository<Certificate, UUID> {
+public interface CertificateRepository extends JpaRepository<Certificate, UUID> {
 
     @Query(value = "SELECT * FROM Certificate where id = ?1", nativeQuery = true)
     Certificate getCertificate(UUID uuid);
@@ -22,7 +22,7 @@ public interface CertificateRepository<T extends Certificate> extends JpaReposit
     @Query(value = "SELECT * FROM Certificate where issuerSorted = ?1 AND  DTYPE = ?2", nativeQuery = true)
     List<Certificate> findBySubjectSorted(String issuedSort, String dType);
     @Query(value = "SELECT * FROM Certificate where DTYPE = ?1", nativeQuery = true)
-    List<T> findByAll(String dType);
+    List<Certificate> findByType(String dType);
     @Query(value = "SELECT * FROM Certificate where serialNumber = ?1 AND DTYPE = ?2", nativeQuery = true)
     Certificate findBySerialNumber(BigInteger serialNumber, String dType);
     @Query(value = "SELECT * FROM Certificate where platformSerial = ?1 AND DTYPE = 'PlatformCredential'", nativeQuery = true)
@@ -32,7 +32,7 @@ public interface CertificateRepository<T extends Certificate> extends JpaReposit
     @Query(value = "SELECT * FROM Certificate where holderSerialNumber = ?1 AND DTYPE = 'PlatformCredential'", nativeQuery = true)
     List<PlatformCredential> getByHolderSerialNumber(BigInteger holderSerialNumber);
     @Query(value = "SELECT * FROM Certificate where certificateHash = ?1 AND DTYPE = ?2", nativeQuery = true)
-    T findByCertificateHash(int certificateHash, String dType);
+    Certificate findByCertificateHash(int certificateHash, String dType);
     EndorsementCredential findByPublicKeyModulusHexValue(String publicKeyModulusHexValue);
     IssuedAttestationCertificate findByDeviceId(UUID deviceId);
     Certificate findByCertificateHash(int certificateHash);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/EndorsementCredentialRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/EndorsementCredentialRepository.java
@@ -1,9 +1,9 @@
 package hirs.attestationca.persist.entity.manager;
 
 import hirs.attestationca.persist.entity.userdefined.certificate.EndorsementCredential;
-import hirs.attestationca.persist.entity.userdefined.certificate.PlatformCredential;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigInteger;
@@ -13,9 +13,8 @@ import java.util.UUID;
 @Repository
 public interface EndorsementCredentialRepository extends JpaRepository<EndorsementCredential, UUID> {
 
-    @Query(value = "SELECT * FROM Certificate WHERE DTYPE='EndorsementCredential' AND archiveFlag=false", nativeQuery = true)
-    @Override
-    List<EndorsementCredential> findAll();
+    List<EndorsementCredential> findByArchiveFlag(boolean archiveFlag);
+    Page<EndorsementCredential> findByArchiveFlag(boolean archiveFlag, Pageable pageable);
     EndorsementCredential findByHolderSerialNumber(BigInteger holderSerialNumber);
     List<EndorsementCredential> findByDeviceId(UUID deviceId);
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/EndorsementCredentialRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/EndorsementCredentialRepository.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 @Repository
 public interface EndorsementCredentialRepository extends JpaRepository<EndorsementCredential, UUID> {
 
+    @Query(value = "SELECT * FROM Certificate WHERE DTYPE='EndorsementCredential' AND archiveFlag=false", nativeQuery = true)
     @Override
     List<EndorsementCredential> findAll();
     EndorsementCredential findByHolderSerialNumber(BigInteger holderSerialNumber);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/IssuedCertificateRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/IssuedCertificateRepository.java
@@ -1,8 +1,9 @@
 package hirs.attestationca.persist.entity.manager;
 
 import hirs.attestationca.persist.entity.userdefined.certificate.IssuedAttestationCertificate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,8 +12,7 @@ import java.util.UUID;
 @Repository
 public interface IssuedCertificateRepository extends JpaRepository<IssuedAttestationCertificate, UUID> {
 
-    @Query(value = "SELECT * FROM Certificate WHERE DTYPE='IssuedAttestationCertificate' AND archiveFlag=false", nativeQuery = true)
-    @Override
-    List<IssuedAttestationCertificate> findAll();
+    List<IssuedAttestationCertificate> findByArchiveFlag(boolean archiveFlag);
+    Page<IssuedAttestationCertificate> findByArchiveFlag(boolean archiveFlag, Pageable pageable);
     List<IssuedAttestationCertificate> findByDeviceId(UUID deviceId);
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/IssuedCertificateRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/IssuedCertificateRepository.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Repository
 public interface IssuedCertificateRepository extends JpaRepository<IssuedAttestationCertificate, UUID> {
 
-    @Query(value = "SELECT * FROM Certificate where DTYPE='IssuedAttestationCertificate'", nativeQuery = true)
+    @Query(value = "SELECT * FROM Certificate WHERE DTYPE='IssuedAttestationCertificate' AND archiveFlag=false", nativeQuery = true)
     @Override
     List<IssuedAttestationCertificate> findAll();
     List<IssuedAttestationCertificate> findByDeviceId(UUID deviceId);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/PlatformCertificateRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/PlatformCertificateRepository.java
@@ -1,8 +1,9 @@
 package hirs.attestationca.persist.entity.manager;
 
 import hirs.attestationca.persist.entity.userdefined.certificate.PlatformCredential;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,8 +12,7 @@ import java.util.UUID;
 @Repository
 public interface PlatformCertificateRepository extends JpaRepository<PlatformCredential, UUID> {
 
-    @Query(value = "SELECT * FROM Certificate WHERE DTYPE='PlatformCredential' AND archiveFlag=false", nativeQuery = true)
-    @Override
-    List<PlatformCredential> findAll();
+    List<PlatformCredential> findByArchiveFlag(boolean archiveFlag);
+    Page<PlatformCredential> findByArchiveFlag(boolean archiveFlag, Pageable pageable);
     List<PlatformCredential> findByDeviceId(UUID deviceId);
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/PlatformCertificateRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/PlatformCertificateRepository.java
@@ -2,6 +2,7 @@ package hirs.attestationca.persist.entity.manager;
 
 import hirs.attestationca.persist.entity.userdefined.certificate.PlatformCredential;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.UUID;
 @Repository
 public interface PlatformCertificateRepository extends JpaRepository<PlatformCredential, UUID> {
 
+    @Query(value = "SELECT * FROM Certificate WHERE DTYPE='PlatformCredential' AND archiveFlag=false", nativeQuery = true)
     @Override
     List<PlatformCredential> findAll();
     List<PlatformCredential> findByDeviceId(UUID deviceId);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceManifestRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceManifestRepository.java
@@ -18,7 +18,7 @@ public interface ReferenceManifestRepository extends JpaRepository<ReferenceMani
     ReferenceManifest findByBase64Hash(String base64Hash);
     ReferenceManifest findByHexDecHashAndRimType(String hexDecHash, String rimType);
     @Query(value = "SELECT * FROM ReferenceManifest WHERE platformManufacturer = ?1 AND platformModel = ?2 AND rimType = 'Base'", nativeQuery = true)
-    BaseReferenceManifest getBaseByManufacturerModel(String manufacturer, String model);
+    List<BaseReferenceManifest> getBaseByManufacturerModel(String manufacturer, String model);
     @Query(value = "SELECT * FROM ReferenceManifest WHERE platformManufacturer = ?1 AND DTYPE = ?2", nativeQuery = true)
     List<BaseReferenceManifest> getByManufacturer(String manufacturer, String dType);
     @Query(value = "SELECT * FROM ReferenceManifest WHERE platformModel = ?1 AND DTYPE = ?2", nativeQuery = true)

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceManifestRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceManifestRepository.java
@@ -4,6 +4,8 @@ import hirs.attestationca.persist.entity.userdefined.ReferenceManifest;
 import hirs.attestationca.persist.entity.userdefined.rim.BaseReferenceManifest;
 import hirs.attestationca.persist.entity.userdefined.rim.EventLogMeasurements;
 import hirs.attestationca.persist.entity.userdefined.rim.SupportReferenceManifest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -41,4 +43,5 @@ public interface ReferenceManifestRepository extends JpaRepository<ReferenceMani
     List<SupportReferenceManifest> getSupportByManufacturerModel(String manufacturer, String model);
     @Query(value = "SELECT * FROM ReferenceManifest WHERE platformModel = ?1 AND DTYPE = 'EventLogMeasurements'", nativeQuery = true)
     EventLogMeasurements getLogByModel(String model);
+    Page<ReferenceManifest> findByArchiveFlag(boolean archiveFlag, Pageable pageable);
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceManifestRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceManifestRepository.java
@@ -43,5 +43,6 @@ public interface ReferenceManifestRepository extends JpaRepository<ReferenceMani
     List<SupportReferenceManifest> getSupportByManufacturerModel(String manufacturer, String model);
     @Query(value = "SELECT * FROM ReferenceManifest WHERE platformModel = ?1 AND DTYPE = 'EventLogMeasurements'", nativeQuery = true)
     EventLogMeasurements getLogByModel(String model);
+    List<ReferenceManifest> findByArchiveFlag(boolean archiveFlag);
     Page<ReferenceManifest> findByArchiveFlag(boolean archiveFlag, Pageable pageable);
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
@@ -448,7 +448,7 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                     referenceManifestRepository.delete(measurements);
                 }
 
-                BaseReferenceManifest baseRim = referenceManifestRepository
+                List<BaseReferenceManifest> baseRims = referenceManifestRepository
                         .getBaseByManufacturerModel(dv.getHw().getManufacturer(),
                                 dv.getHw().getProductName());
                 measurements = temp;
@@ -456,20 +456,20 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                 measurements.setPlatformModel(dv.getHw().getProductName());
                 measurements.setTagId(tagId);
                 measurements.setDeviceName(dv.getNw().getHostname());
-                if (baseRim != null) {
-                    measurements.setAssociatedRim(baseRim.getAssociatedRim());
-                }
+
                 this.referenceManifestRepository.save(measurements);
 
-                if (baseRim != null) {
-                    // pull the base versions of the swidtag and rimel and set the
-                    // event log hash for use during provision
-                    SupportReferenceManifest sBaseRim = referenceManifestRepository
-                            .getSupportRimEntityById(baseRim.getAssociatedRim());
-                    baseRim.setEventLogHash(temp.getHexDecHash());
-                    sBaseRim.setEventLogHash(temp.getHexDecHash());
-                    referenceManifestRepository.save(baseRim);
-                    referenceManifestRepository.save(sBaseRim);
+                for (BaseReferenceManifest baseRim : baseRims) {
+                    if (baseRim != null) {
+                        // pull the base versions of the swidtag and rimel and set the
+                        // event log hash for use during provision
+                        SupportReferenceManifest sBaseRim = referenceManifestRepository
+                                .getSupportRimEntityById(baseRim.getAssociatedRim());
+                        baseRim.setEventLogHash(temp.getHexDecHash());
+                        sBaseRim.setEventLogHash(temp.getHexDecHash());
+                        referenceManifestRepository.save(baseRim);
+                        referenceManifestRepository.save(sBaseRim);
+                    }
                 }
             } catch (IOException ioEx) {
                 log.error(ioEx);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
@@ -456,6 +456,7 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                 measurements.setPlatformModel(dv.getHw().getProductName());
                 measurements.setTagId(tagId);
                 measurements.setDeviceName(dv.getNw().getHostname());
+                measurements.archive();
 
                 this.referenceManifestRepository.save(measurements);
 

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
@@ -235,7 +235,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
         // serial number. (pc.HolderSerialNumber = ec.SerialNumber)
         if (certificateType.equals(PLATFORMCREDENTIAL)) {
             FilteredRecordsList<PlatformCredential> records = new FilteredRecordsList<>();
-            org.springframework.data.domain.Page<PlatformCredential> pagedResult = this.platformCertificateRepository.findAll(paging);
+            org.springframework.data.domain.Page<PlatformCredential> pagedResult = this.platformCertificateRepository.findByArchiveFlag(false, paging);
 
             if (pagedResult.hasContent()) {
                 records.addAll(pagedResult.getContent());
@@ -244,7 +244,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
                 records.setRecordsTotal(input.getLength());
             }
 
-            records.setRecordsFiltered(platformCertificateRepository.count());
+            records.setRecordsFiltered(platformCertificateRepository.findByArchiveFlag(false).size());
             EndorsementCredential associatedEC;
 
             if (!records.isEmpty()) {
@@ -268,7 +268,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
             return new DataTableResponse<>(records, input);
         } else if (certificateType.equals(ENDORSEMENTCREDENTIAL)) {
             FilteredRecordsList<EndorsementCredential> records = new FilteredRecordsList<>();
-            org.springframework.data.domain.Page<EndorsementCredential> pagedResult = this.endorsementCredentialRepository.findAll(paging);
+            org.springframework.data.domain.Page<EndorsementCredential> pagedResult = this.endorsementCredentialRepository.findByArchiveFlag(false, paging);
 
             if (pagedResult.hasContent()) {
                 records.addAll(pagedResult.getContent());
@@ -277,13 +277,13 @@ public class CertificatePageController extends PageController<NoPageParams> {
                 records.setRecordsTotal(input.getLength());
             }
 
-            records.setRecordsFiltered(endorsementCredentialRepository.count());
+            records.setRecordsFiltered(endorsementCredentialRepository.findByArchiveFlag(false).size());
 
             log.debug("Returning list of size: " + records.size());
             return new DataTableResponse<>(records, input);
         } else if (certificateType.equals(TRUSTCHAIN)) {
             FilteredRecordsList<CertificateAuthorityCredential> records = new FilteredRecordsList<>();
-            org.springframework.data.domain.Page<CertificateAuthorityCredential> pagedResult = this.caCredentialRepository.findAll(paging);
+            org.springframework.data.domain.Page<CertificateAuthorityCredential> pagedResult = this.caCredentialRepository.findByArchiveFlag(false, paging);
 
             if (pagedResult.hasContent()) {
                 records.addAll(pagedResult.getContent());
@@ -292,13 +292,13 @@ public class CertificatePageController extends PageController<NoPageParams> {
                 records.setRecordsTotal(input.getLength());
             }
 
-            records.setRecordsFiltered(caCredentialRepository.count());
+            records.setRecordsFiltered(caCredentialRepository.findByArchiveFlag(false).size());
 
             log.debug("Returning list of size: " + records.size());
             return new DataTableResponse<>(records, input);
         } else if (certificateType.equals(ISSUEDCERTIFICATES)) {
             FilteredRecordsList<IssuedAttestationCertificate> records = new FilteredRecordsList<>();
-            org.springframework.data.domain.Page<IssuedAttestationCertificate> pagedResult = this.issuedCertificateRepository.findAll(paging);
+            org.springframework.data.domain.Page<IssuedAttestationCertificate> pagedResult = this.issuedCertificateRepository.findByArchiveFlag(false, paging);
 
             if (pagedResult.hasContent()) {
                 records.addAll(pagedResult.getContent());
@@ -307,7 +307,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
                 records.setRecordsTotal(input.getLength());
             }
 
-            records.setRecordsFiltered(issuedCertificateRepository.count());
+            records.setRecordsFiltered(issuedCertificateRepository.findByArchiveFlag(false).size());
 
             log.debug("Returning list of size: " + records.size());
             return new DataTableResponse<>(records, input);
@@ -821,7 +821,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
             log.error(failMessage, dEx);
             messages.addError(failMessage + dEx.getMessage());
             return null;
-        } catch (IllegalArgumentException iaEx) {
+        } catch (IllegalArgumentException | IllegalStateException iaEx) {
             final String failMessage = String.format(
                     "Certificate format not recognized(%s): ", fileName);
             log.error(failMessage, iaEx);

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
@@ -399,7 +399,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
                     }
                 }
 
-                certificate.archive();
+                certificate.archive("User requested deletion via UI");
                 certificateRepository.save(certificate);
 
                 String deleteCompletedMessage = "Certificate successfully deleted";
@@ -512,7 +512,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
 
         try (ZipOutputStream zipOut = new ZipOutputStream(response.getOutputStream())) {
             // get all files
-            bulkDownload(zipOut, this.certificateRepository.findByAll("CertificateAuthorityCredential"), singleFileName);
+            bulkDownload(zipOut, this.certificateRepository.findByType("CertificateAuthorityCredential"), singleFileName);
             // write cert to output stream
         } catch (IllegalArgumentException ex) {
             String uuidError = "Failed to parse ID from: ";
@@ -544,7 +544,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
 
         try (ZipOutputStream zipOut = new ZipOutputStream(response.getOutputStream())) {
             // get all files
-            bulkDownload(zipOut, this.certificateRepository.findByAll("PlatformCredential"), singleFileName);
+            bulkDownload(zipOut, this.certificateRepository.findByType("PlatformCredential"), singleFileName);
             // write cert to output stream
         } catch (IllegalArgumentException ex) {
             String uuidError = "Failed to parse ID from: ";
@@ -576,7 +576,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
 
         try (ZipOutputStream zipOut = new ZipOutputStream(response.getOutputStream())) {
             // get all files
-            bulkDownload(zipOut, this.certificateRepository.findByAll("IssuedAttestationCertificate"), singleFileName);
+            bulkDownload(zipOut, this.certificateRepository.findByType("IssuedAttestationCertificate"), singleFileName);
             // write cert to output stream
         } catch (IllegalArgumentException ex) {
             String uuidError = "Failed to parse ID from: ";
@@ -607,7 +607,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
 
         try (ZipOutputStream zipOut = new ZipOutputStream(response.getOutputStream())) {
             // get all files
-            bulkDownload(zipOut, this.certificateRepository.findByAll("EndorsementCredential"), singleFileName);
+            bulkDownload(zipOut, this.certificateRepository.findByType("EndorsementCredential"), singleFileName);
             // write cert to output stream
         } catch (IllegalArgumentException ex) {
             String uuidError = "Failed to parse ID from: ";

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
@@ -313,7 +313,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
             return new DataTableResponse<>(records, input);
         }
 
-        return new DataTableResponse<Certificate>(new FilteredRecordsList<>(), input);
+        return new DataTableResponse<>(new FilteredRecordsList<>(), input);
     }
 
     /**
@@ -375,7 +375,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
 
         try {
             UUID uuid = UUID.fromString(id);
-            Certificate certificate = getCertificateById(certificateType, uuid);
+            Certificate certificate = certificateRepository.getReferenceById(uuid);
             if (certificate == null) {
                 // Use the term "record" here to avoid user confusion b/t cert and cred
                 String notFoundMessage = "Unable to locate record with ID: " + uuid;
@@ -392,7 +392,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
 
                         for (PlatformCredential pc : sharedCertificates) {
                             if (!pc.isPlatformBase()) {
-                                pc.archive();
+                                pc.archive("User requested deletion via UI of the base certificate");
                                 certificateRepository.save(pc);
                             }
                         }
@@ -746,21 +746,6 @@ public class CertificatePageController extends PageController<NoPageParams> {
         }
 
         return associatedCertificates;
-    }
-
-    private Certificate getCertificateById(final String certificateType, final UUID uuid) {
-        switch (certificateType) {
-            case PLATFORMCREDENTIAL:
-                return this.platformCertificateRepository.getReferenceById(uuid);
-            case ENDORSEMENTCREDENTIAL:
-                return this.endorsementCredentialRepository.getReferenceById(uuid);
-            case ISSUEDCERTIFICATES:
-                return this.issuedCertificateRepository.getReferenceById(uuid);
-            case TRUSTCHAIN:
-                return this.caCredentialRepository.getReferenceById(uuid);
-            default:
-                return null;
-        }
     }
 
     /**

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
@@ -133,7 +133,7 @@ public class ReferenceManifestPageController extends PageController<NoPageParams
             records.setRecordsTotal(input.getLength());
         }
 
-        records.setRecordsFiltered(referenceManifestRepository.count());
+        records.setRecordsFiltered(referenceManifestRepository.findByArchiveFlag(false).size());
 
         log.debug("Returning list of size: " + records.size());
         return new DataTableResponse<>(records, input);
@@ -413,7 +413,7 @@ public class ReferenceManifestPageController extends PageController<NoPageParams
                     baseRims.add(baseRim);
                 }
             }
-        } catch (IOException ioEx) {
+        } catch (IOException | NullPointerException ioEx) {
             final String failMessage
                     = String.format("Failed to parse uploaded file (%s): ", fileName);
             log.error(failMessage, ioEx);

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
@@ -475,7 +475,7 @@ public class ReferenceManifestPageController extends PageController<NoPageParams
         if (supportRim != null && (supportRim.getId() != null
                 && !supportRim.getId().toString().equals(""))) {
             List<BaseReferenceManifest> baseRims = new LinkedList<>();
-            baseRims.add(this.referenceManifestRepository
+            baseRims.addAll(this.referenceManifestRepository
                     .getBaseByManufacturerModel(supportRim.getPlatformManufacturer(),
                             supportRim.getPlatformModel()));
 

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -150,7 +150,7 @@ public final class CertificateStringMapBuilder {
             final Certificate certificate,
             final CertificateRepository certificateRepository,
             final CACredentialRepository caCredentialRepository) {
-        List<CertificateAuthorityCredential> issuerCertificates = new ArrayList<>();
+        List<Certificate> issuerCertificates = new ArrayList<>();
         CertificateAuthorityCredential skiCA = null;
         String issuerResult;
 


### PR DESCRIPTION
This pull request has some bug fixes and migrated functionality that was not included in the original push.  Due to unit test migration, there was a problem found with a unit test that calls the archive method for DB entities.  This function wasn't originally set up to work.  This PR includes the call and fixes up issues with the /list portion of the ACA portal displaying the correct number of items displayed and not the number in the DB.

In addition, while testing there was a mistake that led to a 500 error that wasn't covered in the try/catch handling.  When uploading a rim to a certificate page and vice versa; these actions produced 500 errors for IllegalStateException and Nullpointer.   The nullpointer can't be handled by our code because it is in the parsing libraries that are imported.

This does not resolve the issue listed in #619.  