### PR TITLE
[#646] Fix broken rimtool validation

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -210,7 +210,7 @@ public class ReferenceManifestValidator {
                 log.error("Cannot validate RIM, signature element not found!");
                 return false;
             }
-            if (trustStoreFile != null && !trustStoreFile.isEmpty()) {
+            if (trustStore == null && trustStoreFile != null && !trustStoreFile.isEmpty()) {
                 trustStore = parseCertificatesFromPem(trustStoreFile);
             }
             NodeList certElement = rim.getElementsByTagName("X509Certificate");
@@ -251,6 +251,9 @@ public class ReferenceManifestValidator {
      */
     public boolean validateSwidtagFile(String path) {
         Element fileElement = (Element) rim.getElementsByTagName("File").item(0);
+        if (trustStoreFile != null && !trustStoreFile.isEmpty()) {
+            trustStore = parseCertificatesFromPem(trustStoreFile);
+        }
         X509Certificate signingCert = null;
         try {
             signingCert = getCertFromTruststore();
@@ -337,7 +340,7 @@ public class ReferenceManifestValidator {
     private String getHashValue(final String filepath, final String sha) {
         try {
             MessageDigest md = MessageDigest.getInstance(sha);
-            byte[] bytes = md.digest(Files.readAllBytes(Paths.get(filepath)));
+            byte[] bytes = Files.readAllBytes(Paths.get(filepath));
             return getHashValue(bytes, sha);
         } catch (NoSuchAlgorithmException e) {
             log.warn(e.getMessage());

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -28,6 +28,7 @@ public class Main {
                 String certificateFile = commander.getPublicCertificate();
                 String trustStore = commander.getTruststoreFile();
                 if (!verifyFile.isEmpty()) {
+                    validator.setRim(verifyFile);
                     if (!rimel.isEmpty()) {
                         validator.setRimEventLog(rimel);
                     }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -623,14 +623,6 @@ public class SwidTagGateway {
         if (defaultCredentials) {
             cp.parseJKSCredentials(jksTruststoreFile);
             privateKey = cp.getPrivateKey();
-            KeyName keyName = null;
-            try {
-                keyName = kiFactory.newKeyName(cp.getCertificateSubjectKeyIdentifier());
-            } catch (IOException e) {
-                System.out.println("Error while getting SKID: " + e.getMessage());
-                System.exit(1);
-            }
-            keyInfoElements.add(keyName);
         } else {
             try {
                 cp.parsePEMCredentials(pemCertificateFile, pemPrivateKeyFile);
@@ -653,6 +645,13 @@ public class SwidTagGateway {
                     System.out.println("Error while creating KeyValue: " + e.getMessage());
                 }
             }
+        }
+        try {
+            KeyName keyName = kiFactory.newKeyName(cp.getCertificateSubjectKeyIdentifier());
+            keyInfoElements.add(keyName);
+        } catch (IOException e) {
+            System.out.println("Error while getting SKID: " + e.getMessage());
+            System.exit(1);
         }
         KeyInfo keyinfo = kiFactory.newKeyInfo(keyInfoElements);
 

--- a/tools/tcg_rim_tool/src/test/java/hirs/swid/TestSwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/test/java/hirs/swid/TestSwidTagGateway.java
@@ -69,6 +69,7 @@ public class TestSwidTagGateway {
 		expectedFile = TestSwidTagGateway.class.getClassLoader()
 				.getResourceAsStream(BASE_USER_CERT);
 		Assert.assertTrue(compareFileBytesToExpectedFile(DEFAULT_OUTPUT));
+		validator.setRim(DEFAULT_OUTPUT);
 		Assert.assertTrue(validator.validateSwidtagFile(DEFAULT_OUTPUT));
 	}
 
@@ -88,6 +89,7 @@ public class TestSwidTagGateway {
 		expectedFile = TestSwidTagGateway.class.getClassLoader()
 				.getResourceAsStream(BASE_USER_CERT_EMBED);
 		Assert.assertTrue(compareFileBytesToExpectedFile(DEFAULT_OUTPUT));
+		validator.setRim(DEFAULT_OUTPUT);
 		Assert.assertTrue(validator.validateSwidtagFile(DEFAULT_OUTPUT));
 	}
 
@@ -103,6 +105,7 @@ public class TestSwidTagGateway {
 		expectedFile = TestSwidTagGateway.class.getClassLoader()
 				.getResourceAsStream(BASE_DEFAULT_CERT);
 		Assert.assertTrue(compareFileBytesToExpectedFile(DEFAULT_OUTPUT));
+		validator.setRim(DEFAULT_OUTPUT);
 		Assert.assertTrue(validator.validateSwidtagFile(DEFAULT_OUTPUT));
 	}
 
@@ -120,6 +123,7 @@ public class TestSwidTagGateway {
 		expectedFile = TestSwidTagGateway.class.getClassLoader()
 				.getResourceAsStream(BASE_RFC3339_TIMESTAMP);
 		Assert.assertTrue(compareFileBytesToExpectedFile(DEFAULT_OUTPUT));
+		validator.setRim(DEFAULT_OUTPUT);
 		Assert.assertTrue(validator.validateSwidtagFile(DEFAULT_OUTPUT));
 	}
 
@@ -137,6 +141,7 @@ public class TestSwidTagGateway {
 		expectedFile = TestSwidTagGateway.class.getClassLoader()
 				.getResourceAsStream(BASE_RFC3852_TIMESTAMP);
 		Assert.assertTrue(compareFileBytesToExpectedFile(DEFAULT_OUTPUT));
+		validator.setRim(DEFAULT_OUTPUT);
 		Assert.assertTrue(validator.validateSwidtagFile(DEFAULT_OUTPUT));
 	}
 
@@ -149,6 +154,7 @@ public class TestSwidTagGateway {
 		String filepath = TestSwidTagGateway.class.getClassLoader()
 				.getResource(BASE_USER_CERT).getPath();
 		System.out.println("Validating file at " + filepath);
+		validator.setRim(DEFAULT_OUTPUT);
 		Assert.assertTrue(validator.validateSwidtagFile(filepath));
 	}
 

--- a/tools/tcg_rim_tool/src/test/resources/generated_default_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_default_cert.swidtag
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
-  <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
-  <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
-  <Payload>
+<ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+  <ns2:Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
+  <ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
+  <ns2:Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
+  <ns2:Payload>
     <Directory name="rim">
       <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.BIOS.01.rimel" size="7549"/>
     </Directory>
-  </Payload>
+  </ns2:Payload>
   <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
     <SignedInfo>
       <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
@@ -17,16 +17,16 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>DJMc0n3VHHwU+F3HNpiY/l3EMcjRZAQOYlrjhD5v9qE=</DigestValue>
+        <DigestValue>ltjNmhHEqfpWwGmv1fTLLhJbtcn36wzPc8ZrOoUxXAI=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>ojJ6v8ToxLWWekCKmBoZ+Yg2V4MYMPbKB9FjDs/QG/AMP+LKjnb55Z7FSLhC8+CvvShKPAoS9mv1&#13;
-QepwI17NEqbfnC1U4WH0u578A3J6wiHMXIDnIQqKAAXb8v2c/wjMDArzFl8CXmDA7HUDIt+3C4VC&#13;
-tA598YY7o0Hf6hK5qO8oWGQxXUKfpUwvtGLxHpbDWYFuVSPa+uk6OTzutt/QyzTERzxyO9Le1i6K&#13;
-nrpzh4lgHn6EfGs6HR1ffdHQ069q0bE61zDx0VC18nK9DmszW6p6FlMzApiTVW/4PiVt+dSFeVGR&#13;
-9///OdtxcoBCeofDDFPRyO+s+kY1pXd92Q3nfg==</SignatureValue>
+    <SignatureValue>UWzTHnnQwc4+OYRl3bGXdGwAZsYBjQpoJb6jgif6c9/mHl1xCNjO1zJUzAGpeEq14j4qJ1WV8rHb&#13;
+5R16iMN05xQ5FCC8o1KvtJ6xwAkIgYei06iWaypgv39R42MD8HySVWBv5Ya7qIrvCBfp57L7z8Wm&#13;
+KvKptRctbb8of7OBdAH/Ywr2z1avwVVI7K7ugvjYkxn4sBfO4HkGABcJ4vIr1haOOU0/ip0qA/4U&#13;
+Fm1EJRDA2cYhTPcxHNoWDh2SAYVDH3t9vF/1BEPy5ke5iqRIsvTjoLz3WJtub6zKJ7fg4+1oyDK6&#13;
+641x+SIRT7EqRMLtxlpXniVMGbp8i4mxFaQGpQ==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>
   </Signature>
-</SoftwareIdentity>
+</ns2:SoftwareIdentity>

--- a/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3339.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3339.swidtag
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
-  <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
-  <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
-  <Payload>
+<ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+  <ns2:Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
+  <ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
+  <ns2:Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
+  <ns2:Payload>
     <Directory name="rim">
       <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.BIOS.01.rimel" size="7549"/>
     </Directory>
-  </Payload>
+  </ns2:Payload>
   <Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="RimSignature">
     <SignedInfo>
       <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
@@ -17,18 +17,18 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>DJMc0n3VHHwU+F3HNpiY/l3EMcjRZAQOYlrjhD5v9qE=</DigestValue>
+        <DigestValue>ltjNmhHEqfpWwGmv1fTLLhJbtcn36wzPc8ZrOoUxXAI=</DigestValue>
       </Reference>
       <Reference URI="#TST">
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>j8sqX9NGt8DAPOvbhXKAT648BGdPnQnblai1PYDUryE=</DigestValue>
+        <DigestValue>KOli94FU4OwApn2yz7J4SmnBEDE2u+jc1Fm2ajoaBhI=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>N8QB5dMLnSLaDuCO8Ds/9nPlJGzsF1HJCthEXDXPrMTpfWBwmsVTqtNwoGzHIXlx8HDdDcfTLa3j&#13;
-3rfFmDZNMqv6+6jjjJZerpN6XyWHGaVjVuPiNGmafE5SajTg53+6KlWXTGs3kcbbV5cTtjASz/A0&#13;
-cz9gBYTwYXmWA3+V0USLA0MNYzPkKp83eDnizbrkGx824NU9qG1DetVFfZqotWoTGJ1Wz4J8D1yR&#13;
-wUILS0DbtZalCNVv3kw9raIRKQ/CjlDztfP1SgiNuXu6IaVZKoVG9HGp3s8pQvFPHr0HD2sNrAkx&#13;
-twKcg3XIzGrTc22Y2TYw9Dk3NxumQSp4kve6ow==</SignatureValue>
+    <SignatureValue>jJQLwoWj8AXLzNn9H0jTtDV32SvFonY0TDlMQg9lhOCTi3HPRGuUzPCCBg+JukM9THuAbXx8yVKW&#13;
+pGr8fCLmGkfLy7S0YJwQLaulZvGgV0gprD5M8lqDAUibkN98ArOzTDBd6AxW8GVcOpb7Wc9ckS20&#13;
+K/uQCLC4AyxRT8AVJ193Ru3DGBOH/WRXBHFIo6ySSi2i8a3soOEzFWmU1euXD0XqrQLa4Q4n4u2e&#13;
+ChivQNqC8s9Xl1h07S9JFF4v1q+hmAOY+8pqYxDZtw6cVpiXQGufSuzBIxiYKv4p+cAD+OhXL9z1&#13;
+h0PAgMBd0VsH8SrtKaDe/Jw91GG8L8YvP1tG0g==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>
@@ -40,4 +40,4 @@ twKcg3XIzGrTc22Y2TYw9Dk3NxumQSp4kve6ow==</SignatureValue>
       </SignatureProperties>
     </Object>
   </Signature>
-</SoftwareIdentity>
+</ns2:SoftwareIdentity>

--- a/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3852.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_timestamp_rfc3852.swidtag
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
-  <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
-  <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
-  <Payload>
+<ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+  <ns2:Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
+  <ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
+  <ns2:Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
+  <ns2:Payload>
     <Directory name="rim">
       <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.BIOS.01.rimel" size="7549"/>
     </Directory>
-  </Payload>
+  </ns2:Payload>
   <Signature xmlns="http://www.w3.org/2000/09/xmldsig#" Id="RimSignature">
     <SignedInfo>
       <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
@@ -17,18 +17,18 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>DJMc0n3VHHwU+F3HNpiY/l3EMcjRZAQOYlrjhD5v9qE=</DigestValue>
+        <DigestValue>ltjNmhHEqfpWwGmv1fTLLhJbtcn36wzPc8ZrOoUxXAI=</DigestValue>
       </Reference>
       <Reference URI="#TST">
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>KC51x7iXfEjDYEieFP1lktWNGP6eCWpXe5/sr3V8PlU=</DigestValue>
+        <DigestValue>5l1XanjF3l/o5zXbuAaQUVv242+X9ZeiGbg8AAXCNgc=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>M6a+lIU7vIQmO0By/WCtocI4qzk4R4oXtduEpeyOfIH/xOTKkDI7E17v6dywLd7psZSKMPw8lRqp&#13;
-AZCBvsU6zDXzLsAakO2ydmH2i5POWNArUq+GRw9KDnNPZWanmRSqjpV2mEjfx84IF2MaqXDPng1q&#13;
-JrzKN8f00uHM+eOmXktyiBhJR9gT+htceMzAEzk8qeWCg6o6wFMx0JR1lUbGOXe070DtZCR7I0iQ&#13;
-0iZfnNzMzuRf2GHw6aKnSyGwdr1pUeoxEVGR5jkY8a7mT/0mt+8kVq4FL1gikrSOzvotoZ+dGb0Q&#13;
-JjzA2IgK+ti/Tc/FpLYKefXQwcVSUY+CD/HCvA==</SignatureValue>
+    <SignatureValue>DP+66mRubZK3X+zyeDPL0yKevIALl+REu6siVBNtHyf2nDPk5/Iekvqdki8ild1ieSD0i7Wbsz9+&#13;
+8StHMfOOYRd7QDwOL0QVW213JZRemn/EckuQic1Rz+V2Kw2kjBuzsLsJE4GHR8WFO4SDklze74KL&#13;
+U43suxuZ4hqPsNRS0Fe085h7y7KcXNLlmsIQfLsVVHfdXLZPt29nN7DscT+PhCI4QuUU0SKnkOx1&#13;
+/iW2wWf1lCESgpUmRKU5Tf1uvgbPgEf7CWurHptSKs38ZVwz6AFyMIY5g2XwbDkCTocgrC9xlI9h&#13;
+GV3jB3ojUwB3ne06Sp21FgRbOgI9xbvoD3G33g==</SignatureValue>
     <KeyInfo>
       <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>
@@ -40,4 +40,4 @@ JjzA2IgK+ti/Tc/FpLYKefXQwcVSUY+CD/HCvA==</SignatureValue>
       </SignatureProperties>
     </Object>
   </Signature>
-</SoftwareIdentity>
+</ns2:SoftwareIdentity>

--- a/tools/tcg_rim_tool/src/test/resources/generated_user_cert.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_user_cert.swidtag
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
-  <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
-  <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
-  <Payload>
+<ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+  <ns2:Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
+  <ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
+  <ns2:Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
+  <ns2:Payload>
     <Directory name="rim">
       <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.BIOS.01.rimel" size="7549"/>
     </Directory>
-  </Payload>
+  </ns2:Payload>
   <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
     <SignedInfo>
       <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>DJMc0n3VHHwU+F3HNpiY/l3EMcjRZAQOYlrjhD5v9qE=</DigestValue>
+        <DigestValue>ltjNmhHEqfpWwGmv1fTLLhJbtcn36wzPc8ZrOoUxXAI=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>ojJ6v8ToxLWWekCKmBoZ+Yg2V4MYMPbKB9FjDs/QG/AMP+LKjnb55Z7FSLhC8+CvvShKPAoS9mv1&#13;
-QepwI17NEqbfnC1U4WH0u578A3J6wiHMXIDnIQqKAAXb8v2c/wjMDArzFl8CXmDA7HUDIt+3C4VC&#13;
-tA598YY7o0Hf6hK5qO8oWGQxXUKfpUwvtGLxHpbDWYFuVSPa+uk6OTzutt/QyzTERzxyO9Le1i6K&#13;
-nrpzh4lgHn6EfGs6HR1ffdHQ069q0bE61zDx0VC18nK9DmszW6p6FlMzApiTVW/4PiVt+dSFeVGR&#13;
-9///OdtxcoBCeofDDFPRyO+s+kY1pXd92Q3nfg==</SignatureValue>
+    <SignatureValue>UWzTHnnQwc4+OYRl3bGXdGwAZsYBjQpoJb6jgif6c9/mHl1xCNjO1zJUzAGpeEq14j4qJ1WV8rHb&#13;
+5R16iMN05xQ5FCC8o1KvtJ6xwAkIgYei06iWaypgv39R42MD8HySVWBv5Ya7qIrvCBfp57L7z8Wm&#13;
+KvKptRctbb8of7OBdAH/Ywr2z1avwVVI7K7ugvjYkxn4sBfO4HkGABcJ4vIr1haOOU0/ip0qA/4U&#13;
+Fm1EJRDA2cYhTPcxHNoWDh2SAYVDH3t9vF/1BEPy5ke5iqRIsvTjoLz3WJtub6zKJ7fg4+1oyDK6&#13;
+641x+SIRT7EqRMLtxlpXniVMGbp8i4mxFaQGpQ==</SignatureValue>
     <KeyInfo>
       <KeyValue>
         <RSAKeyValue>
@@ -36,6 +36,7 @@ jDQeHiY0VIoPik/jVVIpjWe6zzeZ2S66Q/LmjQ==</Modulus>
           <Exponent>AQAB</Exponent>
         </RSAKeyValue>
       </KeyValue>
+      <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>
   </Signature>
-</SoftwareIdentity>
+</ns2:SoftwareIdentity>

--- a/tools/tcg_rim_tool/src/test/resources/generated_user_cert_embed.swidtag
+++ b/tools/tcg_rim_tool/src/test/resources/generated_user_cert_embed.swidtag
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<SoftwareIdentity xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns2="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
-  <Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
-  <Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
-  <Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
-  <Payload>
+<ns2:SoftwareIdentity xmlns:ns2="http://standards.iso.org/iso/19770/-2/2015/schema.xsd" xmlns:ns3="http://www.w3.org/2000/09/xmldsig#" corpus="false" name="Example.com BIOS" patch="false" supplemental="false" tagId="94f6b457-9ac9-4d35-9b3f-78804173b65as" tagVersion="0" version="01" versionScheme="multipartnumeric" xml:lang="en">
+  <ns2:Entity name="Example Inc" regid="http://Example.com" role="softwareCreator tagCreator"/>
+  <ns2:Link href="https://Example.com/support/ProductA/firmware/installfiles" rel="installationmedia"/>
+  <ns2:Meta xmlns:n8060="http://csrc.nist.gov/ns/swid/2015-extensions/1.0" xmlns:rim="https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model" n8060:colloquialVersion="Firmware_2019" n8060:edition="12" n8060:product="ProductA" n8060:revision="r2" rim:PayloadType="direct" rim:bindingSpec="PC Client RIM" rim:bindingSpecVersion="1.2" rim:firmwareManufacturerId="00213022" rim:firmwareManufacturerStr="BIOSVendorA" rim:firmwareModel="A0" rim:firmwareVersion="12" rim:pcURIGlobal="https://Example.com/support/ProductA/" rim:pcURIlocal="/boot/tcg/manifest/switag/" rim:platformManufacturerId="00201234" rim:platformManufacturerStr="Example.com" rim:platformModel="ProductA" rim:platformVersion="01"/>
+  <ns2:Payload>
     <Directory name="rim">
       <File xmlns:SHA256="http://www.w3.org/2001/04/xmlenc#sha256" SHA256:hash="4479ca722623f8c47b703996ced3cbd981b06b1ae8a897db70137e0b7c546848" name="Example.com.BIOS.01.rimel" size="7549"/>
     </Directory>
-  </Payload>
+  </ns2:Payload>
   <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
     <SignedInfo>
       <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
@@ -17,14 +17,14 @@
           <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
         </Transforms>
         <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
-        <DigestValue>DJMc0n3VHHwU+F3HNpiY/l3EMcjRZAQOYlrjhD5v9qE=</DigestValue>
+        <DigestValue>ltjNmhHEqfpWwGmv1fTLLhJbtcn36wzPc8ZrOoUxXAI=</DigestValue>
       </Reference>
     </SignedInfo>
-    <SignatureValue>ojJ6v8ToxLWWekCKmBoZ+Yg2V4MYMPbKB9FjDs/QG/AMP+LKjnb55Z7FSLhC8+CvvShKPAoS9mv1&#13;
-QepwI17NEqbfnC1U4WH0u578A3J6wiHMXIDnIQqKAAXb8v2c/wjMDArzFl8CXmDA7HUDIt+3C4VC&#13;
-tA598YY7o0Hf6hK5qO8oWGQxXUKfpUwvtGLxHpbDWYFuVSPa+uk6OTzutt/QyzTERzxyO9Le1i6K&#13;
-nrpzh4lgHn6EfGs6HR1ffdHQ069q0bE61zDx0VC18nK9DmszW6p6FlMzApiTVW/4PiVt+dSFeVGR&#13;
-9///OdtxcoBCeofDDFPRyO+s+kY1pXd92Q3nfg==</SignatureValue>
+    <SignatureValue>UWzTHnnQwc4+OYRl3bGXdGwAZsYBjQpoJb6jgif6c9/mHl1xCNjO1zJUzAGpeEq14j4qJ1WV8rHb&#13;
+5R16iMN05xQ5FCC8o1KvtJ6xwAkIgYei06iWaypgv39R42MD8HySVWBv5Ya7qIrvCBfp57L7z8Wm&#13;
+KvKptRctbb8of7OBdAH/Ywr2z1avwVVI7K7ugvjYkxn4sBfO4HkGABcJ4vIr1haOOU0/ip0qA/4U&#13;
+Fm1EJRDA2cYhTPcxHNoWDh2SAYVDH3t9vF/1BEPy5ke5iqRIsvTjoLz3WJtub6zKJ7fg4+1oyDK6&#13;
+641x+SIRT7EqRMLtxlpXniVMGbp8i4mxFaQGpQ==</SignatureValue>
     <KeyInfo>
       <X509Data>
         <X509SubjectName>CN=example.RIM.signer,OU=PCClient,O=Example,ST=VA,C=US</X509SubjectName>
@@ -47,6 +47,7 @@ BzAChhlodHRwczovL2V4YW1wbGUuY29tL2NlcnRzMA0GCSqGSIb3DQEBCwUAA4IBAQDpKx5oQlkS&#13
 cIEQ5OqfpdFrV3De238RhMH6J4xePSidnFpfBc6FrdyDI1A8eRFz36I4xfVL3ZnJP/+j+NE4q6yz&#13;
 5VGvm0npLO394ZihtsI1sRAR8ORJ</X509Certificate>
       </X509Data>
+      <KeyName>2fdeb8e7d030a2209daa01861a964fedecf2bcc1</KeyName>
     </KeyInfo>
   </Signature>
-</SoftwareIdentity>
+</ns2:SoftwareIdentity>


### PR DESCRIPTION
These changes address some errors that were thrown during validation of valid RIMs.  

`Exception in thread "main" java.lang.NullPointerException: Cannot invoke "java.util.List.iterator()" because "this.trustStore" is null`
The truststore List object is now set where it previously was not for validating flat files.  The hash calculation for support RIMs was also modified for consistency with the rimtool.

`Exception in thread "main" java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "subjectKeyIdentifier" is null`
All base RIM signatures now include KeyName, which is used as the skid for validation.  Unit test files have been updated accordingly.


Closes #646 