### PR TITLE
HIRS_Utils Unit Tests Migration from /hirs/persist/ and /hirs/appraiser/ directories

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/Appraiser.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/Appraiser.java
@@ -6,12 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 
 /**
  * The <code>Appraiser</code> class represents an appraiser that can appraise a <code>Report</code>.
@@ -67,7 +62,6 @@ public class Appraiser {
     private Long id;
 
     @Getter
-    @Setter
     @Column(nullable = false, unique = true)
     private String name;
 
@@ -83,6 +77,19 @@ public class Appraiser {
      * @param name unique name
      */
     public Appraiser(final String name) {
+        setName(name);
+    }
+
+    /**
+     * Sets the name that uniquely identifies this <code>Appraiser</code>. The name may not be
+     * null.
+     *
+     * @param name unique name for this <code>Appraiser</code>
+     */
+    public final void setName(final String name) {
+        if (name == null) {
+            throw new NullPointerException("name");
+        }
         this.name = name;
     }
 }

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/AppraiserTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/AppraiserTest.java
@@ -1,11 +1,8 @@
 package hirs.attestationca.persist.entity;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for the class <code>Appraiser</code>.
@@ -28,7 +25,7 @@ public final class AppraiserTest {
     public void testGetName() {
         final String name = "Test Appraiser";
         final Appraiser appraiser = new TestAppraiser(name);
-        assertEquals(appraiser.getName(), name);
+        assertEquals(name, appraiser.getName());
     }
 
     /**
@@ -38,10 +35,10 @@ public final class AppraiserTest {
     public void testSetName() {
         final String originalName = "Test Appraiser";
         final Appraiser appraiser = new TestAppraiser(originalName);
-        assertEquals(appraiser.getName(), originalName);
+        assertEquals(originalName, appraiser.getName());
         final String newName = "Awesome Test Appraiser";
         appraiser.setName(newName);
-        assertEquals(appraiser.getName(), newName);
+        assertEquals(newName, appraiser.getName());
     }
 
     /**
@@ -51,7 +48,7 @@ public final class AppraiserTest {
     public void testEqualsNull() {
         final String name = "Test Appraiser";
         final Appraiser appraiser = new TestAppraiser(name);
-        assertNotEquals(null, appraiser);
+        assertFalse(appraiser.equals(null));
     }
 
     /**
@@ -72,8 +69,8 @@ public final class AppraiserTest {
         final String name = "Test Appraiser";
         final Appraiser appraiser1 = new TestAppraiser(name);
         final Appraiser appraiser2 = new TestAppraiser(name);
-        assertEquals(appraiser1, appraiser2);
-        assertEquals(appraiser2, appraiser1);
+        assertTrue(appraiser1.equals(appraiser2));
+        assertTrue(appraiser2.equals(appraiser1));
     }
 
     /**
@@ -85,9 +82,9 @@ public final class AppraiserTest {
         final Appraiser appraiser1 = new TestAppraiser(name);
         final Appraiser appraiser2 = new TestAppraiser(name);
         final Appraiser appraiser3 = new TestAppraiser(name);
-        assertEquals(appraiser1, appraiser2);
-        assertEquals(appraiser2, appraiser3);
-        assertEquals(appraiser1, appraiser3);
+        assertTrue(appraiser1.equals(appraiser2));
+        assertTrue(appraiser2.equals(appraiser3));
+        assertTrue(appraiser1.equals(appraiser3));
     }
 
     /**
@@ -99,8 +96,8 @@ public final class AppraiserTest {
         final String name2 = "Other Appraiser";
         final Appraiser appraiser1 = new TestAppraiser(name1);
         final Appraiser appraiser2 = new TestAppraiser(name2);
-        assertNotEquals(appraiser1, appraiser2);
-        assertNotEquals(appraiser2, appraiser1);
+        assertFalse(appraiser1.equals(appraiser2));
+        assertFalse(appraiser2.equals(appraiser1));
     }
 
     /**
@@ -111,8 +108,8 @@ public final class AppraiserTest {
         final String name = "Test Appraiser";
         final Appraiser appraiser1 = new TestAppraiser(name);
         final Appraiser appraiser2 = new TestAppraiser(name);
-        assertEquals(appraiser1, appraiser2);
-        assertEquals(appraiser2, appraiser1);
+        assertTrue(appraiser1.equals(appraiser2));
+        assertTrue(appraiser2.equals(appraiser1));
         assertEquals(appraiser1.hashCode(), appraiser2.hashCode());
         assertEquals(appraiser2.hashCode(), appraiser1.hashCode());
     }
@@ -126,8 +123,8 @@ public final class AppraiserTest {
         final String name2 = "Other Appraiser";
         final Appraiser appraiser1 = new TestAppraiser(name1);
         final Appraiser appraiser2 = new TestAppraiser(name2);
-        assertNotEquals(appraiser1, appraiser2);
-        assertNotEquals(appraiser2, appraiser1);
+        assertFalse(appraiser1.equals(appraiser2));
+        assertFalse(appraiser2.equals(appraiser1));
         assertNotEquals(appraiser1.hashCode(), appraiser2.hashCode());
         assertNotEquals(appraiser2.hashCode(), appraiser1.hashCode());
     }

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/AppraiserTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/AppraiserTest.java
@@ -1,6 +1,10 @@
 package hirs.attestationca.persist.entity;
 
+import hirs.attestationca.persist.entity.userdefined.certificate.CertificateAuthorityCredential;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -16,6 +20,16 @@ public final class AppraiserTest {
     public void testAppraiser() {
         final String name = "Test Appraiser";
         new TestAppraiser(name);
+    }
+
+    /**
+     * Tests that <code>Appraiser</code> throws a <code>NullPointerException</code> if a name is not
+     * provided.
+     */
+    @Test
+    public void testAppraiserNullName() {
+        assertThrows(NullPointerException.class, () ->
+                new TestAppraiser(null));
     }
 
     /**
@@ -39,6 +53,24 @@ public final class AppraiserTest {
         final String newName = "Awesome Test Appraiser";
         appraiser.setName(newName);
         assertEquals(newName, appraiser.getName());
+    }
+
+    /**
+     * Tests that a <code>NullPointerException</code> is thrown if the name is null.
+     */
+    @Test
+    public void testSetNameNull() {
+        final String name = "Test Appraiser";
+        final Appraiser appraiser = new TestAppraiser(name);
+        assertEquals(name, appraiser.getName());
+        NullPointerException expected = null;
+        try {
+            appraiser.setName(null);
+        } catch (NullPointerException e) {
+            expected = e;
+        }
+        assertNotNull(expected, "NullPointerException not caught");
+        assertEquals(name, appraiser.getName());
     }
 
     /**

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/AppraiserTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/AppraiserTest.java
@@ -1,0 +1,135 @@
+package hirs.attestationca.persist.entity;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Unit tests for the class <code>Appraiser</code>.
+ */
+public final class AppraiserTest {
+
+    /**
+     * Tests that an <code>Appraiser</code> can be created with a valid name.
+     */
+    @Test
+    public void testAppraiser() {
+        final String name = "Test Appraiser";
+        new TestAppraiser(name);
+    }
+
+    /**
+     * Tests that the name is returned from <code>getName</code>.
+     */
+    @Test
+    public void testGetName() {
+        final String name = "Test Appraiser";
+        final Appraiser appraiser = new TestAppraiser(name);
+        assertEquals(appraiser.getName(), name);
+    }
+
+    /**
+     * Tests that the name property can be set.
+     */
+    @Test
+    public void testSetName() {
+        final String originalName = "Test Appraiser";
+        final Appraiser appraiser = new TestAppraiser(originalName);
+        assertEquals(appraiser.getName(), originalName);
+        final String newName = "Awesome Test Appraiser";
+        appraiser.setName(newName);
+        assertEquals(appraiser.getName(), newName);
+    }
+
+    /**
+     * Tests that x.equals(null) returns false.
+     */
+    @Test
+    public void testEqualsNull() {
+        final String name = "Test Appraiser";
+        final Appraiser appraiser = new TestAppraiser(name);
+        assertNotEquals(null, appraiser);
+    }
+
+    /**
+     * Tests that x.equals(x) for an appraiser.
+     */
+    @Test
+    public void testEqualsReflexive() {
+        final String name = "Test Appraiser";
+        final Appraiser appraiser = new TestAppraiser(name);
+        assertTrue(appraiser.equals(appraiser));
+    }
+
+    /**
+     * Tests that x.equals(y) and y.equals(x) for an appraiser.
+     */
+    @Test
+    public void testEqualsSymmetric() {
+        final String name = "Test Appraiser";
+        final Appraiser appraiser1 = new TestAppraiser(name);
+        final Appraiser appraiser2 = new TestAppraiser(name);
+        assertEquals(appraiser1, appraiser2);
+        assertEquals(appraiser2, appraiser1);
+    }
+
+    /**
+     * Tests that x.equals(y) and y.equals(z) then x.equals(z) for an appraiser.
+     */
+    @Test
+    public void testEqualsTransitive() {
+        final String name = "Test Appraiser";
+        final Appraiser appraiser1 = new TestAppraiser(name);
+        final Appraiser appraiser2 = new TestAppraiser(name);
+        final Appraiser appraiser3 = new TestAppraiser(name);
+        assertEquals(appraiser1, appraiser2);
+        assertEquals(appraiser2, appraiser3);
+        assertEquals(appraiser1, appraiser3);
+    }
+
+    /**
+     * Tests that two appraisers are not equal if their names are different.
+     */
+    @Test
+    public void testNotEquals() {
+        final String name1 = "Test Appraiser";
+        final String name2 = "Other Appraiser";
+        final Appraiser appraiser1 = new TestAppraiser(name1);
+        final Appraiser appraiser2 = new TestAppraiser(name2);
+        assertNotEquals(appraiser1, appraiser2);
+        assertNotEquals(appraiser2, appraiser1);
+    }
+
+    /**
+     * Tests that if two appraisers are equal that their hash codes are equal.
+     */
+    @Test
+    public void testHashCodeEquals() {
+        final String name = "Test Appraiser";
+        final Appraiser appraiser1 = new TestAppraiser(name);
+        final Appraiser appraiser2 = new TestAppraiser(name);
+        assertEquals(appraiser1, appraiser2);
+        assertEquals(appraiser2, appraiser1);
+        assertEquals(appraiser1.hashCode(), appraiser2.hashCode());
+        assertEquals(appraiser2.hashCode(), appraiser1.hashCode());
+    }
+
+    /**
+     * Tests that if two appraisers are not equal that their hash codes are not equal.
+     */
+    @Test
+    public void testHashCodeNotEquals() {
+        final String name1 = "Test Appraiser";
+        final String name2 = "Other Appraiser";
+        final Appraiser appraiser1 = new TestAppraiser(name1);
+        final Appraiser appraiser2 = new TestAppraiser(name2);
+        assertNotEquals(appraiser1, appraiser2);
+        assertNotEquals(appraiser2, appraiser1);
+        assertNotEquals(appraiser1.hashCode(), appraiser2.hashCode());
+        assertNotEquals(appraiser2.hashCode(), appraiser1.hashCode());
+    }
+
+}

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/TestAppraiser.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/TestAppraiser.java
@@ -1,0 +1,26 @@
+package hirs.attestationca.persist.entity;
+
+import jakarta.persistence.Entity;
+
+/**
+ * Test class for the <code>Appraiser</code> abstract base class.
+ */
+@Entity
+public class TestAppraiser extends Appraiser {
+
+    /**
+     * Creates a new <code>TestAppraiser</code>.
+     *
+     * @param name name
+     */
+    public TestAppraiser(final String name) {
+        super(name);
+    }
+
+    /**
+     * Default constructor necessary for Hibernate.
+     */
+    protected TestAppraiser() {
+        /* do nothing */
+    }
+}

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/tpm/TPM2ProvisionerStateTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/tpm/TPM2ProvisionerStateTest.java
@@ -18,7 +18,7 @@ import java.util.Random;
 /**
  * Contains unit tests for {@link TPM2ProvisionerState}.
  */
-public class TestTPM2ProvisionerState {
+public class TPM2ProvisionerStateTest {
 
     /**
      * Tests that the values passed to the constructor are equal to the values

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/tpm/TPM2ProvisionerStateTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/tpm/TPM2ProvisionerStateTest.java
@@ -36,8 +36,8 @@ public class TPM2ProvisionerStateTest {
 
         TPM2ProvisionerState state = new TPM2ProvisionerState(nonce, identityClaim);
 
-        assertArrayEquals(state.getNonce(), nonce);
-        assertArrayEquals(state.getIdentityClaim(), identityClaim);
+        assertArrayEquals(nonce, state.getNonce());
+        assertArrayEquals(identityClaim, state.getIdentityClaim());
     }
 
     /**
@@ -112,7 +112,7 @@ public class TPM2ProvisionerStateTest {
         TPM2ProvisionerState tpm2ProvisionerState
                 = TPM2ProvisionerState.getTPM2ProvisionerState(tpm2ProvisionerStateRepository, nonce);
         assertNotNull(tpm2ProvisionerState);
-        assertArrayEquals(tpm2ProvisionerState.getIdentityClaim(), value.getIdentityClaim());
+        assertArrayEquals(value.getIdentityClaim(), tpm2ProvisionerState.getIdentityClaim());
     }
 
     /**

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/tpm/TestTPM2ProvisionerState.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/tpm/TestTPM2ProvisionerState.java
@@ -1,0 +1,164 @@
+package hirs.attestationca.persist.entity.tpm;
+
+import hirs.attestationca.persist.entity.manager.TPM2ProvisionerStateRepository;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.Random;
+
+/**
+ * Contains unit tests for {@link TPM2ProvisionerState}.
+ */
+public class TestTPM2ProvisionerState {
+
+    /**
+     * Tests that the values passed to the constructor are equal to the values
+     * returned by the getters.
+     *
+     * @throws IOException this will never happen
+     */
+    @Test
+    public final void testTPM2ProvisionerState() throws IOException {
+        Random rand = new Random();
+        byte[] nonce = new byte[32];
+        byte[] identityClaim = new byte[360];
+        rand.nextBytes(nonce);
+        rand.nextBytes(identityClaim);
+
+        TPM2ProvisionerState state = new TPM2ProvisionerState(nonce, identityClaim);
+
+        assertArrayEquals(state.getNonce(), nonce);
+        assertArrayEquals(state.getIdentityClaim(), identityClaim);
+    }
+
+    /**
+     * Test that the constructor throws an {@link IllegalArgumentException} when a null is
+     * passed in for the nonce.
+     *
+     * @throws IOException this will never happen
+     */
+    @Test
+    public final void testNullNonce() throws IOException {
+        Random rand = new Random();
+        byte[] nonce = null;
+        byte[] identityClaim = new byte[360];
+        rand.nextBytes(identityClaim);
+        assertThrows(IllegalArgumentException.class, () ->
+                new TPM2ProvisionerState(nonce, identityClaim));
+    }
+
+    /**
+     * Test that the constructor throws an {@link IllegalArgumentException} when a null is
+     * passed in for the identity claim.
+     *
+     * @throws IOException this will never happen
+     */
+    @Test
+    public final void testNullIdentityClaim() throws IOException {
+        Random rand = new Random();
+        byte[] nonce = new byte[32];
+        byte[] identityClaim = null;
+        rand.nextBytes(nonce);
+        assertThrows(IllegalArgumentException.class, () ->
+                new TPM2ProvisionerState(nonce, identityClaim));
+    }
+
+    /**
+     * Test that the constructor throws an {@link IllegalArgumentException} when a nonce is
+     * passed in that is less than 8 bytes.
+     *
+     * @throws IOException this will never happen
+     */
+    @Test
+    public final void testNonceToSmall() throws IOException {
+        Random rand = new Random();
+        byte[] nonce = new byte[7];
+        byte[] identityClaim = new byte[360];
+        rand.nextBytes(nonce);
+        rand.nextBytes(identityClaim);
+        assertThrows(IllegalArgumentException.class, () ->
+                new TPM2ProvisionerState(nonce, identityClaim));
+    }
+
+
+    /**
+     * Test that {@link TPM2ProvisionerState#getTPM2ProvisionerState(TPM2ProvisionerStateRepository, byte[])} works.
+     * {@link TPM2ProvisionerState#getTPM2ProvisionerState(TPM2ProvisionerStateRepository, byte[])}, null is returned.
+     * @throws IOException this will never happen
+     */
+    @Test
+    public final void testGetTPM2ProvisionerStateNominal() throws IOException {
+        TPM2ProvisionerStateRepository tpm2ProvisionerStateRepository = mock(TPM2ProvisionerStateRepository.class);
+        Random rand = new Random();
+        byte[] nonce = new byte[32];
+        byte[] identityClaim = new byte[360];
+        rand.nextBytes(nonce);
+        rand.nextBytes(identityClaim);
+
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(nonce));
+        Long index = dis.readLong();
+        dis.close();
+        TPM2ProvisionerState value = new TPM2ProvisionerState(nonce, identityClaim);
+        when(tpm2ProvisionerStateRepository.findByFirstPartOfNonce(index)).thenReturn(value);
+        TPM2ProvisionerState tpm2ProvisionerState
+                = TPM2ProvisionerState.getTPM2ProvisionerState(tpm2ProvisionerStateRepository, nonce);
+        assertNotNull(tpm2ProvisionerState);
+        assertArrayEquals(tpm2ProvisionerState.getIdentityClaim(), value.getIdentityClaim());
+    }
+
+    /**
+     * Test that if a null is passed as a nonce to
+     * {@link TPM2ProvisionerState#getTPM2ProvisionerState(TPM2ProvisionerStateRepository, byte[])}, null is returned.
+     * @throws IOException this will never happen
+     */
+    @Test
+    public final void testGetTPM2ProvisionerStateNullNonce() throws IOException {
+        TPM2ProvisionerStateRepository tpm2ProvisionerStateRepository = mock(TPM2ProvisionerStateRepository.class);
+        Random rand = new Random();
+        byte[] nonce = new byte[32];
+        byte[] identityClaim = new byte[360];
+        rand.nextBytes(nonce);
+        rand.nextBytes(identityClaim);
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(nonce));
+        Long index = dis.readLong();
+        dis.close();
+        TPM2ProvisionerState value = new TPM2ProvisionerState(nonce, identityClaim);
+        when(tpm2ProvisionerStateRepository.findByFirstPartOfNonce(index)).thenReturn(value);
+        TPM2ProvisionerState tpm2ProvisionerState
+                = TPM2ProvisionerState.getTPM2ProvisionerState(tpm2ProvisionerStateRepository, null);
+        assertNull(tpm2ProvisionerState);
+
+    }
+
+    /**
+     * Test that if a nonce that is less than 8 bytes is passed to
+     * {@link TPM2ProvisionerState#getTPM2ProvisionerState(TPM2ProvisionerStateRepository, byte[])}, null is returned.
+     * @throws IOException this will never happen
+     */
+    @Test
+    public final void testGetTPM2ProvisionerStateNonceTooSmall() throws IOException {
+        TPM2ProvisionerStateRepository tpm2ProvisionerStateRepository = mock(TPM2ProvisionerStateRepository.class);
+        Random rand = new Random();
+        byte[] nonce = new byte[32];
+        byte[] identityClaim = new byte[360];
+        rand.nextBytes(nonce);
+        rand.nextBytes(identityClaim);
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(nonce));
+        Long index = dis.readLong();
+        dis.close();
+        TPM2ProvisionerState value = new TPM2ProvisionerState(nonce, identityClaim);
+        when(tpm2ProvisionerStateRepository.findByFirstPartOfNonce(index)).thenReturn(value);
+        TPM2ProvisionerState tpm2ProvisionerState =
+                TPM2ProvisionerState.getTPM2ProvisionerState(tpm2ProvisionerStateRepository, new byte[7]);
+        assertNull(tpm2ProvisionerState);
+    }
+}

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/userdefined/CertificateTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/userdefined/CertificateTest.java
@@ -123,8 +123,8 @@ public class CertificateTest {
                 )
         );
         assertEquals(
-                certificate.getX509Certificate().getIssuerX500Principal().getName(),
-                "CN=Fake Root CA"
+                "CN=Fake Root CA",
+                certificate.getX509Certificate().getIssuerX500Principal().getName()
         );
     }
 
@@ -166,8 +166,8 @@ public class CertificateTest {
                 Paths.get(Objects.requireNonNull(this.getClass().getResource(FAKE_ROOT_CA_FILE)).toURI())
         );
         assertEquals(
-                certificate.getX509Certificate().getIssuerX500Principal().getName(),
-                "CN=Fake Root CA"
+                "CN=Fake Root CA",
+                certificate.getX509Certificate().getIssuerX500Principal().getName()
         );
     }
 
@@ -191,19 +191,23 @@ public class CertificateTest {
      */
     @Test
     public void testGetCertificateType() throws IOException {
-        assertEquals(getTestCertificate(FAKE_ROOT_CA_FILE).getCertificateType(),
-                Certificate.CertificateType.X509_CERTIFICATE);
-        assertNotEquals(getTestCertificate(FAKE_ROOT_CA_FILE).getCertificateType(),
-                Certificate.CertificateType.ATTRIBUTE_CERTIFICATE);
+        assertEquals(
+                Certificate.CertificateType.X509_CERTIFICATE,
+                getTestCertificate(FAKE_ROOT_CA_FILE).getCertificateType());
+        assertNotEquals(
+                Certificate.CertificateType.ATTRIBUTE_CERTIFICATE,
+                getTestCertificate(FAKE_ROOT_CA_FILE).getCertificateType());
 
-        assertNotEquals(getTestCertificate(
+        assertNotEquals(
+                Certificate.CertificateType.X509_CERTIFICATE,
+                getTestCertificate(
                         PlatformCredential.class,
-                        PlatformCredentialTest.TEST_PLATFORM_CERT_3).getCertificateType(),
-                Certificate.CertificateType.X509_CERTIFICATE);
-        assertEquals(getTestCertificate(
+                        PlatformCredentialTest.TEST_PLATFORM_CERT_3).getCertificateType());
+        assertEquals(
+                Certificate.CertificateType.ATTRIBUTE_CERTIFICATE,
+                getTestCertificate(
                         PlatformCredential.class,
-                        PlatformCredentialTest.TEST_PLATFORM_CERT_3).getCertificateType(),
-                Certificate.CertificateType.ATTRIBUTE_CERTIFICATE);
+                        PlatformCredentialTest.TEST_PLATFORM_CERT_3).getCertificateType());
 
     }
 
@@ -219,22 +223,24 @@ public class CertificateTest {
                 PlatformCredential.class, PlatformCredentialTest.TEST_PLATFORM_CERT_4
         );
 
-        assertEquals(platformCredential.getCertificateType(),
-                Certificate.CertificateType.ATTRIBUTE_CERTIFICATE);
         assertEquals(
-                ((PlatformCredential) platformCredential).getPlatformSerial(),
-                "GETY421001GV"
+                Certificate.CertificateType.ATTRIBUTE_CERTIFICATE,
+                platformCredential.getCertificateType());
+        assertEquals(
+                "GETY421001GV",
+                ((PlatformCredential) platformCredential).getPlatformSerial()
         );
 
         platformCredential = getTestCertificate(
                 PlatformCredential.class, PlatformCredentialTest.TEST_PLATFORM_CERT_5
         );
 
-        assertEquals(platformCredential.getCertificateType(),
-                Certificate.CertificateType.ATTRIBUTE_CERTIFICATE);
         assertEquals(
-                ((PlatformCredential) platformCredential).getPlatformSerial(),
-                "GETY42100160"
+                Certificate.CertificateType.ATTRIBUTE_CERTIFICATE,
+                platformCredential.getCertificateType());
+        assertEquals(
+                "GETY42100160",
+                ((PlatformCredential) platformCredential).getPlatformSerial()
         );
 
     }
@@ -249,16 +255,16 @@ public class CertificateTest {
         Certificate rootCert = getTestCertificate(FAKE_ROOT_CA_FILE);
         X509Certificate certificate = readX509Certificate(FAKE_ROOT_CA_FILE);
 
-        assertEquals(rootCert.getSerialNumber(), certificate.getSerialNumber());
-        assertEquals(rootCert.getIssuer(),
-                certificate.getIssuerX500Principal().getName());
-        assertEquals(rootCert.getSubject(),
-                certificate.getSubjectX500Principal().getName());
-        assertArrayEquals(rootCert.getEncodedPublicKey(),
-                certificate.getPublicKey().getEncoded());
-        assertArrayEquals(rootCert.getSignature(), certificate.getSignature());
-        assertEquals(rootCert.getBeginValidity(), certificate.getNotBefore());
-        assertEquals(rootCert.getEndValidity(), certificate.getNotAfter());
+        assertEquals(certificate.getSerialNumber(), rootCert.getSerialNumber());
+        assertEquals(certificate.getIssuerX500Principal().getName(),
+                rootCert.getIssuer());
+        assertEquals(certificate.getSubjectX500Principal().getName(),
+                rootCert.getSubject());
+        assertArrayEquals(certificate.getPublicKey().getEncoded(),
+                rootCert.getEncodedPublicKey());
+        assertArrayEquals(certificate.getSignature(), rootCert.getSignature());
+        assertEquals(certificate.getNotBefore(), rootCert.getBeginValidity());
+        assertEquals(certificate.getNotAfter(), rootCert.getEndValidity());
     }
 
     /**
@@ -269,11 +275,13 @@ public class CertificateTest {
     @Test
     public void testX509CertificateParsingExtended() throws IOException {
         Certificate rootCert = getTestCertificate(INTEL_INT_CA_FILE);
-        assertEquals(rootCert.getAuthorityInfoAccess(),
+        assertEquals(
                 "https://trustedservices.intel.com/"
-                        + "content/TSC/certs/TSC_SS_RootCA_Certificate.cer\n");
-        assertEquals(rootCert.getAuthorityKeyIdentifier(),
-                "b56f72cdfd66ce839e1fdb40498f07291f5b99b7");
+                        + "content/TSC/certs/TSC_SS_RootCA_Certificate.cer\n",
+                rootCert.getAuthorityInfoAccess());
+        assertEquals(
+                "b56f72cdfd66ce839e1fdb40498f07291f5b99b7",
+                rootCert.getAuthorityKeyIdentifier());
     }
 
     /**
@@ -297,18 +305,18 @@ public class CertificateTest {
         );
 
         assertEquals(
-                platformCert.getSerialNumber(),
-                attrCertHolder.getSerialNumber()
+                attrCertHolder.getSerialNumber(),
+                platformCert.getSerialNumber()
         );
         assertEquals(
-                platformCert.getIssuer(),
-                attrCertHolder.getIssuer().getNames()[0].toString()
+                attrCertHolder.getIssuer().getNames()[0].toString(),
+                platformCert.getIssuer()
         );
-        assertEquals(platformCert.getSubject(), null);
-        assertArrayEquals(platformCert.getEncodedPublicKey(), null);
-        assertArrayEquals(platformCert.getSignature(), attrCertHolder.getSignature());
-        assertEquals(platformCert.getBeginValidity(), attrCertHolder.getNotBefore());
-        assertEquals(platformCert.getEndValidity(), attrCertHolder.getNotAfter());
+        assertEquals(null, platformCert.getSubject());
+        assertArrayEquals(null, platformCert.getEncodedPublicKey());
+        assertArrayEquals(attrCertHolder.getSignature(), platformCert.getSignature());
+        assertEquals(attrCertHolder.getNotBefore(), platformCert.getBeginValidity());
+        assertEquals(attrCertHolder.getNotAfter(), platformCert.getEndValidity());
     }
 
     /**
@@ -324,11 +332,11 @@ public class CertificateTest {
         Certificate platformCert = getTestCertificate(
                 PlatformCredential.class, PlatformCredentialTest.TEST_PLATFORM_CERT_6);
 
-        assertEquals(platformCert.getAuthorityInfoAccess(),
-                "https://trustedservices.intel.com/"
-                        + "content/TSC/certs/TSC_IssuingCAIKGF_TEST.cer\n");
-        assertEquals(platformCert.getAuthorityKeyIdentifier(),
-                "a5ecc6c07da02c6af8764d4e5c16483610a0b040");
+        assertEquals("https://trustedservices.intel.com/"
+                        + "content/TSC/certs/TSC_IssuingCAIKGF_TEST.cer\n",
+                platformCert.getAuthorityInfoAccess());
+        assertEquals("a5ecc6c07da02c6af8764d4e5c16483610a0b040",
+                platformCert.getAuthorityKeyIdentifier());
     }
 
     /**
@@ -344,11 +352,11 @@ public class CertificateTest {
         byte[] expectedCertBytes = Arrays.copyOfRange(rawFileBytes, 0, 908);
         Certificate ekCert = getTestCertificate(EndorsementCredential.class,
                 EK_CERT_WITH_PADDED_BYTES);
-        assertEquals(ekCert.getSerialNumber(), new BigInteger("16842032579184247954"));
-        assertEquals(ekCert.getIssuer(),
-                "CN=Nuvoton TPM Root CA 2010+O=Nuvoton Technology Corporation+C=TW");
-        assertEquals(ekCert.getSubject(), "");
-        assertArrayEquals(ekCert.getRawBytes(), expectedCertBytes);
+        assertEquals(new BigInteger("16842032579184247954"), ekCert.getSerialNumber());
+        assertEquals("CN=Nuvoton TPM Root CA 2010+O=Nuvoton Technology Corporation+C=TW",
+                ekCert.getIssuer());
+        assertEquals("", ekCert.getSubject());
+        assertArrayEquals(expectedCertBytes, ekCert.getRawBytes());
     }
 
     /**
@@ -440,9 +448,9 @@ public class CertificateTest {
         );
 
         assertNotEquals(
-                getTestCertificate(CertificateAuthorityCredential.class, FAKE_ROOT_CA_FILE),
-                null
-        );
+                null,
+                getTestCertificate(CertificateAuthorityCredential.class, FAKE_ROOT_CA_FILE)
+       );
     }
 
     /**
@@ -460,7 +468,7 @@ public class CertificateTest {
         Certificate issuerCert = getTestCertificate(FAKE_ROOT_CA_FILE);
         Certificate cert = getTestCertificate(INT_CA_CERT02);
 
-        assertEquals(issuerCert.isIssuer(cert), "Certificate signature failed to verify");
+        assertEquals("Certificate signature failed to verify", issuerCert.isIssuer(cert));
         assertTrue(cert.isIssuer(issuerCert).isEmpty());
     }
 

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/userdefined/CertificateTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/userdefined/CertificateTest.java
@@ -15,6 +15,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import hirs.attestationca.persist.entity.userdefined.certificate.*;
 import org.bouncycastle.cert.X509AttributeCertificateHolder;
@@ -118,11 +119,11 @@ public class CertificateTest {
     public void testConstructCertFromByteArray() throws IOException, URISyntaxException {
         Certificate certificate = new CertificateAuthorityCredential(
                 Files.readAllBytes(
-                        Paths.get(this.getClass().getResource(FAKE_ROOT_CA_FILE).toURI())
+                        Paths.get(Objects.requireNonNull(this.getClass().getResource(FAKE_ROOT_CA_FILE)).toURI())
                 )
         );
         assertEquals(
-                certificate.getX509Certificate().getIssuerDN().getName(),
+                certificate.getX509Certificate().getIssuerX500Principal().getName(),
                 "CN=Fake Root CA"
         );
     }
@@ -162,10 +163,10 @@ public class CertificateTest {
     @Test
     public void testConstructCertFromPath() throws URISyntaxException, IOException {
         Certificate certificate = new CertificateAuthorityCredential(
-                Paths.get(this.getClass().getResource(FAKE_ROOT_CA_FILE).toURI())
+                Paths.get(Objects.requireNonNull(this.getClass().getResource(FAKE_ROOT_CA_FILE)).toURI())
         );
         assertEquals(
-                certificate.getX509Certificate().getIssuerDN().getName(),
+                certificate.getX509Certificate().getIssuerX500Principal().getName(),
                 "CN=Fake Root CA"
         );
     }
@@ -290,9 +291,9 @@ public class CertificateTest {
         );
 
         X509AttributeCertificateHolder attrCertHolder = new X509AttributeCertificateHolder(
-                Files.readAllBytes(Paths.get(this.getClass().getResource(
+                Files.readAllBytes(Paths.get(Objects.requireNonNull(this.getClass().getResource(
                         PlatformCredentialTest.TEST_PLATFORM_CERT_3
-                ).toURI()))
+                )).toURI()))
         );
 
         assertEquals(
@@ -338,8 +339,8 @@ public class CertificateTest {
      */
     @Test
     public void testCertificateTrim() throws IOException, URISyntaxException {
-        byte[] rawFileBytes = Files.readAllBytes(Paths.get(CertificateTest.class
-                .getResource(EK_CERT_WITH_PADDED_BYTES).toURI()));
+        byte[] rawFileBytes = Files.readAllBytes(Paths.get(Objects.requireNonNull(CertificateTest.class
+                .getResource(EK_CERT_WITH_PADDED_BYTES)).toURI()));
         byte[] expectedCertBytes = Arrays.copyOfRange(rawFileBytes, 0, 908);
         Certificate ekCert = getTestCertificate(EndorsementCredential.class,
                 EK_CERT_WITH_PADDED_BYTES);
@@ -360,8 +361,8 @@ public class CertificateTest {
     @Test
     public void testCertificateTrimThrowsWhenNoLengthFieldFound() throws IOException,
             URISyntaxException {
-        byte[] rawFileBytes = Files.readAllBytes(Paths.get(CertificateTest.class
-                .getResource(EK_CERT_WITH_PADDED_BYTES).toURI()));
+        byte[] rawFileBytes = Files.readAllBytes(Paths.get(Objects.requireNonNull(CertificateTest.class
+                .getResource(EK_CERT_WITH_PADDED_BYTES)).toURI()));
         assertThrows(IllegalArgumentException.class, () ->
                         new EndorsementCredential(Arrays.copyOfRange(rawFileBytes, 0, 2)),
                 ".* No certificate length field could be found\\.");
@@ -377,8 +378,8 @@ public class CertificateTest {
     @Test
     public void testCertificateTrimThrowsWhenOnlyASN1Sequence() throws IOException,
             URISyntaxException {
-        byte[] rawFileBytes = Files.readAllBytes(Paths.get(CertificateTest.class
-                .getResource(EK_CERT_WITH_PADDED_BYTES).toURI()));
+        byte[] rawFileBytes = Files.readAllBytes(Paths.get(Objects.requireNonNull(CertificateTest.class
+                .getResource(EK_CERT_WITH_PADDED_BYTES)).toURI()));
         assertThrows(IllegalArgumentException.class, () ->
                         new EndorsementCredential(Arrays.copyOfRange(rawFileBytes, 0, 4)),
                 ".* Certificate is nothing more than ASN.1 Sequence\\\\.");
@@ -394,8 +395,8 @@ public class CertificateTest {
     @Test
     public void testCertificateTrimThrowsWhenLengthIsTooLarge() throws IOException,
             URISyntaxException {
-        byte[] rawFileBytes = Files.readAllBytes(Paths.get(CertificateTest.class
-                .getResource(EK_CERT_WITH_PADDED_BYTES).toURI()));
+        byte[] rawFileBytes = Files.readAllBytes(Paths.get(Objects.requireNonNull(CertificateTest.class
+                .getResource(EK_CERT_WITH_PADDED_BYTES)).toURI()));
         assertThrows(IllegalArgumentException.class, () ->
                         new EndorsementCredential(Arrays.copyOfRange(rawFileBytes, 0, 42)),
                 ".* Value of certificate length field extends beyond"
@@ -419,11 +420,11 @@ public class CertificateTest {
 
         assertEquals(
                 new CertificateAuthorityCredential(
-                        Paths.get(this.getClass().getResource(FAKE_ROOT_CA_FILE).toURI())
+                        Paths.get(Objects.requireNonNull(this.getClass().getResource(FAKE_ROOT_CA_FILE)).toURI())
                 ),
                 new CertificateAuthorityCredential(
                         Files.readAllBytes(
-                                Paths.get(this.getClass().getResource(FAKE_ROOT_CA_FILE).toURI())
+                                Paths.get(Objects.requireNonNull(this.getClass().getResource(FAKE_ROOT_CA_FILE)).toURI())
                         )
                 )
         );
@@ -480,11 +481,11 @@ public class CertificateTest {
 
         assertEquals(
                 new CertificateAuthorityCredential(
-                        Paths.get(this.getClass().getResource(FAKE_ROOT_CA_FILE).toURI())
+                        Paths.get(Objects.requireNonNull(this.getClass().getResource(FAKE_ROOT_CA_FILE)).toURI())
                 ).hashCode(),
                 new CertificateAuthorityCredential(
                         Files.readAllBytes(
-                                Paths.get(this.getClass().getResource(FAKE_ROOT_CA_FILE).toURI())
+                                Paths.get(Objects.requireNonNull(this.getClass().getResource(FAKE_ROOT_CA_FILE)).toURI())
                         )
                 ).hashCode()
         );
@@ -546,7 +547,7 @@ public class CertificateTest {
 
         Path certPath;
         try {
-            certPath = Paths.get(CertificateTest.class.getResource(filename).toURI());
+            certPath = Paths.get(Objects.requireNonNull(CertificateTest.class.getResource(filename)).toURI());
         } catch (URISyntaxException e) {
             throw new IOException("Could not resolve path URI", e);
         }
@@ -595,7 +596,7 @@ public class CertificateTest {
         }
 
         try (FileInputStream certInputStream = new FileInputStream(
-                Paths.get(CertificateTest.class.getResource(resourceName).toURI()).toFile()
+                Paths.get(Objects.requireNonNull(CertificateTest.class.getResource(resourceName)).toURI()).toFile()
         )) {
             return (X509Certificate) cf.generateCertificate(certInputStream);
         } catch (CertificateException | URISyntaxException e) {


### PR DESCRIPTION
[Issue 615](https://github.com/nsacyber/HIRS/issues/615) includes:

Migration into the main branch's `HIRS_AttestationCA/src/test`, including the following 3 unit tests from master:

- `HIRS_Utils/src/test/java/hirs/persist/TestTPM2ProvisionerState`
- `HIRS_Utils/src/test/java/hirs/appraiser/AppraiserTest`
- `HIRS_Utils/src/test/java/hirs/appraiser/TestAppraiser`
- Fixing of `HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/userdefined/CertificateTest` in main branch to replace some deprecated methods with up-to-date ones. Runs the same as before, but without a warning in the console.