### PR TITLE
Bouncy Castle version update

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/EndorsementCredential.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/EndorsementCredential.java
@@ -324,8 +324,7 @@ public class EndorsementCredential extends DeviceAssociatedCertificate {
             ASN1Integer ver;
             // Parse Security Assertions Version
             if (seq.getObjectAt(seqPosition) instanceof ASN1Integer) {
-                ver = (ASN1Integer) seq.getObjectAt(seqPosition);
-                seqPosition++;
+                ver = (ASN1Integer) seq.getObjectAt(seqPosition++);
             } else {
                 // Default value of 1 if field not found
                 ver = new ASN1Integer(BigInteger.ONE);
@@ -334,8 +333,7 @@ public class EndorsementCredential extends DeviceAssociatedCertificate {
             ASN1Boolean fieldUpgradeable;
             // Parse Security Assertions Field Upgradeable
             if (seq.getObjectAt(seqPosition) instanceof ASN1Boolean) {
-                fieldUpgradeable = (ASN1Boolean) seq.getObjectAt(seqPosition);
-                seqPosition++;
+                fieldUpgradeable = (ASN1Boolean) seq.getObjectAt(seqPosition++);
             } else {
                 // Default value of false if field not found
                 fieldUpgradeable = ASN1Boolean.getInstance(false);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/EndorsementCredential.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/EndorsementCredential.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.bouncycastle.asn1.ASN1ApplicationSpecific;
 import org.bouncycastle.asn1.ASN1BitString;
 import org.bouncycastle.asn1.ASN1Boolean;
 import org.bouncycastle.asn1.ASN1Encodable;
@@ -55,7 +54,7 @@ import java.util.Set;
 
 /**
  *
- * This class persists Certificate Authority credentials by extending the base Certificate
+ * This class persists an Endorsement Credential by extending the base Certificate
  * class with fields unique to Endorsement credentials, as defined in the Trusted
  * Computing Group Credential Profiles, specification v.1.2.
  *
@@ -529,10 +528,6 @@ public class EndorsementCredential extends DeviceAssociatedCertificate {
                     e.printStackTrace();
                 }
             }
-
-        } else if (component instanceof ASN1ApplicationSpecific) {
-            parseSingle(((ASN1ApplicationSpecific) component).getObject(), addToMapping, key);
-
         } else if (component instanceof DERBMPString) {
             if (addToMapping) {
                 String bmpStr = ((DERBMPString) component).getString();

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/CommonCriteriaMeasures.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/CommonCriteriaMeasures.java
@@ -201,15 +201,15 @@ public class CommonCriteriaMeasures {
         //Get all the mandatory values
         int index = 0;
         version = ASN1IA5String.getInstance(sequence.getObjectAt(index++));
-        ASN1Enumerated enumarated = ASN1Enumerated.getInstance(sequence.getObjectAt(index++));
+        ASN1Enumerated enumerated = ASN1Enumerated.getInstance(sequence.getObjectAt(index++));
         //Throw exception when is not between 1 and 7
-        if (enumarated.getValue().intValue() <= 0
-                || enumarated.getValue().intValue() > EvaluationAssuranceLevel.values().length) {
+        if (enumerated.getValue().intValue() <= 0
+                || enumerated.getValue().intValue() > EvaluationAssuranceLevel.values().length) {
             throw new IllegalArgumentException("Invalid assurance level.");
         }
-        assuranceLevel = EvaluationAssuranceLevel.values()[enumarated.getValue().intValue() - 1];
-        enumarated = ASN1Enumerated.getInstance(sequence.getObjectAt(index++));
-        evaluationStatus = EvaluationStatus.values()[enumarated.getValue().intValue()];
+        assuranceLevel = EvaluationAssuranceLevel.values()[enumerated.getValue().intValue() - 1];
+        enumerated = ASN1Enumerated.getInstance(sequence.getObjectAt(index++));
+        evaluationStatus = EvaluationStatus.values()[enumerated.getValue().intValue()];
         //Default plus value
         plus = ASN1Boolean.FALSE;
 
@@ -233,9 +233,9 @@ public class CommonCriteriaMeasures {
             ASN1TaggedObject taggedObj = ASN1TaggedObject.getInstance(sequence.getObjectAt(index));
             switch (taggedObj.getTagNo()) {
                 case STRENGTH_OF_FUNCTION:
-                    enumarated = ASN1Enumerated.getInstance(taggedObj, false);
+                    enumerated = ASN1Enumerated.getInstance(taggedObj, false);
                     strengthOfFunction
-                            = StrengthOfFunction.values()[enumarated.getValue().intValue()];
+                            = StrengthOfFunction.values()[enumerated.getValue().intValue()];
                     break;
                 case PROFILE_OID:
                     profileOid = ASN1ObjectIdentifier.getInstance(taggedObj, false);

--- a/HIRS_Utils/src/test/java/hirs/utils/BouncyCastleUtilsTest.java
+++ b/HIRS_Utils/src/test/java/hirs/utils/BouncyCastleUtilsTest.java
@@ -1,6 +1,5 @@
 package hirs.utils;
 
-import lombok.extern.log4j.Log4j2;
 import org.apache.logging.log4j.util.Strings;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -9,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 /**
  * Tests methods in the (@link BouncyCastleUtils) utility class.
  */
-@Log4j2
 public class BouncyCastleUtilsTest {
 
     private static final String VALID_RDN_STRING = "OU=PCTest,O=example.com,C=US";
@@ -28,6 +26,7 @@ public class BouncyCastleUtilsTest {
                 VALID_RDN_STRING, VALID_RDN_STRING_SWITCHED));
         assertTrue(BouncyCastleUtils.x500NameCompare(
                 VALID_RDN_STRING, VALID_RDN_STRING_UPPERCASE));
+        assertTrue(BouncyCastleUtils.x500NameCompare(Strings.EMPTY, Strings.EMPTY));
     }
 
     /**
@@ -40,7 +39,6 @@ public class BouncyCastleUtilsTest {
         // Error that aren't thrown but logged
         assertFalse(BouncyCastleUtils.x500NameCompare(VALID_RDN_STRING, Strings.EMPTY));
         assertFalse(BouncyCastleUtils.x500NameCompare(Strings.EMPTY, VALID_RDN_STRING));
-        assertFalse(BouncyCastleUtils.x500NameCompare(Strings.EMPTY, Strings.EMPTY));
         assertFalse(BouncyCastleUtils.x500NameCompare(
                 VALID_RDN_STRING, MALFORMED_RDN_STRING));
         assertFalse(BouncyCastleUtils.x500NameCompare(

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ dependencyResolutionManagement {
             library('commons-codec', 'commons-codec:commons-codec:1.15')
             library('commons_io',    'commons-io:commons-io:2.11.0')
             library('commons-lang3', 'org.apache.commons:commons-lang3:3.13.0')
-            library('bouncycastle', 'org.bouncycastle:bcmail-jdk15on:1.70')
+            library('bouncycastle', 'org.bouncycastle:bcmail-jdk18on:1.77')
             library('glassfish_json',   'org.glassfish:javax.json:1.1.4')
             library('glassfish_jaxb_runtime',   'org.glassfish.jaxb:jaxb-runtime:2.3.1')
             library('gson', 'com.google.code.gson:gson:2.10.1')


### PR DESCRIPTION
Bouncy Castle, updating the version from 1.70 (2021) to 1.77 (2023)

While expecting a StackOverFlow error from uploading an EK certificate,
this is not occurring.  A unit test had to be updated because the
previous BouncyCastle X500Compare.equals() method returned false for 2
empty string compares.  Now it returns true.