### PR TITLE
PCI Ids Translation Fix

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/PciIds.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/PciIds.java
@@ -8,6 +8,7 @@ import hirs.attestationca.persist.entity.userdefined.certificate.attributes.Comp
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.V2.ComponentIdentifierV2;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
 import org.bouncycastle.asn1.ASN1UTF8String;
 import org.bouncycastle.asn1.DERUTF8String;
 
@@ -159,7 +160,7 @@ public final class PciIds {
         if (manufacturer != null && manufacturer.getString().trim().matches("^[0-9A-Fa-f]{4}$")) {
             Vendor ven = DB.findVendor(manufacturer.getString().toLowerCase());
             if (ven != null && !Strings.isNullOrEmpty(ven.getName())) {
-                manufacturer = ASN1UTF8String.getInstance(ven.getName());
+                manufacturer = new DERUTF8String(ven.getName());
             }
         }
         return manufacturer;
@@ -184,7 +185,7 @@ public final class PciIds {
             Device dev = DB.findDevice(manufacturer.getString().toLowerCase(),
                     model.getString().toLowerCase());
             if (dev != null && !Strings.isNullOrEmpty(dev.getName())) {
-                model = ASN1UTF8String.getInstance(dev.getName());
+                model = new DERUTF8String(dev.getName());
             }
         }
         return model;

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/provision/helper/IssuedCertificateAttributeHelperTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/provision/helper/IssuedCertificateAttributeHelperTest.java
@@ -191,7 +191,7 @@ public class IssuedCertificateAttributeHelperTest {
 
         DLSequence dlSequence = (DLSequence) subjectAlternativeName.getParsedValue();
         ASN1TaggedObject asn1TaggedObject = (ASN1TaggedObject) dlSequence.getObjectAt(0);
-        ASN1Sequence asn1Sequence = (ASN1Sequence) asn1TaggedObject.getObject();
+        ASN1Sequence asn1Sequence = (ASN1Sequence) asn1TaggedObject.getBaseObject();
 
         Enumeration enumeration = asn1Sequence.getObjects();
         while (enumeration.hasMoreElements()) {


### PR DESCRIPTION
ASN1UTF8String change to DERUTF8String so that the vendor string aren't throwing exceptions because ANS1UTF8String.getInstance does not take Strings

If the file is present, the current set of bouncycastle utilized code tries to create an ANS1UTF8String object from the vendor translations but ASN1UTF8String is abstract and the getInstance does not take in String.  