### PR TITLE
[#642] Initial Spotbugs Setup

### DIFF
--- a/HIRS_AttestationCA/config/spotbugs/spotbugs-exclude.xml
+++ b/HIRS_AttestationCA/config/spotbugs/spotbugs-exclude.xml
@@ -4,6 +4,15 @@
     <Match>
         <Package name="~hirs\.attestationca.*" />
     </Match>
+    <Match>
+        <!-- https://github.com/spotbugs/spotbugs/pull/2748 -->
+        <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    </Match>
 
+    <!--    <Match>-->
+    <!--        &lt;!&ndash; To suppress false warnings in unit-tests for lambdas not using return values. &ndash;&gt;-->
+    <!--        <Package name="~com\.company\.service\.interfaces\.types\.contacts"/>-->
+    <!--        <Bug pattern="RV_RETURN_VALUE_IGNORED"/>-->
+    <!--    </Match>-->
 </FindBugsFilter>
 

--- a/HIRS_AttestationCA/config/spotbugs/spotbugs-exclude.xml
+++ b/HIRS_AttestationCA/config/spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Docs at http://findbugs.sourceforge.net/manual/filter.html -->
+<FindBugsFilter>
+    <Match>
+        <Package name="~hirs\.attestationca.*" />
+    </Match>
+
+</FindBugsFilter>
+

--- a/HIRS_AttestationCAPortal/config/spotbugs/spotbugs-exclude.xml
+++ b/HIRS_AttestationCAPortal/config/spotbugs/spotbugs-exclude.xml
@@ -4,6 +4,15 @@
     <Match>
         <Package name="~hirs\.attestationca.*" />
     </Match>
+    <Match>
+        <!-- https://github.com/spotbugs/spotbugs/pull/2748 -->
+        <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    </Match>
 
+    <!--    <Match>-->
+    <!--        &lt;!&ndash; To suppress false warnings in unit-tests for lambdas not using return values. &ndash;&gt;-->
+    <!--        <Package name="~com\.company\.service\.interfaces\.types\.contacts"/>-->
+    <!--        <Bug pattern="RV_RETURN_VALUE_IGNORED"/>-->
+    <!--    </Match>-->
 </FindBugsFilter>
 

--- a/HIRS_AttestationCAPortal/config/spotbugs/spotbugs-exclude.xml
+++ b/HIRS_AttestationCAPortal/config/spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Docs at http://findbugs.sourceforge.net/manual/filter.html -->
+<FindBugsFilter>
+    <Match>
+        <Package name="~hirs\.attestationca.*" />
+    </Match>
+
+</FindBugsFilter>
+

--- a/HIRS_Structs/config/spotbugs/spotbugs-exclude.xml
+++ b/HIRS_Structs/config/spotbugs/spotbugs-exclude.xml
@@ -4,6 +4,15 @@
     <Match>
         <Package name="~hirs\.structs.*" />
     </Match>
+    <Match>
+        <!-- https://github.com/spotbugs/spotbugs/pull/2748 -->
+        <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    </Match>
 
+    <!--    <Match>-->
+    <!--        &lt;!&ndash; To suppress false warnings in unit-tests for lambdas not using return values. &ndash;&gt;-->
+    <!--        <Package name="~com\.company\.service\.interfaces\.types\.contacts"/>-->
+    <!--        <Bug pattern="RV_RETURN_VALUE_IGNORED"/>-->
+    <!--    </Match>-->
 </FindBugsFilter>
 

--- a/HIRS_Structs/config/spotbugs/spotbugs-exclude.xml
+++ b/HIRS_Structs/config/spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Docs at http://findbugs.sourceforge.net/manual/filter.html -->
+<FindBugsFilter>
+    <Match>
+        <Package name="~hirs\.structs.*" />
+    </Match>
+
+</FindBugsFilter>
+

--- a/HIRS_Utils/config/spotbugs/spotbugs-exclude.xml
+++ b/HIRS_Utils/config/spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Docs at http://findbugs.sourceforge.net/manual/filter.html -->
+<FindBugsFilter>
+    <Match>
+	<Package name="~hirs\.utils.*" />
+    </Match>
+
+</FindBugsFilter>
+

--- a/HIRS_Utils/config/spotbugs/spotbugs-exclude.xml
+++ b/HIRS_Utils/config/spotbugs/spotbugs-exclude.xml
@@ -4,6 +4,15 @@
     <Match>
 	<Package name="~hirs\.utils.*" />
     </Match>
+    <Match>
+        <!-- https://github.com/spotbugs/spotbugs/pull/2748 -->
+        <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    </Match>
 
+    <!--    <Match>-->
+    <!--        &lt;!&ndash; To suppress false warnings in unit-tests for lambdas not using return values. &ndash;&gt;-->
+    <!--        <Package name="~com\.company\.service\.interfaces\.types\.contacts"/>-->
+    <!--        <Bug pattern="RV_RETURN_VALUE_IGNORED"/>-->
+    <!--    </Match>-->
 </FindBugsFilter>
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,16 +4,33 @@ import org.gradle.api.tasks.Copy
 plugins {
     // Apply the application plugin to add support for building a CLI application in Java.
     id 'application'
+    id 'com.github.spotbugs' version '6.0.4' apply false
 }
 
 // Global checkstyle file
     ext.checkstyleConfigFile = new File(rootDir, "/config/checkstyle/sun_checks.xml")
 
+subprojects {
+    apply plugin: "com.github.spotbugs"
+
+    spotbugs {
+        excludeFilter = file('config/spotbugs/spotbugs-exclude.xml')
+    }
+
+    tasks.withType(com.github.spotsbugs.snom.SpotBugsTask) {
+        reports {
+            html {
+                enabled = true
+            }
+        }
+    }
+}
+
 dependencies {
     repositories {
-          // Use Maven Central for resolving dependencies.
-             mavenCentral()
-         }
+        // Use Maven Central for resolving dependencies.
+        mavenCentral()
+    }
 }
 
 def projectVersion = rootProject.file('VERSION').text.trim()

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ subprojects {
         excludeFilter = file('config/spotbugs/spotbugs-exclude.xml')
     }
 
-    tasks.withType(com.github.spotsbugs.snom.SpotBugsTask) {
+    tasks.withType(com.github.spotbugs.snom.SpotBugsTask) {
         reports {
             html {
                 enabled = true

--- a/tools/tcg_eventlog_tool/config/spotbugs/spotbugs-exclude.xml
+++ b/tools/tcg_eventlog_tool/config/spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Docs at http://findbugs.sourceforge.net/manual/filter.html -->
+<FindBugsFilter>
+
+</FindBugsFilter>

--- a/tools/tcg_eventlog_tool/config/spotbugs/spotbugs-exclude.xml
+++ b/tools/tcg_eventlog_tool/config/spotbugs/spotbugs-exclude.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Docs at http://findbugs.sourceforge.net/manual/filter.html -->
 <FindBugsFilter>
+    <Match>
+        <!-- https://github.com/spotbugs/spotbugs/pull/2748 -->
+        <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    </Match>
 
 </FindBugsFilter>

--- a/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Commander.java
+++ b/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Commander.java
@@ -59,10 +59,10 @@ public class Commander {
         if (hasArguments) {
             parseArguments(args);
         } else {
-            String[] defualtArgs = new String[1];
-            defualtArgs[0] = "-e";
+            String[] defaultArgs = new String[1];
+            defaultArgs[0] = "-e";
             hasArguments = true;
-            parseArguments(defualtArgs);
+            parseArguments(defaultArgs);
         }
     }
 
@@ -445,14 +445,17 @@ public class Commander {
      * @return true if path is valid
      */
     public static boolean isValidPath(final String filepath) {
+        System.out.println("Checking for a valid creation path...");
+        if (filepath != null) {
+            return false;
+        }
         try {
-            System.out.println("Checking for a valid creation path...");
             File file = new File(filepath);
             boolean test = file.createNewFile();
             if (!test) {
                 return false;
             }
-        } catch (IOException | InvalidPathException | NullPointerException ex) {
+        } catch (IOException | InvalidPathException ex) {
             return false;
         }
         return true;

--- a/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Commander.java
+++ b/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Commander.java
@@ -446,7 +446,7 @@ public class Commander {
      */
     public static boolean isValidPath(final String filepath) {
         System.out.println("Checking for a valid creation path...");
-        if (filepath != null) {
+        if (filepath == null) {
             return false;
         }
         try {

--- a/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
+++ b/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
@@ -88,6 +88,7 @@ final class Main {
             System.exit(1);
         }   // End commander processing
 
+        handleEventLog();
     }
 
     private static void handleEventLog() {

--- a/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
+++ b/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
@@ -88,9 +88,12 @@ final class Main {
             System.exit(1);
         }   // End commander processing
 
+    }
+
+    private static void handleEventLog() {
         try {
-           eventLog = openLog(commander.getInFileName());
-           // Main Event processing
+            eventLog = openLog(commander.getInFileName());
+            // Main Event processing
             TCGEventLog evLog = new TCGEventLog(eventLog, bEventFlag, bContentFlag, bHexEvent);
             if (bPcrFlag) {
                 String[] pcrs = evLog.getExpectedPCRValues();

--- a/tools/tcg_rim_tool/config/spotbugs/spotbugs-exclude.xml
+++ b/tools/tcg_rim_tool/config/spotbugs/spotbugs-exclude.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Docs at http://findbugs.sourceforge.net/manual/filter.html -->
+<FindBugsFilter>
+
+    <Match>
+	<!-- To suppress false warnings in unit-tests for lambdas not using return values. -->
+        <Package name="~com\.company\.service\.interfaces\.types\.contacts"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED"/>
+    </Match>
+    <Match>
+	<Package name="~hirs\.swid.*" />
+    </Match>
+
+</FindBugsFilter>

--- a/tools/tcg_rim_tool/config/spotbugs/spotbugs-exclude.xml
+++ b/tools/tcg_rim_tool/config/spotbugs/spotbugs-exclude.xml
@@ -2,13 +2,18 @@
 <!-- Docs at http://findbugs.sourceforge.net/manual/filter.html -->
 <FindBugsFilter>
 
-    <Match>
-	<!-- To suppress false warnings in unit-tests for lambdas not using return values. -->
-        <Package name="~com\.company\.service\.interfaces\.types\.contacts"/>
-        <Bug pattern="RV_RETURN_VALUE_IGNORED"/>
-    </Match>
+
     <Match>
 	<Package name="~hirs\.swid.*" />
     </Match>
+    <Match>
+        <!-- https://github.com/spotbugs/spotbugs/pull/2748 -->
+        <Bug pattern="CT_CONSTRUCTOR_THROW" />
+    </Match>
 
+<!--    <Match>-->
+<!--        &lt;!&ndash; To suppress false warnings in unit-tests for lambdas not using return values. &ndash;&gt;-->
+<!--        <Package name="~com\.company\.service\.interfaces\.types\.contacts"/>-->
+<!--        <Bug pattern="RV_RETURN_VALUE_IGNORED"/>-->
+<!--    </Match>-->
 </FindBugsFilter>


### PR DESCRIPTION
This is the first step for adding spotbugs (formerly findbugs) back into the build.  The configuration is in place but the majority of the projects are being excluded.  The eventlog (a small sample size) is however being run with the proper corrections committed.

This is the first part of #642 

To initial the "spotted" bugs you have to take out the line in the exclude file, the entire match tag.
`<Match>`
`        <Package name="~hirs\.structs.*" />  `
`   </Match>`

as an example for HIRS_Structs