### PR TITLE
[#705] PC Attributes Provision Error

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
@@ -730,19 +730,19 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
         final List<ComponentIdentifier> pcComponents = new ArrayList<>();
         for (ComponentIdentifier component : untrimmedPcComponents) {
             if (component.getComponentManufacturer() != null) {
-                component.setComponentManufacturer((DERUTF8String) ASN1UTF8String.getInstance(
+                component.setComponentManufacturer(new DERUTF8String(
                         component.getComponentManufacturer().getString().trim()));
             }
             if (component.getComponentModel() != null) {
-                component.setComponentModel((DERUTF8String) ASN1UTF8String.getInstance(
+                component.setComponentModel(new DERUTF8String(
                         component.getComponentModel().getString().trim()));
             }
             if (component.getComponentSerial() != null) {
-                component.setComponentSerial((DERUTF8String) ASN1UTF8String.getInstance(
+                component.setComponentSerial(new DERUTF8String(
                         component.getComponentSerial().getString().trim()));
             }
             if (component.getComponentRevision() != null) {
-                component.setComponentRevision((DERUTF8String) ASN1UTF8String.getInstance(
+                component.setComponentRevision(new DERUTF8String(
                         component.getComponentRevision().getString().trim()));
             }
             pcComponents.add(component);

--- a/HIRS_Utils/src/main/java/hirs/utils/BouncyCastleUtils.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/BouncyCastleUtils.java
@@ -1,7 +1,5 @@
 package hirs.utils;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.bouncycastle.asn1.x500.X500Name;
 
@@ -9,11 +7,14 @@ import org.bouncycastle.asn1.x500.X500Name;
  * Utilities class specific for additional Bouncy Castle functionality.
  */
 @Log4j2
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class BouncyCastleUtils {
 
     private static final String SEPARATOR_COMMA = ",";
     private static final String SEPARATOR_PLUS = "+";
+
+    private BouncyCastleUtils() {
+        // intentionally blank, should never be instantiated
+    }
 
     /**
      * This method can be used to compare the distinguished names given from

--- a/HIRS_Utils/src/main/java/hirs/utils/VersionHelper.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/VersionHelper.java
@@ -23,6 +23,7 @@ public final class VersionHelper {
     private static final String OPT_PREFIX = "/opt";
     private static final String ETC_PREFIX = "/etc";
     private static final String VERSION = "VERSION";
+    private static final int FILE_BUFFER_SIZE = 8192;
 
     private VersionHelper() {
         // intentionally blank, should never be instantiated
@@ -91,7 +92,7 @@ public final class VersionHelper {
      * @throws IOException
      */
     private static String getFileContents(final String filename) throws IOException {
-        final char[] buffer = new char[8192];
+        final char[] buffer = new char[FILE_BUFFER_SIZE];
         final StringBuilder result = new StringBuilder();
         InputStream inputStream = new FileInputStream(filename);
 

--- a/HIRS_Utils/src/main/java/hirs/utils/digest/OptionalDigest.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/digest/OptionalDigest.java
@@ -36,15 +36,15 @@ public final class OptionalDigest extends AbstractDigest {
     /**
      * Creates a new <code>OptionalDigest</code>.
      *
-     * @param algorithm algorithm used to generate the digest
-     * @param digest digest value
+     * @param digestAlgorithm algorithm used to generate the digest
+     * @param optionalDigest digest value
      * @throws IllegalArgumentException if digest length does not match that of the algorithm
      */
-    public OptionalDigest(final DigestAlgorithm algorithm, final byte[] digest)
+    public OptionalDigest(final DigestAlgorithm digestAlgorithm, final byte[] optionalDigest)
             throws IllegalArgumentException {
-        validateInput(algorithm, digest);
-        this.algorithm = algorithm;
-        this.digest = Arrays.copyOf(digest, digest.length);
+        validateInput(digestAlgorithm, optionalDigest);
+        this.algorithm = digestAlgorithm;
+        this.digest = Arrays.copyOf(optionalDigest, optionalDigest.length);
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
@@ -169,13 +169,13 @@ public final class TCGEventLog {
             }
     }
 
-    /**
-     * Creates a TPM baseline using the expected PCR Values.
-     * Expected PCR Values were Calculated from the EventLog (RIM Support file).
-     *
-     * @param name name to call the TPM Baseline
-     * @return whitelist baseline
-     */
+//    /**
+//     * Creates a TPM baseline using the expected PCR Values.
+//     * Expected PCR Values were Calculated from the EventLog (RIM Support file).
+//     *
+//     * @param name name to call the TPM Baseline
+//     * @return whitelist baseline
+//     */
 //    public TpmWhiteListBaseline createTPMBaseline(final String name) {
 //        TpmWhiteListBaseline baseline = new TpmWhiteListBaseline(name);
 //        TPMMeasurementRecord record;
@@ -300,21 +300,21 @@ public final class TCGEventLog {
 
     /**
      * Human readable string representing the contents of the Event Log.
-     * @param bEvent flag to set
-     * @param bHexEvent flag to set
-     * @param bContent flag to set
+     * @param event flag to set
+     * @param hexEvent flag to set
+     * @param content flag to set
      * @return Description of the log.
      */
-    public String toString(final boolean bEvent,
-                           final boolean bHexEvent,
-                           final boolean bContent) {
-        this.bEvent = bEvent;
-        this.bHexEvent = bHexEvent;
-        this.bContent = bContent;
+    public String toString(final boolean event,
+                           final boolean hexEvent,
+                           final boolean content) {
+        this.bEvent = event;
+        this.bHexEvent = hexEvent;
+        this.bContent = content;
 
         return this.toString();
     }
-    
+
     /**
      * Returns the TCG Algorithm Registry defined ID for the Digest Algorithm
      * used in the event log.

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
@@ -35,14 +35,14 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
      * @param eventNumber event position within the event log.
      * @throws java.io.IOException              if an error occurs in parsing the event.
      * @throws java.security.NoSuchAlgorithmException if an undefined algorithm is encountered.
-     * @throws java.security.cert.CertificateException     If a certificate within an event can't be processed.
+     * @throws java.security.cert.CertificateException If a certificate within an event can't be processed.
      */
     public TpmPcrEvent1(final ByteArrayInputStream is, final int eventNumber)
             throws IOException, CertificateException, NoSuchAlgorithmException {
         super(is);
         setDigestLength(EvConstants.SHA1_LENGTH);
         setLogFormat(1);
-        /**  Event data. */
+        // Event data.
         byte[] event = null;
         byte[] rawIndex = new byte[UefiConstants.SIZE_4];
         byte[] rawType = new byte[UefiConstants.SIZE_4];

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
@@ -70,15 +70,15 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
      * @param eventNumber event position within the event log.
      * @throws java.io.IOException              if an error occurs in parsing the event
      * @throws java.security.NoSuchAlgorithmException if an undefined algorithm is encountered.
-     * @throws java.security.cert.CertificateException     If a certificate within an event can't be processed.
+     * @throws java.security.cert.CertificateException If a certificate within an event can't be processed.
      */
     public TpmPcrEvent2(final ByteArrayInputStream is, final int eventNumber)
             throws IOException, CertificateException, NoSuchAlgorithmException {
         super(is);
         setDigestLength(EvConstants.SHA256_LENGTH);
         setLogFormat(2);
-        /**  Event data. */
-        int eventDigestLength = 0;
+        // Event data.
+        // int eventDigestLength = 0;
         String hashName = "";
         byte[] event;
         byte[] rawIndex = new byte[UefiConstants.SIZE_4];

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvEfiGptPartition.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvEfiGptPartition.java
@@ -3,7 +3,6 @@ package hirs.utils.tpm.eventlog.events;
 import hirs.utils.HexUtils;
 import hirs.utils.tpm.eventlog.uefi.UefiConstants;
 import hirs.utils.tpm.eventlog.uefi.UefiPartition;
-import lombok.Getter;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
@@ -102,13 +101,13 @@ public class EvEfiGptPartition {
      * Processes an individual GPT partition entry.
      *
      * @param partitions           byte array holding partition data.
-     * @param numberOfPartitions number of partitions included in the data.
+     * @param numOfPartitions number of partitions included in the data.
      * @throws java.io.UnsupportedEncodingException if partition data fails to parse.
      */
-    private void processesPartitions(final byte[] partitions, final int numberOfPartitions)
+    private void processesPartitions(final byte[] partitions, final int numOfPartitions)
             throws UnsupportedEncodingException {
         byte[] partitionData = new byte[UefiConstants.SIZE_128];
-        for (int i = 0; i < numberOfPartitions; i++) {
+        for (int i = 0; i < numOfPartitions; i++) {
             System.arraycopy(partitions, i * partitonEntryLength, partitionData, 0,
                     partitonEntryLength);
             partitionList.add(new UefiPartition(partitionData));


### PR DESCRIPTION
This commit is for the 3rd listed issue on #705.  The green check mark test was causing an error from ASN1UTF8String.getInstance.  And did some checkstyle fixes.

To replicate, you should just need to select PC attribute policy and provision.  My test was done on a dell.