### PR TITLE
ACA Provisioning Clean up

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/ArchivableEntity.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/ArchivableEntity.java
@@ -60,7 +60,6 @@ public abstract class ArchivableEntity extends AbstractEntity {
      *      false is archived time is already set, signifying the entity has been archived.
      */
     public final boolean archive() {
-        this.archiveFlag = false;
         if (this.archivedTime == null) {
             this.archivedTime = new Date();
             archiveFlag = true;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceManifestRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ReferenceManifestRepository.java
@@ -43,6 +43,7 @@ public interface ReferenceManifestRepository extends JpaRepository<ReferenceMani
     List<SupportReferenceManifest> getSupportByManufacturerModel(String manufacturer, String model);
     @Query(value = "SELECT * FROM ReferenceManifest WHERE platformModel = ?1 AND DTYPE = 'EventLogMeasurements'", nativeQuery = true)
     EventLogMeasurements getLogByModel(String model);
+    List<ReferenceManifest> findByDeviceName(String deviceName);
     List<ReferenceManifest> findByArchiveFlag(boolean archiveFlag);
     Page<ReferenceManifest> findByArchiveFlag(boolean archiveFlag, Pageable pageable);
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/SupplyChainValidation.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/SupplyChainValidation.java
@@ -2,6 +2,7 @@ package hirs.attestationca.persist.entity.userdefined;
 
 import com.google.common.base.Preconditions;
 import hirs.attestationca.persist.entity.ArchivableEntity;
+import hirs.attestationca.persist.entity.userdefined.rim.BaseReferenceManifest;
 import hirs.attestationca.persist.enums.AppraisalStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -104,7 +105,7 @@ public class SupplyChainValidation extends ArchivableEntity {
         this.certificatesUsed = new ArrayList<>();
         this.rimId = "";
         for (ArchivableEntity ae : certificatesUsed) {
-            if (ae instanceof ReferenceManifest) {
+            if (ae instanceof BaseReferenceManifest) {
                 this.rimId = ae.getId().toString();
                 break;
             } else {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/info/ComponentInfo.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/info/ComponentInfo.java
@@ -145,7 +145,7 @@ public class ComponentInfo implements Serializable {
                                      final String componentModel,
                                      final String componentSerial,
                                      final String componentRevision) {
-        return !(StringUtils.isEmpty(componentManufacturer)
+        return (StringUtils.isEmpty(componentManufacturer)
                 || StringUtils.isEmpty(componentModel));
     }
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/AbstractProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/AbstractProcessor.java
@@ -170,7 +170,8 @@ public class AbstractProcessor {
             for (ByteString platformCredential : identityClaim.getPlatformCredentialList()) {
                 if (!platformCredential.isEmpty()) {
                     platformCredentials.add(CredentialManagementHelper.storePlatformCredential(
-                            certificateRepository, platformCredential.toByteArray()));
+                            certificateRepository, platformCredential.toByteArray(),
+                            identityClaim.getDv().getNw().getHostname()));
                 }
             }
         } else if (endorsementCredential != null) {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/helper/CredentialManagementHelper.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/helper/CredentialManagementHelper.java
@@ -82,11 +82,12 @@ public final class CredentialManagementHelper {
      * it is unarchived.
      * @param certificateRepository the certificate manager used for storage
      * @param platformBytes the raw PC bytes used for parsing
+     * @param deviceName the host name of the associated machine
      * @return the parsed, valid PC, or null if the provided bytes are not a valid EK.
      */
     public static PlatformCredential storePlatformCredential(
             final CertificateRepository certificateRepository,
-            final byte[] platformBytes) {
+            final byte[] platformBytes, final String deviceName) {
 
         if (certificateRepository == null) {
             throw new IllegalArgumentException("null certificate manager");
@@ -130,6 +131,7 @@ public final class CredentialManagementHelper {
                         }
                     }
                 }
+                platformCredential.setDeviceName(deviceName);
                 return (PlatformCredential) certificateRepository.save(platformCredential);
             } else if (existingCredential.isArchived()) {
                 // if the PC is stored in the DB and it's archived, unarchive.

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
@@ -9,6 +9,7 @@ import hirs.attestationca.persist.entity.manager.ReferenceManifestRepository;
 import hirs.attestationca.persist.entity.userdefined.Certificate;
 import hirs.attestationca.persist.entity.userdefined.Device;
 import hirs.attestationca.persist.entity.userdefined.PolicySettings;
+import hirs.attestationca.persist.entity.userdefined.ReferenceManifest;
 import hirs.attestationca.persist.entity.userdefined.SupplyChainValidation;
 import hirs.attestationca.persist.entity.userdefined.certificate.CertificateAuthorityCredential;
 import hirs.attestationca.persist.entity.userdefined.certificate.ComponentResult;
@@ -187,6 +188,13 @@ public class ValidationService {
         final SupplyChainValidation.ValidationType validationType
                 = SupplyChainValidation.ValidationType.FIRMWARE;
 
+        List<ReferenceManifest> rims = rimRepo.findByDeviceName(device.getName());
+        ReferenceManifest baseRim = null;
+        for (ReferenceManifest rim : rims) {
+            if (rim.getRimType().equals(ReferenceManifest.BASE_RIM)) {
+                baseRim = rim;
+            }
+        }
         AppraisalStatus result = FirmwareScvValidator.validateFirmware(device, policySettings,
                 rimRepo, rdvRepo, caRepo);
         Level logLevel;
@@ -203,7 +211,7 @@ public class ValidationService {
                 logLevel = Level.ERROR;
         }
         return buildValidationRecord(validationType, result.getAppStatus(),
-                result.getMessage(), null, logLevel);
+                result.getMessage(), baseRim, logLevel);
     }
 
     /**

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
@@ -66,8 +66,8 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
             failedString = "Base Reference Integrity Manifest\n";
             passed = false;
         } else {
-            measurement = (EventLogMeasurements) referenceManifestRepository.findByHexDecHash(
-                    baseReferenceManifest.getEventLogHash());
+            measurement = (EventLogMeasurements) referenceManifestRepository.findByHexDecHashAndRimType(
+                    baseReferenceManifest.getEventLogHash(), ReferenceManifest.MEASUREMENT_RIM);
 
             if (measurement == null) {
                 measurement = referenceManifestRepository.byMeasurementDeviceName(
@@ -125,8 +125,8 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
             }
 
             for (SwidResource swidRes : resources) {
-                supportReferenceManifest = referenceManifestRepository.findByHexDecHash(
-                        swidRes.getHashValue());
+                supportReferenceManifest = referenceManifestRepository.findByHexDecHashAndRimType(
+                        swidRes.getHashValue(), ReferenceManifest.SUPPORT_RIM);
                 if (supportReferenceManifest != null) {
                     // Removed the filename check from this if statement
                     referenceManifestValidator.validateSupportRimHash(

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidator.java
@@ -342,7 +342,7 @@ public class SupplyChainCredentialValidator  {
 
     private static String getJSONNodeValueAsText(final JsonNode node, final String fieldName) {
         if (node.hasNonNull(fieldName)) {
-            return node.findValue(fieldName).asText();
+            return node.findValue(fieldName).textValue();
         }
         return null;
     }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
@@ -375,7 +375,7 @@ public class CertificatePageController extends PageController<NoPageParams> {
 
         try {
             UUID uuid = UUID.fromString(id);
-            Certificate certificate = getCertificateById(certificateType, uuid);
+            Certificate certificate = certificateRepository.getCertificate(uuid);
 
             if (certificate == null) {
                 // Use the term "record" here to avoid user confusion b/t cert and cred
@@ -747,29 +747,6 @@ public class CertificatePageController extends PageController<NoPageParams> {
         }
 
         return associatedCertificates;
-    }
-
-    private Certificate getCertificateById(final String certificateType, final UUID uuid) {
-        switch (certificateType) {
-            case PLATFORMCREDENTIAL:
-                if (platformCertificateRepository.existsById(uuid)) {
-                    return platformCertificateRepository.getReferenceById(uuid);
-                }
-            case ENDORSEMENTCREDENTIAL:
-                if (endorsementCredentialRepository.existsById(uuid)) {
-                    return endorsementCredentialRepository.getReferenceById(uuid);
-                }
-            case ISSUEDCERTIFICATES:
-                if (issuedCertificateRepository.existsById(uuid)) {
-                    return issuedCertificateRepository.getReferenceById(uuid);
-                }
-            case TRUSTCHAIN:
-                if (caCredentialRepository.existsById(uuid)) {
-                    return caCredentialRepository.getReferenceById(uuid);
-                }
-            default:
-                return null;
-        }
     }
 
     /**

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -271,7 +271,8 @@ public class ReferenceManifestDetailsPageController extends PageController<Refer
         // to get the id to make the link
         RIM_VALIDATOR.setRim(baseRim.getRimBytes());
         for (SwidResource swidRes : resources) {
-            support = (SupportReferenceManifest) referenceManifestRepository.findByHexDecHash(swidRes.getHashValue());
+            support = (SupportReferenceManifest) referenceManifestRepository.findByHexDecHashAndRimType(
+                    swidRes.getHashValue(), ReferenceManifest.SUPPORT_RIM);
 
             if (support != null && swidRes.getHashValue()
                     .equalsIgnoreCase(support.getHexDecHash())) {

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -39,7 +39,13 @@ import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.*;
@@ -204,7 +210,9 @@ public class ReferenceManifestValidator {
                 log.error("Cannot validate RIM, signature element not found!");
                 return false;
             }
-            trustStore = parseCertificatesFromPem(trustStoreFile);
+            if (!trustStoreFile.isEmpty()) {
+                trustStore = parseCertificatesFromPem(trustStoreFile);
+            }
             NodeList certElement = rim.getElementsByTagName("X509Certificate");
             if (certElement.getLength() > 0) {
                 X509Certificate embeddedCert = parseCertFromPEMString(

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -210,7 +210,7 @@ public class ReferenceManifestValidator {
                 log.error("Cannot validate RIM, signature element not found!");
                 return false;
             }
-            if (!trustStoreFile.isEmpty()) {
+            if (trustStoreFile != null && !trustStoreFile.isEmpty()) {
                 trustStore = parseCertificatesFromPem(trustStoreFile);
             }
             NodeList certElement = rim.getElementsByTagName("X509Certificate");


### PR DESCRIPTION
After being able to provision and environment that has all of the artifacts that the ACA needs to complete a provision with all policy validations enabled, various issues were found and cleaned up.  This PR now allows for a completion.  However the last test does fail because of mismatched components and signature invalid on the tested BaseRIM.  As these are not initially seen as ACA bugs, I'm pushing this up for further testing.

In addition this updates some visual elements that weren't able to be tested.  1) the icon for firmware on the validation page was not linking to anything.  2) componentInfo isComplete was being handled in the reverse manner 3) the paccor output string was never being used for component comparison because it is never saved to the db and would be cleared on the associated instance of Device when starting validation.  4) updated code to properly archive - something was messed up with previous submissions.