### PR TITLE
Verison helper update

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/utils/VersionHelper.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/VersionHelper.java
@@ -2,16 +2,25 @@ package hirs.utils;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import lombok.extern.log4j.Log4j2;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URL;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
 
 /**
  * Utility class to get the current version from the VERSION file.
  */
+@Log4j2
 public final class VersionHelper {
 
-    private static final String VERSION_FILENAME = "VERSION";
+    private static final Path VERSION_PATH = FileSystems.getDefault().getPath(
+            "/opt", "hirs", "aca", "VERSION");
 
     private VersionHelper() {
         // intentionally blank, should never be instantiated
@@ -23,33 +32,70 @@ public final class VersionHelper {
      * @return A string representing the current version.
      */
     public static String getVersion() {
-        return getVersion(VERSION_FILENAME);
+        return getVersion(VERSION_PATH);
     }
 
     /**
-     * Get the current version of HIRS_Portal that is installed.
+     * Get the current version of HIRS_AttestationCAPortal that is installed.
      *
-     * @param filename
-     *            that contains the version
+     * @param filename that contains the version
+     * @return A string representing the current version.
+     */
+    public static String getVersion(final Path filename) {
+        return getVersion(filename.toString());
+    }
+
+    /**
+     * Get the current version of HIRS_AttestationCAPortal that is installed.
+     *
+     * @param filename that contains the version
      * @return A string representing the current version.
      */
     public static String getVersion(final String filename) {
         String version;
         try {
             version = getFileContents(filename);
-        } catch (Exception e) {
-            version = "";
+        } catch (Exception ex) {
+            try {
+                version = getResourceContents(filename);
+            } catch (Exception e) {
+                version = "";
+                log.error(e.getMessage());
+            }
         }
         return version;
     }
 
     /**
      * Read the symbolic link to VERSION in the top level HIRS directory.
+     *
      * @param filename "VERSION"
      * @return the version number from the file
      * @throws IOException
      */
     private static String getFileContents(final String filename) throws IOException {
+        final char[] buffer = new char[8192];
+        final StringBuilder result = new StringBuilder();
+        InputStream inputStream = new FileInputStream(filename);
+
+        try (Reader reader = new InputStreamReader(inputStream, Charsets.UTF_8)) {
+            int charsRead;
+            while ((charsRead = reader.read(buffer, 0, buffer.length)) > 0) {
+                result.append(buffer, 0, charsRead);
+            }
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Read the symbolic link to VERSION in the top level HIRS directory.
+     *
+     * @param filename "VERSION"
+     * @return the version number from the file
+     * @throws IOException
+     */
+    private static String getResourceContents(final String filename) throws IOException {
         URL url = Resources.getResource(filename);
         return Resources.toString(url, Charsets.UTF_8).trim();
     }

--- a/HIRS_Utils/src/main/java/hirs/utils/VersionHelper.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/VersionHelper.java
@@ -11,6 +11,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -19,20 +20,31 @@ import java.nio.file.Path;
 @Log4j2
 public final class VersionHelper {
 
-    private static final Path VERSION_PATH = FileSystems.getDefault().getPath(
-            "/opt", "hirs", "aca", "VERSION");
+    private static final String OPT_PREFIX = "/opt";
+    private static final String ETC_PREFIX = "/etc";
+    private static final String VERSION = "VERSION";
 
     private VersionHelper() {
         // intentionally blank, should never be instantiated
     }
 
     /**
-     * Get the current version of HIRS_Portal that is installed.
+     * Get the current version of HIRS_AttestationPortal that is installed.
      *
      * @return A string representing the current version.
      */
     public static String getVersion() {
-        return getVersion(VERSION_PATH);
+        if (Files.exists(FileSystems.getDefault().getPath(OPT_PREFIX,
+                "hirs", "aca", VERSION))) {
+            return getVersion(FileSystems.getDefault().getPath(OPT_PREFIX,
+                    "hirs", "aca", VERSION));
+        } else if (Files.exists(FileSystems.getDefault().getPath(ETC_PREFIX,
+                "hirs", "aca", VERSION))) {
+            return getVersion(FileSystems.getDefault().getPath(ETC_PREFIX,
+                    "hirs", "aca", VERSION));
+        }
+
+        return getVersion(VERSION);
     }
 
     /**
@@ -42,7 +54,15 @@ public final class VersionHelper {
      * @return A string representing the current version.
      */
     public static String getVersion(final Path filename) {
-        return getVersion(filename.toString());
+        String version;
+        try {
+            version = getFileContents(filename.toString());
+        } catch (IOException ioEx) {
+            log.error(ioEx.getMessage());
+            version = "";
+        }
+
+        return version;
     }
 
     /**
@@ -54,15 +74,12 @@ public final class VersionHelper {
     public static String getVersion(final String filename) {
         String version;
         try {
-            version = getFileContents(filename);
+            version = getResourceContents(filename);
         } catch (Exception ex) {
-            try {
-                version = getResourceContents(filename);
-            } catch (Exception e) {
-                version = "";
-                log.error(e.getMessage());
-            }
+            version = "";
+            log.error(ex.getMessage());
         }
+
         return version;
     }
 

--- a/HIRS_Utils/src/test/java/hirs/utils/VersionHelperTest.java
+++ b/HIRS_Utils/src/test/java/hirs/utils/VersionHelperTest.java
@@ -1,9 +1,6 @@
 package hirs.utils;
 
-import com.google.common.io.Resources;
 import org.junit.jupiter.api.Test;
-
-import java.net.URL;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,9 +25,8 @@ public class VersionHelperTest {
      */
     @Test
     public void testGetVersionDefault() {
-        URL url = Resources.getResource("VERSION");
         String expected = "Test.Version";
-        String actual = VersionHelper.getVersion(url.getPath());
+        String actual = VersionHelper.getVersion("VERSION");
         assertEquals(expected, actual);
     }
 }

--- a/HIRS_Utils/src/test/java/hirs/utils/VersionHelperTest.java
+++ b/HIRS_Utils/src/test/java/hirs/utils/VersionHelperTest.java
@@ -15,7 +15,6 @@ public class VersionHelperTest {
      */
     @Test
     public void testGetVersionFail() {
-
         String actual = VersionHelper.getVersion("somefile");
         assertTrue(actual.startsWith(""));
     }

--- a/HIRS_Utils/src/test/java/hirs/utils/VersionHelperTest.java
+++ b/HIRS_Utils/src/test/java/hirs/utils/VersionHelperTest.java
@@ -1,6 +1,10 @@
 package hirs.utils;
 
+import com.google.common.io.Resources;
 import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -24,9 +28,9 @@ public class VersionHelperTest {
      */
     @Test
     public void testGetVersionDefault() {
-
+        URL url = Resources.getResource("VERSION");
         String expected = "Test.Version";
-        String actual = VersionHelper.getVersion();
+        String actual = VersionHelper.getVersion(url.getPath());
         assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
The version number was not showing up on the ACA Portal.  This was due to the changes in how the ACA was packaged and loaded when switching from v2 to v3.  The location has been updated in #671, this PR updates the code to use the new location.
![image](https://github.com/nsacyber/HIRS/assets/24922493/ad8a9508-4d72-48c3-9039-931977e1b7cc)
