### PR TITLE
Updated compose files for the acceptance test for Windows and Linux

### DIFF
--- a/.ci/docker/compose-acceptance-test-linux.yml
+++ b/.ci/docker/compose-acceptance-test-linux.yml
@@ -4,11 +4,11 @@ services:
     image: ghcr.io/nsacyber/hirs/aca
     container_name: aca
     ports:
-      - "8443:8443"
+      - 8443:8443
     networks:
       hat_network:
         ipv4_address: 172.16.1.75
-      nat:
+      default:
   hat:
     image: ghcr.io/nsacyber/hirs/hat
     container_name: hat
@@ -24,11 +24,11 @@ services:
         ipv4_address: 172.16.1.3
 networks:
   hat_network:
-    driver: transparent
+    driver: macvlan
     name: hat_network
+    driver_opts:
+      parent: eno2
     ipam:
       config:
         - subnet: 172.16.1.0/24
           gateway: 172.16.1.1
-  nat:
-    external: true

--- a/.ci/docker/compose-acceptance-test-windows.yml
+++ b/.ci/docker/compose-acceptance-test-windows.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+services:
+  aca:  # policy settings not saved, will have a clean database/default policy on each boot for now
+    image: ghcr.io/nsacyber/hirs/aca
+    container_name: aca
+    ports:
+      - "8443:8443"
+    networks:
+      hat_network:
+        ipv4_address: 172.16.1.75
+      default:
+  hat:
+    image: ghcr.io/nsacyber/hirs/hat
+    container_name: hat
+    ports:
+       - 53:53/tcp
+       - 53:53/udp
+       - 67:67/udp
+       - 68:68/udp
+       - 69:69
+       - 80:80
+    networks:
+      hat_network:
+        ipv4_address: 172.16.1.3
+networks:
+  hat_network:
+    driver: transparent
+    name: hat_network
+    ipam:
+      config:
+        - subnet: 172.16.1.0/24
+          gateway: 172.16.1.1

--- a/.ci/docker/compose-acceptance-test-windows.yml
+++ b/.ci/docker/compose-acceptance-test-windows.yml
@@ -8,7 +8,7 @@ services:
     networks:
       hat_network:
         ipv4_address: 172.16.1.75
-      default:
+      nat:
   hat:
     image: ghcr.io/nsacyber/hirs/hat
     container_name: hat
@@ -30,3 +30,5 @@ networks:
       config:
         - subnet: 172.16.1.0/24
           gateway: 172.16.1.1
+  nat:
+    external: true


### PR DESCRIPTION
The compose file for linux uses a different docker network driver. And that driver on linux requires naming an interface in the compose file. 

Launch and operation of the acceptance test is identical on both operating systems.