### PR TITLE
Migration Fixes: HIRS_Structs Unit Tests

### DIFF
--- a/HIRS_Structs/build.gradle
+++ b/HIRS_Structs/build.gradle
@@ -19,7 +19,13 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.13.0'
 
 //    testCompile libs.mockito
-    testImplementation libs.testng
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+    testImplementation 'org.junit.platform:junit-platform-launcher:1.9.3'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 //ext.configDir = new File(projectDir, 'config')

--- a/HIRS_Structs/src/test/java/hirs/structs/converters/SimpleStructBuilderTest.java
+++ b/HIRS_Structs/src/test/java/hirs/structs/converters/SimpleStructBuilderTest.java
@@ -1,7 +1,8 @@
 package hirs.structs.converters;
 
-import static org.testng.Assert.assertEquals;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests suite for {@link SimpleStructConverter}.
@@ -12,9 +13,9 @@ public class SimpleStructBuilderTest {
 
     /**
      * Tests {@link SimpleStructBuilder#build()}.
-     * @throws java.lang.NoSuchFieldException sometimes
-     * @throws java.lang.IllegalAccessException sometimes
-     * @throws java.lang.IllegalArgumentException sometimes
+     * @throws NoSuchFieldException sometimes
+     * @throws IllegalAccessException sometimes
+     * @throws IllegalArgumentException sometimes
      */
     @Test
     public final void testBuild() throws NoSuchFieldException, IllegalArgumentException,
@@ -31,15 +32,15 @@ public class SimpleStructBuilderTest {
                 .build())
             .build();
 
-        assertEquals(struct.getTestShort(), NUMBER);
-        assertEquals(struct.getTestByte(), NUMBER);
+        assertEquals(NUMBER, struct.getTestShort());
+        assertEquals(NUMBER, struct.getTestByte());
 
-        assertEquals(struct.getTestEmbeddedStruct().getEmbeddedShort(), NUMBER);
-        assertEquals(struct.getTestEmbeddedStruct().getEmbedded(), ARRAY);
-        assertEquals(struct.getTestEmbeddedStruct().getEmbeddedSize(), ARRAY.length);
+        assertEquals(NUMBER, struct.getTestEmbeddedStruct().getEmbeddedShort());
+        assertArrayEquals(ARRAY, struct.getTestEmbeddedStruct().getEmbedded());
+        assertEquals(ARRAY.length, struct.getTestEmbeddedStruct().getEmbeddedSize());
 
-        assertEquals(struct.getTestVariableStruct().getTestArray(), ARRAY);
-        assertEquals(struct.getTestVariableStructLength(), ARRAY.length);
+        assertArrayEquals(ARRAY, struct.getTestVariableStruct().getTestArray());
+        assertEquals(ARRAY.length, struct.getTestVariableStructLength());
     }
 
 }

--- a/HIRS_Structs/src/test/java/hirs/structs/converters/SimpleStructConverterTest.java
+++ b/HIRS_Structs/src/test/java/hirs/structs/converters/SimpleStructConverterTest.java
@@ -1,7 +1,8 @@
 package hirs.structs.converters;
 
-import org.testng.Assert;
-import org.testng.annotations.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests suite for {@link SimpleStructConverter}.
@@ -24,7 +25,7 @@ public class SimpleStructConverterTest {
         byte[] serializedStruct = converter.convert(testStruct);
 
         // assert that the returned contents are expected
-        Assert.assertEquals(serializedStruct, EXPECTED_BYTES);
+        assertArrayEquals(EXPECTED_BYTES, serializedStruct);
     }
 
     /**
@@ -44,20 +45,20 @@ public class SimpleStructConverterTest {
      * Struct does not have the required {@link hirs.structs.elements.StructElements}
      * annotation.
      */
-    @Test(expectedExceptions = StructConversionException.class,
-            expectedExceptionsMessageRegExp = ".*@StructElements.*")
+    @Test
     public final void testNoElementsStructConvertToArray() {
-        converter.convert(new TestNoElementsAnnotationStruct());
+        assertThrows(StructConversionException.class, () ->
+                {converter.convert(new TestNoElementsAnnotationStruct());}, ".*@StructElements.*");
     }
 
     /**
      * Tests {@link SimpleStructConverter#convert(byte[], Class)}  where the Struct type does not
      * have the required {@link hirs.structs.elements.StructElements} annotation.
      */
-    @Test(expectedExceptions = StructConversionException.class,
-            expectedExceptionsMessageRegExp = ".*@StructElements.*")
+    @Test
     public final void testNoElementsStructConvertToStruct() {
-        converter.convert(new byte[1], TestNoElementsAnnotationStruct.class);
+        assertThrows(StructConversionException.class, () ->
+            {converter.convert(new byte[1], TestNoElementsAnnotationStruct.class);}, ".*@StructElements.*");
     }
 
     /**
@@ -65,10 +66,10 @@ public class SimpleStructConverterTest {
      * Struct is {@link TestInvalidDataTypeStruct}. It is expected that a conversion exception will
      * be thrown with a message indicating that a field type is unsupported.
      */
-    @Test(expectedExceptions = StructConversionException.class,
-            expectedExceptionsMessageRegExp = "Unsupported field type.*")
+    @Test
     public final void testInvalidDataTypeStructConvertToArray() {
-        converter.convert(new TestInvalidDataTypeStruct());
+        assertThrows(StructConversionException.class, () ->
+            {converter.convert(new TestInvalidDataTypeStruct());}, "Unsupported field type.*");
     }
 
     /**
@@ -76,10 +77,11 @@ public class SimpleStructConverterTest {
      * TestInvalidDataTypeStruct}. It is expected that a conversion exception will be thrown with a
      * message indicating that a field type is unsupported.
      */
-    @Test(expectedExceptions = StructConversionException.class,
-            expectedExceptionsMessageRegExp = "Unsupported field type.*")
+    @Test
     public final void testInvalidDataTypeStructConvertToStruct() {
-        converter.convert(new byte[1], TestInvalidDataTypeStruct.class);
+        assertThrows(StructConversionException.class, () ->
+            {converter.convert(new byte[1], TestInvalidDataTypeStruct.class);}, "Unsupported field type.*");
+
     }
 
 }


### PR DESCRIPTION
[Issue 685](https://github.com/nsacyber/HIRS/issues/685) includes:

Modification of the following unit tests from the main branch's  `HIRS_Structs` subproject, in which all TestNG properties were replaced with JUnit5:

- `HIRS_Structs/src/test/java/hirs/structs/converters/SimpleStructBuilderTest.java`
- `HIRS_Structs/src/test/java/hirs/structs/converters/SimpleStructConverterTest.java`
- `HIRS_Structs/build.gradle`