### PR TITLE
DB Returning non-null but blank Objects

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/CertificateRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/CertificateRepository.java
@@ -17,10 +17,10 @@ public interface CertificateRepository extends JpaRepository<Certificate, UUID> 
 
     @Query(value = "SELECT * FROM Certificate where id = ?1", nativeQuery = true)
     Certificate getCertificate(UUID uuid);
-    @Query(value = "SELECT * FROM Certificate where issuer = ?1 AND DTYPE = ?2", nativeQuery = true)
-    List<Certificate> findBySubject(String issuer, String dType);
-    @Query(value = "SELECT * FROM Certificate where issuerSorted = ?1 AND  DTYPE = ?2", nativeQuery = true)
-    List<Certificate> findBySubjectSorted(String issuedSort, String dType);
+    @Query(value = "SELECT * FROM Certificate where subject = ?1 AND DTYPE = ?2", nativeQuery = true)
+    List<Certificate> findBySubject(String subject, String dType);
+    @Query(value = "SELECT * FROM Certificate where subjectSorted = ?1 AND  DTYPE = ?2", nativeQuery = true)
+    List<Certificate> findBySubjectSorted(String subjectSorted, String dType);
     @Query(value = "SELECT * FROM Certificate where DTYPE = ?1", nativeQuery = true)
     List<Certificate> findByType(String dType);
     @Query(value = "SELECT * FROM Certificate where serialNumber = ?1 AND DTYPE = ?2", nativeQuery = true)

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
@@ -375,7 +375,8 @@ public class CertificatePageController extends PageController<NoPageParams> {
 
         try {
             UUID uuid = UUID.fromString(id);
-            Certificate certificate = certificateRepository.getReferenceById(uuid);
+            Certificate certificate = getCertificateById(certificateType, uuid);
+
             if (certificate == null) {
                 // Use the term "record" here to avoid user confusion b/t cert and cred
                 String notFoundMessage = "Unable to locate record with ID: " + uuid;
@@ -748,6 +749,29 @@ public class CertificatePageController extends PageController<NoPageParams> {
         return associatedCertificates;
     }
 
+    private Certificate getCertificateById(final String certificateType, final UUID uuid) {
+        switch (certificateType) {
+            case PLATFORMCREDENTIAL:
+                if (platformCertificateRepository.existsById(uuid)) {
+                    return platformCertificateRepository.getReferenceById(uuid);
+                }
+            case ENDORSEMENTCREDENTIAL:
+                if (endorsementCredentialRepository.existsById(uuid)) {
+                    return endorsementCredentialRepository.getReferenceById(uuid);
+                }
+            case ISSUEDCERTIFICATES:
+                if (issuedCertificateRepository.existsById(uuid)) {
+                    return issuedCertificateRepository.getReferenceById(uuid);
+                }
+            case TRUSTCHAIN:
+                if (caCredentialRepository.existsById(uuid)) {
+                    return caCredentialRepository.getReferenceById(uuid);
+                }
+            default:
+                return null;
+        }
+    }
+
     /**
      * Parses an uploaded file into a certificate and populates the given model
      * with error messages if parsing fails.
@@ -821,7 +845,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
             log.error(failMessage, dEx);
             messages.addError(failMessage + dEx.getMessage());
             return null;
-        } catch (IllegalArgumentException | IllegalStateException iaEx) {
+        } catch (IllegalArgumentException iaEx) {
             final String failMessage = String.format(
                     "Certificate format not recognized(%s): ", fileName);
             log.error(failMessage, iaEx);

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
@@ -350,20 +350,12 @@ public class ReferenceManifestPageController extends PageController<NoPageParams
      */
     private ReferenceManifest getRimFromDb(final String id) throws IllegalArgumentException {
         UUID uuid = UUID.fromString(id);
-//        ReferenceManifest rim = BaseReferenceManifest.select(referenceManifestManager)
-//                .byEntityId(uuid).getRIM();
-//
-//        if (rim == null) {
-//            rim = SupportReferenceManifest.select(referenceManifestManager)
-//                    .byEntityId(uuid).getRIM();
-//        }
-//
-//        if (rim == null) {
-//            rim = EventLogMeasurements.select(referenceManifestManager)
-//                    .byEntityId(uuid).getRIM();
-//        }
 
-        return this.referenceManifestRepository.getReferenceById(uuid);
+        if (referenceManifestRepository.existsById(uuid)) {
+            return referenceManifestRepository.getReferenceById(uuid);
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/RimDatabasePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/RimDatabasePageController.java
@@ -126,15 +126,13 @@ public class RimDatabasePageController extends PageController<NoPageParams> {
         SupportReferenceManifest support;
         for (ReferenceDigestValue rdv : referenceDigestValues) {
             // We are updating the base rim ID field if necessary and
-            if (rdv.getBaseRimId() == null) {
+            if (rdv.getBaseRimId() == null && referenceManifestRepository.existsById(rdv.getSupportRimId())) {
                 support = (SupportReferenceManifest) referenceManifestRepository.getReferenceById(rdv.getSupportRimId());
-                if (support != null) {
-                    rdv.setBaseRimId(support.getAssociatedRim());
-                    try {
-                        referenceDigestValueRepository.save(rdv);
-                    } catch (DBManagerException e) {
-                        log.error("Failed to update TPM Event with Base RIM ID");
-                    }
+                rdv.setBaseRimId(support.getAssociatedRim());
+                try {
+                    referenceDigestValueRepository.save(rdv);
+                } catch (DBManagerException dbMEx) {
+                    log.error("Failed to update TPM Event with Base RIM ID");
                 }
             }
         }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -150,7 +150,7 @@ public final class CertificateStringMapBuilder {
             final Certificate certificate,
             final CertificateRepository certificateRepository,
             final CACredentialRepository caCredentialRepository) {
-        List<Certificate> issuerCertificates = new ArrayList<>();
+        List<CertificateAuthorityCredential> issuerCertificates = new ArrayList<>();
         CertificateAuthorityCredential skiCA = null;
         String issuerResult;
 
@@ -167,12 +167,10 @@ public final class CertificateStringMapBuilder {
             if (certificate.getIssuerSorted() == null
                     || certificate.getIssuerSorted().isEmpty()) {
                 //Get certificates by subject
-                issuerCertificates = certificateRepository.findBySubject(certificate.getIssuer(),
-                        "CertificateAuthorityCredential");
+                issuerCertificates = caCredentialRepository.findBySubject(certificate.getIssuer());
             } else {
                 //Get certificates by subject organization
-                issuerCertificates = certificateRepository.findBySubjectSorted(certificate.getIssuerSorted(),
-                        "CertificateAuthorityCredential");
+                issuerCertificates = caCredentialRepository.findBySubjectSorted(certificate.getIssuerSorted());
             }
         } else {
             issuerCertificates.add(skiCA);
@@ -209,6 +207,9 @@ public final class CertificateStringMapBuilder {
     public static HashMap<String, String> getCertificateAuthorityInformation(final UUID uuid,
                                                                              final CertificateRepository certificateRepository,
                                                                              final CACredentialRepository caCertificateRepository) {
+        if (!caCertificateRepository.existsById(uuid)) {
+            return new HashMap<>();
+        }
         CertificateAuthorityCredential certificate = caCertificateRepository.getReferenceById(uuid);
 
         String notFoundMessage = "Unable to find Certificate Authority "


### PR DESCRIPTION
The usage of getReferenceById returns an object regardless if the uuid is valid.  This causes an issue when a false uuid is used and then produces a EntityNotFoundException when trying to access an attribute of the object returned.  These changes address either not using that specific call and changing to one that will return null if the uuid is invalid.  But also using the exists function of the repository to verify an invalid uuid.