### PR TITLE
[#660] Add -V|--version for easy access to rimtool version number

### DIFF
--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -5,7 +5,13 @@ import hirs.swid.utils.TimestampArgumentValidator;
 import hirs.utils.rim.ReferenceManifestValidator;
 import com.beust.jcommander.JCommander;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Main {
 
@@ -19,6 +25,24 @@ public class Main {
         if (commander.isHelp()) {
             jc.usage();
             System.out.println(commander.printHelpExamples());
+        } else if (commander.isVersion()) {
+            try {
+                byte[] content = Files.readAllBytes(Paths.get(SwidTagConstants.VERSION_FILE));
+                String version = new String(content);
+                System.out.println("TCG rimtool version: " + version);
+            } catch (IOException e) {
+                System.out.println("Installation file VERSION not found.");
+                String filename = new File(Main.class.getProtectionDomain()
+                        .getCodeSource()
+                        .getLocation()
+                        .getPath()).getName();
+                Pattern pattern = Pattern.compile("(?<=tcg_rim_tool-)[0-9]\\.[0-9]\\.[0-9]");
+                Matcher matcher = pattern.matcher(filename);
+                if (matcher.find()) {
+                    System.out.println("TCG rimtool version: " + matcher.group());
+                }
+
+            }
         } else {
             if (!commander.getVerifyFile().isEmpty()) {
                 validator = new ReferenceManifestValidator();

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -19,6 +19,8 @@ public class Main {
         if (commander.isHelp()) {
             jc.usage();
             System.out.println(commander.printHelpExamples());
+        } else if (commander.isVersion()) {
+            System.out.println("tcg_rim_tool " + SwidTagConstants.RIMTOOL_VERSION);
         } else {
             if (!commander.getVerifyFile().isEmpty()) {
                 validator = new ReferenceManifestValidator();

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -19,8 +19,6 @@ public class Main {
         if (commander.isHelp()) {
             jc.usage();
             System.out.println(commander.printHelpExamples());
-        } else if (commander.isVersion()) {
-            System.out.println("tcg_rim_tool " + SwidTagConstants.RIMTOOL_VERSION);
         } else {
             if (!commander.getVerifyFile().isEmpty()) {
                 validator = new ReferenceManifestValidator();

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -31,17 +31,7 @@ public class Main {
                 String version = new String(content);
                 System.out.println("TCG rimtool version: " + version);
             } catch (IOException e) {
-                System.out.println("Installation file VERSION not found.");
-                String filename = new File(Main.class.getProtectionDomain()
-                        .getCodeSource()
-                        .getLocation()
-                        .getPath()).getName();
-                Pattern pattern = Pattern.compile("(?<=tcg_rim_tool-)[0-9]\\.[0-9]\\.[0-9]");
-                Matcher matcher = pattern.matcher(filename);
-                if (matcher.find()) {
-                    System.out.println("TCG rimtool version: " + matcher.group());
-                }
-
+                parseVersionFromJar();
             }
         } else {
             if (!commander.getVerifyFile().isEmpty()) {
@@ -125,6 +115,23 @@ public class Main {
                         System.out.println("No create type given, nothing to do");
                 }
             }
+        }
+    }
+
+    /**
+     * This method parses the version number from the jar filename in the absence of
+     * the VERSION file expected with an rpm installation.
+     */
+    private static void parseVersionFromJar() {
+        System.out.println("Installation file VERSION not found.");
+        String filename = new File(Main.class.getProtectionDomain()
+                .getCodeSource()
+                .getLocation()
+                .getPath()).getName();
+        Pattern pattern = Pattern.compile("(?<=tcg_rim_tool-)[0-9]\\.[0-9]\\.[0-9]");
+        Matcher matcher = pattern.matcher(filename);
+        if (matcher.find()) {
+            System.out.println("TCG rimtool version: " + matcher.group());
         }
     }
 }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
@@ -12,7 +12,6 @@ import javax.xml.namespace.QName;
  */
 public class SwidTagConstants {
 
-    public static final String RIMTOOL_VERSION = "2.1.3";
     public static final String DEFAULT_KEYSTORE_FILE = "/opt/hirs/rimtool/data/keystore.jks";
     public static final String DEFAULT_KEYSTORE_PASSWORD = "password";
     public static final String DEFAULT_PRIVATE_KEY_ALIAS = "selfsigned";

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
@@ -12,13 +12,18 @@ import javax.xml.namespace.QName;
  */
 public class SwidTagConstants {
 
-    public static final String DEFAULT_KEYSTORE_FILE = "/opt/hirs/rimtool/data/keystore.jks";
+    public static final String INSTALLATION_DIRECTORY = "/opt/rimtool";
+    public static final String VERSION_FILE = INSTALLATION_DIRECTORY + "/VERSION";
+    public static final String DEFAULT_KEYSTORE_FILE =
+            INSTALLATION_DIRECTORY + "/data/keystore.jks";
     public static final String DEFAULT_KEYSTORE_PASSWORD = "password";
     public static final String DEFAULT_PRIVATE_KEY_ALIAS = "selfsigned";
-    public static final String DEFAULT_ATTRIBUTES_FILE = "/opt/hirs/rimtool/data/rim_fields.json";
+    public static final String DEFAULT_ATTRIBUTES_FILE =
+            INSTALLATION_DIRECTORY + "/data/rim_fields.json";
     public static final String DEFAULT_ENGLISH = "en";
 
-    public static final String SIGNATURE_ALGORITHM_RSA_SHA256 = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+    public static final String SIGNATURE_ALGORITHM_RSA_SHA256 =
+            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
 
     public static final String SCHEMA_PACKAGE = "hirs.utils.xjc";
     public static final String SCHEMA_LANGUAGE = XMLConstants.W3C_XML_SCHEMA_NS_URI;

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagConstants.java
@@ -12,6 +12,7 @@ import javax.xml.namespace.QName;
  */
 public class SwidTagConstants {
 
+    public static final String RIMTOOL_VERSION = "2.1.3";
     public static final String DEFAULT_KEYSTORE_FILE = "/opt/hirs/rimtool/data/keystore.jks";
     public static final String DEFAULT_KEYSTORE_PASSWORD = "password";
     public static final String DEFAULT_PRIVATE_KEY_ALIAS = "selfsigned";

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -17,6 +17,11 @@ public class Commander {
     @Parameter(names = {"-c", "--create \"base\""}, order = 0,
             description = "The type of RIM to create. A base RIM will be created by default.")
     private String createType = "";
+    @Parameter(names = {"-v", "--verify <path>"}, order = 3,
+            description = "Specify a RIM file to verify.")
+    private String verifyFile = "";
+    @Parameter(names = {"-V", "--version"}, description = "Output the current version.")
+    private boolean version = false;
     @Parameter(names = {"-a", "--attributes <path>"}, order = 1,
             description = "The configuration file holding attributes "
             + "to populate the base RIM with.")
@@ -25,9 +30,6 @@ public class Commander {
             description = "The file to write the RIM out to. "
             + "The RIM will be written to stdout by default.")
     private String outFile = "";
-    @Parameter(names = {"-v", "--verify <path>"}, order = 3,
-            description = "Specify a RIM file to verify.")
-    private String verifyFile = "";
     @Parameter(names = {"-t", "--truststore <path>"}, order = 4,
             description = "The truststore to sign the base RIM created "
             + "or to validate the signed base RIM.")
@@ -62,16 +64,19 @@ public class Commander {
         return createType;
     }
 
+    public String getVerifyFile() {
+        return verifyFile;
+    }
+
+    public boolean isVersion() {
+        return version;
+    }
     public String getAttributesFile() {
         return attributesFile;
     }
 
     public String getOutFile() {
         return outFile;
-    }
-
-    public String getVerifyFile() {
-        return verifyFile;
     }
 
     public String getTruststoreFile() { return truststoreFile; }


### PR DESCRIPTION
These changes support `rim -V` or `rim --version`, which will print the following message to console:
`TCG rimtool version: [version]`

Closes #660 