### PR TITLE
[#661] Output handling should be more concise

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -257,6 +257,11 @@ public class ReferenceManifestValidator {
         X509Certificate signingCert = null;
         try {
             signingCert = getCertFromTruststore();
+            if (signingCert == null) {
+                log.error("Unable to locate the signing cert in the provided truststore "
+                        + trustStoreFile);
+                return false;
+            }
         } catch (IOException e) {
             log.warn("Error while parsing signing cert from truststore: " + e.getMessage());
             return false;

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/CredentialParser.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/CredentialParser.java
@@ -278,19 +278,17 @@ public class CredentialParser {
     }
 
     /**
-     * This method returns the authorityKeyIdentifier from the local X509Certificate.
-     * @return the String representation of the AKI
+     * This method returns the subjectKeyIdentifier from the local X509Certificate.
+     * @return the String representation of the subjectKeyIdentifier
      * @throws IOException
      */
-    public String getCertificateAuthorityKeyIdentifier() throws IOException {
+    public String getCertificateSubjectKeyIdentifier() throws IOException {
         String decodedValue = null;
-        byte[] extension = certificate.getExtensionValue(Extension.authorityKeyIdentifier.getId());
+        byte[] extension = certificate.getExtensionValue(Extension.subjectKeyIdentifier.getId());
         if (extension != null && extension.length > 0) {
             decodedValue = JcaX509ExtensionUtils.parseExtensionValue(extension).toString();
         }
-        //decodedValue above is of the form [[CONTEXT 0]#e0f...], parse out the extraneous chars
-        decodedValue = decodedValue.substring(decodedValue.indexOf("#")+1,decodedValue.length()-1);
-        return decodedValue;
+        return decodedValue.substring(1);//Drop the # at the beginning of the string
     }
 
     /**

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/CredentialParser.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/CredentialParser.java
@@ -278,17 +278,19 @@ public class CredentialParser {
     }
 
     /**
-     * This method returns the subjectKeyIdentifier from the local X509Certificate.
-     * @return the String representation of the subjectKeyIdentifier
+     * This method returns the authorityKeyIdentifier from the local X509Certificate.
+     * @return the String representation of the AKI
      * @throws IOException
      */
-    public String getCertificateSubjectKeyIdentifier() throws IOException {
+    public String getCertificateAuthorityKeyIdentifier() throws IOException {
         String decodedValue = null;
-        byte[] extension = certificate.getExtensionValue(Extension.subjectKeyIdentifier.getId());
+        byte[] extension = certificate.getExtensionValue(Extension.authorityKeyIdentifier.getId());
         if (extension != null && extension.length > 0) {
             decodedValue = JcaX509ExtensionUtils.parseExtensionValue(extension).toString();
         }
-        return decodedValue.substring(1);//Drop the # at the beginning of the string
+        //decodedValue above is of the form [[CONTEXT 0]#e0f...], parse out the extraneous chars
+        decodedValue = decodedValue.substring(decodedValue.indexOf("#")+1,decodedValue.length()-1);
+        return decodedValue;
     }
 
     /**

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -56,26 +56,20 @@ public class Main {
                 String verifyFile = commander.getVerifyFile();
                 String rimel = commander.getRimEventLog();
                 String trustStore = commander.getTruststoreFile();
-                    validator.setRim(verifyFile);
-                    validator.setRimEventLog(rimel);
+                validator.setRim(verifyFile);
+                validator.setRimEventLog(rimel);
+                credValidator = new CredentialArgumentValidator(trustStore,
+                        "","", true);
+                if (credValidator.isValid()) {
                     validator.setTrustStoreFile(trustStore);
-                    if (!certificateFile.isEmpty()) {
-                        System.out.println("A single cert cannot be used for verification. " +
-                                "The signing cert will be searched for in the trust store.");
-                    credValidator = new CredentialArgumentValidator(trustStore,
-                            "","", true);
-                    if (credValidator.isValid()) {
-                        validator.setTrustStoreFile(trustStore);
-                    } else {
-                        System.out.println(credValidator.getErrorMessage());
-                        System.exit(1);
-                    }
-                    if (validator.validateSwidtagFile(verifyFile)) {
-                        System.out.println("Successfully verified " + verifyFile);
-                    } else {
-                        System.out.println("Failed to verify " + verifyFile);
-                        System.exit(1);
-                    }
+                } else {
+                    exitWithErrorCode(credValidator.getErrorMessage());
+                }
+                if (validator.validateSwidtagFile(verifyFile)) {
+                    System.out.println("Successfully verified " + verifyFile);
+                } else {
+                    exitWithErrorCode("Failed to verify " + verifyFile);
+                }
             } else {
                 gateway = new SwidTagGateway();
                 if (commander.isVerbose()) {
@@ -90,18 +84,8 @@ public class Main {
                 String rimEventLog = commander.getRimEventLog();
                 switch (createType) {
                     case "BASE":
-                        if (!attributesFile.isEmpty()) {
-                            gateway.setAttributesFile(attributesFile);
-                        } else {
-                            System.out.println("An attribute file is required.");
-                            System.exit(1);
-                        }
-                        if (!rimEventLog.isEmpty()) {
-                            gateway.setRimEventLog(rimEventLog);
-                        } else {
-                            System.out.println("A support RIM is required.");
-                            System.exit(1);
-                        }
+                        gateway.setAttributesFile(attributesFile);
+                        gateway.setRimEventLog(rimEventLog);
                         credValidator = new CredentialArgumentValidator("" ,
                                 certificateFile, privateKeyFile, false);
                         if (defaultKey){
@@ -116,11 +100,6 @@ public class Main {
                             }
                         } else {
                             exitWithErrorCode(credValidator.getErrorMessage());
-                        }
-                        if (rimEventLog.isEmpty()) {
-                            exitWithErrorCode("A support RIM is required.");
-                        } else {
-                            gateway.setRimEventLog(rimEventLog);
                         }
                         List<String> timestampArguments = commander.getTimestampArguments();
                         if (timestampArguments.size() > 0) {

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -55,22 +55,14 @@ public class Main {
                 String rimel = commander.getRimEventLog();
                 String certificateFile = commander.getPublicCertificate();
                 String trustStore = commander.getTruststoreFile();
-                if (!verifyFile.isEmpty()) {
                     validator.setRim(verifyFile);
-                    if (!rimel.isEmpty()) {
-                        validator.setRimEventLog(rimel);
-                    }
-                    if (!trustStore.isEmpty()) {
-                        validator.setTrustStoreFile(trustStore);
-                    }
+                    validator.setRimEventLog(rimel);
+                    validator.setTrustStoreFile(trustStore);
                     if (!certificateFile.isEmpty()) {
                         System.out.println("A single cert cannot be used for verification. " +
                                 "The signing cert will be searched for in the trust store.");
                     }
                     validator.validateSwidtagFile(verifyFile);
-                } else {
-                    exitWithErrorCode("A RIM file was not found for validation.");
-                }
             } else {
                 gateway = new SwidTagGateway();
                 if (commander.isVerbose()) {

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -4,6 +4,7 @@ import hirs.swid.utils.Commander;
 import hirs.swid.utils.TimestampArgumentValidator;
 import hirs.utils.rim.ReferenceManifestValidator;
 import com.beust.jcommander.JCommander;
+import lombok.extern.log4j.Log4j2;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,13 +13,17 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
+@Log4j2
 public class Main {
 
     public static void main(String[] args) {
         Commander commander = new Commander();
         JCommander jc = JCommander.newBuilder().addObject(commander).build();
-        jc.parse(args);
+        try {
+            jc.parse(args);
+        } catch (Exception e) {
+            exitWithErrorCode(e.getMessage());
+        }
         SwidTagGateway gateway;
         ReferenceManifestValidator validator;
         List<String> unknownOpts = commander.getUnknownOptions();
@@ -121,7 +126,7 @@ public class Main {
                         gateway.generateSwidTag(commander.getOutFile());
                         break;
                     default:
-                        exitWithErrorCode("No create type given, nothing to do");
+                        exitWithErrorCode("Create type not recognized.");
                 }
             }
         }
@@ -131,8 +136,7 @@ public class Main {
      * Use cases that exit with an error code are redirected here.
      */
     private static void exitWithErrorCode(String errorMessage) {
-        //TODO: log errorMessage
-        System.out.println(errorMessage);
+        log.error(errorMessage);
         System.exit(1);
     }
 

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -62,7 +62,11 @@ public class Main {
                         System.out.println("A single cert cannot be used for verification. " +
                                 "The signing cert will be searched for in the trust store.");
                     }
-                    validator.validateSwidtagFile(verifyFile);
+                    if (validator.validateSwidtagFile(verifyFile)) {
+                        System.out.println("Successfully verified " + verifyFile);
+                    } else {
+                        System.out.println("Failed to verify " + verifyFile);
+                    }
             } else {
                 gateway = new SwidTagGateway();
                 if (commander.isVerbose()) {

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -36,7 +36,9 @@ public class Main {
         } else {
             if (!commander.getVerifyFile().isEmpty()) {
                 validator = new ReferenceManifestValidator();
-                System.out.println(commander.toString());
+                if (commander.isVerbose()) {
+                    System.out.println(commander.toString());
+                }
                 String verifyFile = commander.getVerifyFile();
                 String rimel = commander.getRimEventLog();
                 String certificateFile = commander.getPublicCertificate();
@@ -60,7 +62,9 @@ public class Main {
                 }
             } else {
                 gateway = new SwidTagGateway();
-                System.out.println(commander.toString());
+                if (commander.isVerbose()) {
+                    System.out.println(commander.toString());
+                }
                 String createType = commander.getCreateType().toUpperCase();
                 String attributesFile = commander.getAttributesFile();
                 String jksTruststoreFile = commander.getTruststoreFile();

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -66,6 +66,7 @@ public class Main {
                         System.out.println("Successfully verified " + verifyFile);
                     } else {
                         System.out.println("Failed to verify " + verifyFile);
+                        System.exit(1);
                     }
             } else {
                 gateway = new SwidTagGateway();

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -92,11 +92,14 @@ public class Main {
                     case "BASE":
                         if (!attributesFile.isEmpty()) {
                             gateway.setAttributesFile(attributesFile);
+                        } else {
+                            System.out.println("An attribute file is required.");
+                            System.exit(1);
                         }
                         if (!rimEventLog.isEmpty()) {
                             gateway.setRimEventLog(rimEventLog);
                         } else {
-                            System.out.println("Error: a support RIM is required!");
+                            System.out.println("A support RIM is required.");
                             System.exit(1);
                         }
                         credValidator = new CredentialArgumentValidator("" ,

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -99,7 +99,7 @@ public class SwidTagGateway {
         try {
             JAXBContext jaxbContext = JAXBContext.newInstance(SwidTagConstants.SCHEMA_PACKAGE);
             marshaller = jaxbContext.createMarshaller();
-            attributesFile = SwidTagConstants.DEFAULT_ATTRIBUTES_FILE;
+            attributesFile = "";
             defaultCredentials = true;
             pemCertificateFile = "";
             embeddedCert = false;

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -646,7 +646,7 @@ public class SwidTagGateway {
             }
         }
         try {
-            KeyName keyName = kiFactory.newKeyName(cp.getCertificateAuthorityKeyIdentifier());
+            KeyName keyName = kiFactory.newKeyName(cp.getCertificateSubjectKeyIdentifier());
             keyInfoElements.add(keyName);
         } catch (IOException e) {
             System.out.println("Error while getting SKID: " + e.getMessage());

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -646,7 +646,7 @@ public class SwidTagGateway {
             }
         }
         try {
-            KeyName keyName = kiFactory.newKeyName(cp.getCertificateSubjectKeyIdentifier());
+            KeyName keyName = kiFactory.newKeyName(cp.getCertificateAuthorityKeyIdentifier());
             keyInfoElements.add(keyName);
         } catch (IOException e) {
             System.out.println("Error while getting SKID: " + e.getMessage());

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -64,7 +64,6 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -12,6 +12,8 @@ import java.util.List;
  */
 public class Commander {
 
+    @Parameter(description = "This parameter catches all unrecognized arguments.")
+    private List<String> unknownOptions = new ArrayList<>();
     @Parameter(names = {"-h", "--help"}, help = true, description = "Print this help text.")
     private boolean help;
     @Parameter(names = {"-c", "--create \"base\""}, order = 0,
@@ -57,6 +59,10 @@ public class Commander {
                     "Currently only RFC3339 and RFC3852 are supported:\n" +
                     "\tRFC3339 [yyyy-MM-ddThh:mm:ssZ]\n\tRFC3852 <counterSignature.bin>")
     private List<String> timestampArguments = new ArrayList<String>(2);
+
+    public List<String> getUnknownOptions() {
+        return unknownOptions;
+    }
 
     public boolean isHelp() {
         return help;

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -26,7 +26,7 @@ public class Commander {
     private boolean version = false;
     @Parameter(names = {"-a", "--attributes <path>"}, validateWith = FileArgumentValidator.class,
             description = "The configuration file holding attributes "
-            + "to populate the base RIM with.")
+            + "to populate the base RIM with.  An example file can be found in /opt/rimtool/data.")
     private String attributesFile = "";
     @Parameter(names = {"-o", "--out <path>"}, order = 2,
             description = "The file to write the RIM out to. "
@@ -51,7 +51,7 @@ public class Commander {
             description = "Embed the provided certificate in the signed swidtag.")
     private boolean embedded = false;
     @Parameter(names = {"-d", "--default-key"}, order = 8,
-            description = "Use default signing credentials.")
+            description = "Use the JKS keystore installed in /opt/rimtool/data.")
     private boolean defaultKey = false;
     @Parameter(names = {"-l", "--rimel <path>"}, validateWith = FileArgumentValidator.class,
             description = "The TCG eventlog file to use as a support RIM.")

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -32,9 +32,6 @@ public class Commander {
     private String outFile = "";
     @Parameter(names = {"--verbose"}, description = "Control output verbosity.")
     private boolean verbose = false;
-    @Parameter(names = {"-v", "--verify <path>"}, order = 3,
-            description = "Specify a RIM file to verify.")
-    private String verifyFile = "";
     @Parameter(names = {"-t", "--truststore <path>"}, order = 4,
             description = "The truststore to sign the base RIM created "
             + "or to validate the signed base RIM.")
@@ -76,6 +73,7 @@ public class Commander {
     public boolean isVersion() {
         return version;
     }
+    public boolean isVerbose() { return verbose; }
     public String getAttributesFile() {
         return attributesFile;
     }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -112,26 +112,17 @@ public class Commander {
 
     public String printHelpExamples() {
         StringBuilder sb = new StringBuilder();
-        sb.append("Create a base RIM using the values in attributes.json; " +
-                "sign it with the default keystore; ");
-        sb.append("and write the data to base_rim.swidtag:\n\n");
-        sb.append("\t\t-c base -a attributes.json -d -l support_rim.bin -o base_rim.swidtag" +
-                "\n\n\n");
-        sb.append("Create a base RIM using the default attribute values; ");
-        sb.append("sign it using privateKey.pem; embed cert.pem in the signature block; ");
-        sb.append("and write the data to console output:\n\n");
-        sb.append("\t\t-c base -l support_rim.bin -k privateKey.pem -p cert.pem -e\n\n\n");
-        sb.append("Create a base RIM using the values in attributes.json; " +
-                "sign it with the default keystore; add a RFC3852 timestamp; ");
-        sb.append("and write the data to base_rim.swidtag:\n\n");
-        sb.append("\t\t-c base -a attributes.json -d -l support_rim.bin " +
-                "--timestamp RFC3852 counterSignature.bin -o base_rim.swidtag\n\n\n");
-        sb.append("Validate a base RIM using an external support RIM to override the ");
-        sb.append("payload file:\n\n");
-        sb.append("\t\t-v base_rim.swidtag -l support_rim.bin\n\n\n");
-        sb.append("Validate a base RIM with its own payload file and a PEM truststore ");
-        sb.append("containing the signing cert:\n\n");
-        sb.append("\t\t-v base_rim.swidtag -t ca.crt\n\n\n");
+        sb.append("Create a base RIM: use the values in attributes.json; ");
+        sb.append("add support_rim.bin to the payload; ");
+        sb.append("sign it using privateKey.pem and cert.pem; embed cert.pem in the signature; ");
+        sb.append("add a RFC3852 timestamp; and write the data to base_rim.swidtag:\n\n");
+        sb.append("\t\t-c base -a attributes.json -l support_rim.bin "
+                + "-k privateKey.pem -p cert.pem -e --timestamp RFC3852 counterSignature.bin "
+                + "-o base_rim.swidtag\n\n\n");
+        sb.append("Validate base_rim.swidtag: "
+                + "the payload <File> is validated with support_rim.bin; "
+                + "and the signature is validated with ca.crt:\n\n");
+        sb.append("\t\t-v base_rim.swidtag -l support_rim.bin -t ca.crt\n\n\n");
 
         return sb.toString();
     }

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -30,6 +30,11 @@ public class Commander {
             description = "The file to write the RIM out to. "
             + "The RIM will be written to stdout by default.")
     private String outFile = "";
+    @Parameter(names = {"--verbose"}, description = "Control output verbosity.")
+    private boolean verbose = false;
+    @Parameter(names = {"-v", "--verify <path>"}, order = 3,
+            description = "Specify a RIM file to verify.")
+    private String verifyFile = "";
     @Parameter(names = {"-t", "--truststore <path>"}, order = 4,
             description = "The truststore to sign the base RIM created "
             + "or to validate the signed base RIM.")

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -19,12 +19,12 @@ public class Commander {
     @Parameter(names = {"-c", "--create \"base\""}, order = 0,
             description = "The type of RIM to create. A base RIM will be created by default.")
     private String createType = "";
-    @Parameter(names = {"-v", "--verify <path>"}, order = 3,
+    @Parameter(names = {"-v", "--verify <path>"}, validateWith = FileArgumentValidator.class,
             description = "Specify a RIM file to verify.")
     private String verifyFile = "";
     @Parameter(names = {"-V", "--version"}, description = "Output the current version.")
     private boolean version = false;
-    @Parameter(names = {"-a", "--attributes <path>"}, order = 1,
+    @Parameter(names = {"-a", "--attributes <path>"}, validateWith = FileArgumentValidator.class,
             description = "The configuration file holding attributes "
             + "to populate the base RIM with.")
     private String attributesFile = "";
@@ -34,14 +34,16 @@ public class Commander {
     private String outFile = "";
     @Parameter(names = {"--verbose"}, description = "Control output verbosity.")
     private boolean verbose = false;
-    @Parameter(names = {"-t", "--truststore <path>"}, order = 4,
+    @Parameter(names = {"-t", "--truststore <path>"}, validateWith = FileArgumentValidator.class,
             description = "The truststore to sign the base RIM created "
             + "or to validate the signed base RIM.")
     private String truststoreFile = "";
-    @Parameter(names = {"-k", "--privateKeyFile <path>"}, order = 5,
+    @Parameter(names = {"-k", "--privateKeyFile <path>"},
+            validateWith = FileArgumentValidator.class,
             description = "The private key used to sign the base RIM created by this tool.")
     private String privateKeyFile = "";
-    @Parameter(names = {"-p", "--publicCertificate <path>"}, order = 6,
+    @Parameter(names = {"-p", "--publicCertificate <path>"},
+            validateWith = FileArgumentValidator.class,
             description = "The public key certificate to embed in the base RIM created by "
             + "this tool.")
     private String publicCertificate = "";
@@ -51,7 +53,7 @@ public class Commander {
     @Parameter(names = {"-d", "--default-key"}, order = 8,
             description = "Use default signing credentials.")
     private boolean defaultKey = false;
-    @Parameter(names = {"-l", "--rimel <path>"}, order = 9,
+    @Parameter(names = {"-l", "--rimel <path>"}, validateWith = FileArgumentValidator.class,
             description = "The TCG eventlog file to use as a support RIM.")
     private String rimEventLog = "";
     @Parameter(names = {"--timestamp"}, order = 10, variableArity = true,

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/CredentialArgumentValidator.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/CredentialArgumentValidator.java
@@ -1,0 +1,76 @@
+package hirs.swid.utils;
+
+public class CredentialArgumentValidator {
+    private String truststoreFile;
+    private String certificateFile;
+    private String privateKeyFile;
+    private String format;
+    private boolean isValidating;
+    private String errorMessage;
+    private static final String PEM = "PEM";
+
+    public CredentialArgumentValidator(String truststoreFile,
+                                       String certificateFile,
+                                       String privateKeyFile,
+                                       boolean isValidating) {
+        this.truststoreFile = truststoreFile;
+        this.certificateFile = certificateFile;
+        this.privateKeyFile = privateKeyFile;
+        this.isValidating = isValidating;
+        errorMessage = "";
+    }
+
+    /**
+     * Getter for format property
+     *
+     * @return string
+     */
+    public String getFormat() {
+        return format;
+    }
+
+    /**
+     * Getter for error message
+     *
+     * @return string
+     */
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    /**
+     * This method checks for the following valid configurations of input arguments:
+     * 1.
+     * 2. truststore only for validating (PEM format)
+     * 3. certificate + private key for signing (PEM format)
+     * 4.
+     *
+     * @return true if the above are found, false otherwise
+     */
+    public boolean isValid() {
+        if (isValidating) {
+            if (!truststoreFile.isEmpty()) {
+                format = PEM;
+                return true;
+            } else {
+                errorMessage = "Validation requires a valid truststore file.";
+                return false;
+            }
+        } else {
+            if (!certificateFile.isEmpty() && !privateKeyFile.isEmpty()) {
+                format = PEM;
+                return true;
+            } else {
+                if (certificateFile.isEmpty()) {
+                    errorMessage = "A public certificate must be specified by \'-p\' " +
+                            "for signing operations.";
+                }
+                if (privateKeyFile.isEmpty()) {
+                    errorMessage = "A private key must be specified by \'-k\' " +
+                            "for signing operations.";
+                }
+                return false;
+            }
+        }
+    }
+}

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/FileArgumentValidator.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/FileArgumentValidator.java
@@ -1,0 +1,33 @@
+package hirs.swid.utils;
+
+import com.beust.jcommander.IParameterValidator;
+import com.beust.jcommander.ParameterException;
+
+import java.io.File;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * This class validates arguments that take a String path to a file.
+ * The file path is checked for null, and if the file is found it is checked
+ * for validity, emptiness, and read permissions.
+ */
+@Log4j2
+public class FileArgumentValidator implements IParameterValidator {
+    public void validate(String name, String value) throws ParameterException {
+        try {
+            File file = new File(value);
+            if (!file.isFile()) {
+                throw new ParameterException("Invalid file path: " + value +
+                        ". Please verify file path.");
+            }
+            if (file.length() == 0) {
+                throw new ParameterException("File " + value + " is empty.");
+            }
+        } catch (NullPointerException e) {
+            throw new ParameterException("File path cannot be null: " + e.getMessage());
+        } catch (SecurityException e) {
+            throw new ParameterException("Read access denied for " + value +
+                    ", please verify permissions.");
+        }
+    }
+}


### PR DESCRIPTION
These changes include the following:

1. This block of text is printed following -c and -v functions only if --verbose is also given
Creating: base
Using attributes file: HIRS-issue_103-test-rim-configs/configs/Base_Rim_Config.json
Write to: 
Verify file: 
Truststore file: default (/opt/rimtool/data/keystore.jks)
Event log support RIM: HIRS-issue_103-test-rim-configs/eventlogs/TpmLog.bin
No timestamp included

Unrecognized command line options will cause the rimtool to exit, and all unrecognized options will be printed.

2. Error messages will be logged instead of printed to console, and and exit code of 1 will be returned.

These changes will also check that the proper credential arguments are given, and log appropriate errors if not.

Close #661 
Close #692 