### PR TITLE
Unit Test failures as of 1/22

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/Device.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/Device.java
@@ -20,6 +20,7 @@ import lombok.Setter;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Table(name = "Device")
@@ -112,9 +113,33 @@ public class Device extends AbstractEntity {
     }
 
     public String toString() {
-        return String.format("Device Name: %s%nStatus: %s%nSummary: %s",
+        return String.format("Device Name: %s%nStatus: %s%nSummary: %s%n",
                 name, healthStatus.getStatus(),
                 supplyChainValidationStatus.toString(),
                 summaryId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Device)) {
+            return false;
+        }
+
+        Device device = (Device) o;
+        return isStateOverridden == device.isStateOverridden
+                && Objects.equals(name, device.name)
+                && healthStatus == device.healthStatus
+                && supplyChainValidationStatus == device.supplyChainValidationStatus
+                && Objects.equals(lastReportTimestamp, device.lastReportTimestamp)
+                && Objects.equals(overrideReason, device.overrideReason)
+                && Objects.equals(summaryId, device.summaryId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name, healthStatus,
+                supplyChainValidationStatus, lastReportTimestamp,
+                isStateOverridden, overrideReason, summaryId);
     }
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/info/NetworkInfo.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/info/NetworkInfo.java
@@ -10,11 +10,12 @@ import lombok.extern.log4j.Log4j2;
 
 import java.io.Serializable;
 import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * This class is used to represent the network info of a device.
  */
-@EqualsAndHashCode
 @Log4j2
 @Embeddable
 public class NetworkInfo implements Serializable {
@@ -111,5 +112,24 @@ public class NetworkInfo implements Serializable {
         }
         log.debug("setting MAC address to: {}", sb);
         this.macAddress = macAddress;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NetworkInfo)) {
+            return false;
+        }
+        NetworkInfo that = (NetworkInfo) o;
+        return Objects.equals(hostname, that.hostname)
+                && Objects.equals(ipAddress, that.ipAddress)
+                && Arrays.equals(macAddress, that.macAddress);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(hostname, ipAddress);
+        result = 31 * result + Arrays.hashCode(macAddress);
+        return result;
     }
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/report/DeviceInfoReport.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/report/DeviceInfoReport.java
@@ -20,6 +20,7 @@ import lombok.extern.log4j.Log4j2;
 
 import java.io.Serializable;
 import java.net.InetAddress;
+import java.util.Objects;
 
 /**
  * A <code>DeviceInfoReport</code> is a <code>Report</code> used to transfer the
@@ -229,5 +230,28 @@ public class DeviceInfoReport extends AbstractEntity implements Serializable {
 
     private void setTPMInfo(TPMInfo tpmInfo) {
         this.tpmInfo = tpmInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof DeviceInfoReport)) {
+            return false;
+        }
+        DeviceInfoReport that = (DeviceInfoReport) o;
+        return Objects.equals(networkInfo, that.networkInfo)
+                && Objects.equals(osInfo, that.osInfo)
+                && Objects.equals(firmwareInfo, that.firmwareInfo)
+                && Objects.equals(hardwareInfo, that.hardwareInfo)
+                && Objects.equals(tpmInfo, that.tpmInfo)
+                && Objects.equals(clientApplicationVersion, that.clientApplicationVersion)
+                && Objects.equals(paccorOutputString, that.paccorOutputString);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), networkInfo, osInfo,
+                firmwareInfo, hardwareInfo, tpmInfo,
+                clientApplicationVersion, paccorOutputString);
     }
 }

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/userdefined/DeviceTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/userdefined/DeviceTest.java
@@ -100,11 +100,11 @@ public final class DeviceTest {
      * Tests that retrieving a null LastReportTimestamp will not trigger an exception.
      */
     @Test
-    public void testNullLastReportTimeStamp() {
+    public void testNotNullLastReportTimeStamp() {
         final String name = "my-laptop";
         final DeviceInfoReport deviceInfo = DeviceInfoReportTest.getTestReport();
         final Device device = new Device(name, deviceInfo, HealthStatus.UNKNOWN, AppraisalStatus.Status.UNKNOWN, null, false, null, null);
-        assertNull(device.getLastReportTimestamp());
+        assertNotNull(device.getLastReportTimestamp());
     }
 
     /**


### PR DESCRIPTION
Code checked in from the last spotbugs PR push caused issues with the DeviceTest unit test.  The issue revolved around the equals and hashCode methods that were initially be done by lombok.  Auto generated by an IDE also failed (using Objects).  The issue came up because the methods all called super.equals().  I took this out and all issues were resolved. Lastly the null timestamp unit test was changed because the value will never be null.