### PR TITLE
[#726] Verify base RIM signature against truststore using public signing cert

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -248,10 +248,11 @@ public class ReferenceManifestValidator {
     }
 
     /**
-     * This method validates a signed swidtag XML file.
-     * @param path to the swidtag XML
+     * This method validates the rim with a public key cert.
+     * @param signingCertPath to the public key certificate used to sign the rim
+     * @return true if both the file element and signature are valid, false otherwise
      */
-    public boolean validateSwidtagFile(String signingCertPath) {
+    public boolean validateRim(String signingCertPath) {
         Element fileElement = (Element) rim.getElementsByTagName("File").item(0);
 /*
         if (trustStoreFile != null && !trustStoreFile.isEmpty()) {
@@ -263,19 +264,19 @@ public class ReferenceManifestValidator {
 */
         X509Certificate signingCert = parseCertificatesFromPem(signingCertPath).get(0);
         if (signingCert == null) {
-            return failWithError("Unable to locate the signing cert in the provided " +
-                    "truststore " + trustStoreFile);
+            return failWithError("Unable to parse the signing cert from " + signingCertPath);
         }
         String subjectKeyIdentifier = "";
         try {
             subjectKeyIdentifier = getCertificateSubjectKeyIdentifier(signingCert);
         } catch (IOException e) {
-            return failWithError("Error while parsing certificate data: " + e.getMessage());
+            return failWithError("Error while parsing SKID: " + e.getMessage());
         }
-        return validateXmlSignature(signingCert.getPublicKey(),
-                                    subjectKeyIdentifier,
-                                    signingCert.getPublicKey().getEncoded())
-                                    && validateFile(fileElement);
+
+        boolean isSignatureValid = validateXmlSignature(signingCert.getPublicKey(),
+                                                        subjectKeyIdentifier,
+                                                        signingCert.getPublicKey().getEncoded());
+        return isSignatureValid && validateFile(fileElement);
     }
 
     /**
@@ -304,11 +305,10 @@ public class ReferenceManifestValidator {
         } else {
             filepath = file.getAttribute(SwidTagConstants.NAME);
         }
-        System.out.println("Support rim found at " + filepath);
         if (getHashValue(filepath, "SHA256").equals(
                 file.getAttribute(SwidTagConstants._SHA256_HASH.getPrefix() + ":" +
                         SwidTagConstants._SHA256_HASH.getLocalPart()))) {
-            System.out.println("Support RIM hash verified!" + System.lineSeparator());
+            log.info("Support RIM hash verified for " + filepath);
             return true;
         } else {
             return failWithError("Support RIM hash does not match Base RIM!");
@@ -435,11 +435,10 @@ public class ReferenceManifestValidator {
                                 if (isCertChainValid(embeddedCert)) {
                                     publicKey = ((X509Certificate) embeddedCert).getPublicKey();
                                     signingCert = embeddedCert;
-                                    System.out.println("Certificate chain validity: true");
+                                    log.info("Certificate chain valid.");
                                 }
                             } catch (Exception e) {
-                                System.out.println("Certificate chain invalid: "
-                                        + e.getMessage());
+                                log.error("Certificate chain invalid: " + e.getMessage());
                             }
                         }
                     }
@@ -449,15 +448,17 @@ public class ReferenceManifestValidator {
                         if (isPublicKeyTrusted(pk)) {
                             publicKey = pk;
                             try {
-                                System.out.println("Certificate chain validity: "
-                                        + isCertChainValid(signingCert));
+                                if (isCertChainValid(signingCert)) {
+                                    log.info("Certificate chain valid.");
+                                } else {
+                                    log.error("Certificate chain invalid.");
+                                }
                             } catch (Exception e) {
-                                System.out.println("Certificate chain invalid: "
-                                        + e.getMessage());
+                                log.error("Certificate chain invalid: " + e.getMessage());
                             }
                         }
                     } catch (KeyException e) {
-                        System.out.println("Unable to convert KeyValue data to PK.");
+                        log.error("Unable to convert KeyValue data to PK.");
                     }
                 }
                 if (publicKey != null) {
@@ -670,9 +671,9 @@ public class ReferenceManifestValidator {
             }
             bis.close();
         } catch (CertificateException e) {
-            System.out.println("Error in certificate factory: " + e.getMessage());
+            log.error("Error in certificate factory: " + e.getMessage());
         } catch (IOException e) {
-            System.out.println("Error reading from input stream: " + e.getMessage());
+            log.error("Error reading from input stream: " + e.getMessage());
         } finally {
             try {
                 if (fis != null) {
@@ -682,7 +683,7 @@ public class ReferenceManifestValidator {
                     bis.close();
                 }
             } catch (IOException e) {
-                System.out.println("Error closing input stream: " + e.getMessage());
+                log.warn("Error closing input stream: " + e.getMessage());
             }
         }
 

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -220,7 +220,6 @@ public class ReferenceManifestValidator {
                 X509Certificate embeddedCert = parseCertFromPEMString(
                         certElement.item(0).getTextContent());
                 if (embeddedCert != null) {
-                    //subjectKeyIdentifier = getCertificateSubjectKeyIdentifier(embeddedCert);
                     if (Arrays.equals(embeddedCert.getPublicKey().getEncoded(),
                             encodedPublicKey)) {
                         context = new DOMValidateContext(new X509KeySelector(), nodes.item(0));
@@ -254,14 +253,6 @@ public class ReferenceManifestValidator {
      */
     public boolean validateRim(String signingCertPath) {
         Element fileElement = (Element) rim.getElementsByTagName("File").item(0);
-/*
-        if (trustStoreFile != null && !trustStoreFile.isEmpty()) {
-            trustStore = parseCertificatesFromPem(trustStoreFile);
-        } else {
-            return failWithError("File <" + trustStoreFile + "> is empty; " +
-                    "a valid, non-empty truststore file is required for validation.");
-        }
-*/
         X509Certificate signingCert = parseCertificatesFromPem(signingCertPath).get(0);
         if (signingCert == null) {
             return failWithError("Unable to parse the signing cert from " + signingCertPath);

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,7 @@ dependencyResolutionManagement {
             library('jakarta-servlet', 'org.glassfish.web:jakarta.servlet.jsp.jstl:3.0.0')
             library('jakarta-api', 'jakarta.persistence:jakarta.persistence-api:3.1.0')
             library('jakarta-xml', 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0')
-            library('jcommander',    'com.beust:jcommander:1.82')
+            library('jcommander',    'org.jcommander:jcommander:1.83')
             library('hibernate-core', 'org.hibernate:hibernate-core:6.1.7.Final')
             library('jackson-core', 'com.fasterxml.jackson.core', 'jackson-core').versionRef('jackson')
             library('jackson-databind', 'com.fasterxml.jackson.core', 'jackson-databind').versionRef('jackson')

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -28,7 +28,6 @@ public class Main {
         SwidTagGateway gateway;
         ReferenceManifestValidator validator;
         List<String> unknownOpts = commander.getUnknownOptions();
-        CredentialArgumentValidator credValidator;
 
         if (!unknownOpts.isEmpty()) {
             StringBuilder sb = new StringBuilder("Unknown options encountered: ");
@@ -58,13 +57,7 @@ public class Main {
                 String trustStore = commander.getTruststoreFile();
                 validator.setRim(verifyFile);
                 validator.setRimEventLog(rimel);
-                credValidator = new CredentialArgumentValidator(trustStore,
-                        "","", true);
-                if (credValidator.isValid()) {
-                    validator.setTrustStoreFile(trustStore);
-                } else {
-                    exitWithErrorCode(credValidator.getErrorMessage());
-                }
+                validator.setTrustStoreFile(trustStore);
                 if (validator.validateSwidtagFile(verifyFile)) {
                     System.out.println("Successfully verified " + verifyFile);
                 } else {
@@ -86,20 +79,16 @@ public class Main {
                     case "BASE":
                         gateway.setAttributesFile(attributesFile);
                         gateway.setRimEventLog(rimEventLog);
-                        credValidator = new CredentialArgumentValidator("" ,
-                                certificateFile, privateKeyFile, false);
                         if (defaultKey){
                             gateway.setDefaultCredentials(true);
                             gateway.setJksTruststoreFile(SwidTagConstants.DEFAULT_KEYSTORE_FILE);
-                        } else if (credValidator.isValid()) {
+                        } else {
                             gateway.setDefaultCredentials(false);
                             gateway.setPemCertificateFile(certificateFile);
                             gateway.setPemPrivateKeyFile(privateKeyFile);
                             if (embeddedCert) {
                                 gateway.setEmbeddedCert(true);
                             }
-                        } else {
-                            exitWithErrorCode(credValidator.getErrorMessage());
                         }
                         List<String> timestampArguments = commander.getTimestampArguments();
                         if (timestampArguments.size() > 0) {

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -1,7 +1,6 @@
 package hirs.swid;
 
 import hirs.swid.utils.Commander;
-import hirs.swid.utils.CredentialArgumentValidator;
 import hirs.swid.utils.TimestampArgumentValidator;
 import hirs.utils.rim.ReferenceManifestValidator;
 import com.beust.jcommander.JCommander;
@@ -59,7 +58,7 @@ public class Main {
                 validator.setRim(verifyFile);
                 validator.setRimEventLog(rimel);
                 validator.setTrustStoreFile(trustStore);
-                if (validator.validateSwidtagFile(certificateFile)) {
+                if (validator.validateRim(certificateFile)) {
                     System.out.println("Successfully verified " + verifyFile);
                 } else {
                     exitWithErrorCode("Failed to verify " + verifyFile);

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/Main.java
@@ -54,11 +54,12 @@ public class Main {
                 }
                 String verifyFile = commander.getVerifyFile();
                 String rimel = commander.getRimEventLog();
+                String certificateFile = commander.getPublicCertificate();
                 String trustStore = commander.getTruststoreFile();
                 validator.setRim(verifyFile);
                 validator.setRimEventLog(rimel);
                 validator.setTrustStoreFile(trustStore);
-                if (validator.validateSwidtagFile(verifyFile)) {
+                if (validator.validateSwidtagFile(certificateFile)) {
                     System.out.println("Successfully verified " + verifyFile);
                 } else {
                     exitWithErrorCode("Failed to verify " + verifyFile);

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -1,6 +1,7 @@
 package hirs.swid.utils;
 
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
 import hirs.swid.SwidTagConstants;
 
 import java.util.ArrayList;
@@ -10,39 +11,40 @@ import java.util.List;
  * Commander is a class that handles the command line arguments for the SWID
  * Tags gateway by implementing the JCommander package.
  */
+@Parameters(parametersValidators = CreateArgumentValidator.class)
 public class Commander {
 
     @Parameter(description = "This parameter catches all unrecognized arguments.")
     private List<String> unknownOptions = new ArrayList<>();
     @Parameter(names = {"-h", "--help"}, help = true, description = "Print this help text.")
     private boolean help;
-    @Parameter(names = {"-c", "--create \"base\""}, order = 0,
+    @Parameter(names = {"-c", "--create"}, order = 0,
             description = "The type of RIM to create. A base RIM will be created by default.")
     private String createType = "";
-    @Parameter(names = {"-v", "--verify <path>"}, validateWith = FileArgumentValidator.class,
+    @Parameter(names = {"-v", "--verify"}, validateWith = FileArgumentValidator.class,
             description = "Specify a RIM file to verify.")
     private String verifyFile = "";
     @Parameter(names = {"-V", "--version"}, description = "Output the current version.")
     private boolean version = false;
-    @Parameter(names = {"-a", "--attributes <path>"}, validateWith = FileArgumentValidator.class,
+    @Parameter(names = {"-a", "--attributes"}, validateWith = FileArgumentValidator.class,
             description = "The configuration file holding attributes "
             + "to populate the base RIM with.  An example file can be found in /opt/rimtool/data.")
     private String attributesFile = "";
-    @Parameter(names = {"-o", "--out <path>"}, order = 2,
+    @Parameter(names = {"-o", "--out"}, order = 2,
             description = "The file to write the RIM out to. "
             + "The RIM will be written to stdout by default.")
     private String outFile = "";
     @Parameter(names = {"--verbose"}, description = "Control output verbosity.")
     private boolean verbose = false;
-    @Parameter(names = {"-t", "--truststore <path>"}, validateWith = FileArgumentValidator.class,
+    @Parameter(names = {"-t", "--truststore"}, validateWith = FileArgumentValidator.class,
             description = "The truststore to sign the base RIM created "
             + "or to validate the signed base RIM.")
     private String truststoreFile = "";
-    @Parameter(names = {"-k", "--privateKeyFile <path>"},
+    @Parameter(names = {"-k", "--privateKeyFile"},
             validateWith = FileArgumentValidator.class,
             description = "The private key used to sign the base RIM created by this tool.")
     private String privateKeyFile = "";
-    @Parameter(names = {"-p", "--publicCertificate <path>"},
+    @Parameter(names = {"-p", "--publicCertificate"},
             validateWith = FileArgumentValidator.class,
             description = "The public key certificate to embed in the base RIM created by "
             + "this tool.")
@@ -53,7 +55,7 @@ public class Commander {
     @Parameter(names = {"-d", "--default-key"}, order = 8,
             description = "Use the JKS keystore installed in /opt/rimtool/data.")
     private boolean defaultKey = false;
-    @Parameter(names = {"-l", "--rimel <path>"}, validateWith = FileArgumentValidator.class,
+    @Parameter(names = {"-l", "--rimel"}, validateWith = FileArgumentValidator.class,
             description = "The TCG eventlog file to use as a support RIM.")
     private String rimEventLog = "";
     @Parameter(names = {"--timestamp"}, order = 10, variableArity = true,

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/Commander.java
@@ -11,7 +11,7 @@ import java.util.List;
  * Commander is a class that handles the command line arguments for the SWID
  * Tags gateway by implementing the JCommander package.
  */
-@Parameters(parametersValidators = CreateArgumentValidator.class)
+@Parameters(parametersValidators = {CreateArgumentValidator.class, VerifyArgumentValidator.class})
 public class Commander {
 
     @Parameter(description = "This parameter catches all unrecognized arguments.")

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/CreateArgumentValidator.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/CreateArgumentValidator.java
@@ -1,0 +1,82 @@
+package hirs.swid.utils;
+
+import com.beust.jcommander.IParametersValidator;
+import com.beust.jcommander.ParameterException;
+import lombok.extern.log4j.Log4j2;
+
+import java.util.Map;
+
+/**
+ * This class handles validating all arguments in the context of a create+sign function.
+ * The input arguments are checked that --verify is not also selected and that all
+ * required inputs for --create are present.
+ */
+@Log4j2
+public class CreateArgumentValidator implements IParametersValidator {
+    String[] requiredArgs = {"--attributes", "--rimel"};
+    String errorMessage = "";
+
+    /**
+     * This method validates the input parameter map.
+     * @param parameters
+     *            Name-value-pairs of all parameters (e.g. "-host":"localhost").
+     *
+     * @throws ParameterException
+     */
+    @Override
+    public void validate(Map<String, Object> parameters) throws ParameterException {
+	    if (isValueNotNull(parameters,"--create")) {
+            if (isValueNotNull(parameters,"--verify")) {
+                errorMessage += "Create and verify cannot be called together. ";
+            } else {
+                for (String arg : requiredArgs) {
+                    if (!isValueNotNull(parameters, arg)) {
+                        errorMessage += arg + " is required to create and sign a base RIM. ";
+                    }
+                }
+                validateSigningCredentials(parameters);
+            }
+        }
+        if (!errorMessage.isEmpty()) {
+            throw new ParameterException(errorMessage);
+        }
+    }
+
+    /**
+     * This method checks the given key for a null value
+     * @param parameters map
+     * @param key the key to check
+     * @return true if not null, else false
+     */
+    private boolean isValueNotNull(Map<String, Object> parameters, String key) {
+        Object object = parameters.get(key);
+        if (object == null) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private void validateSigningCredentials(Map<String, Object> parameters) {
+        if (isValueNotNull(parameters, "--default-key") &&
+                (isValueNotNull(parameters, "--privateKeyFile") ||
+                        isValueNotNull(parameters, "--publicCertificate"))) {
+            errorMessage += "Too many signing credentials given, either choose --default-key OR " +
+                    "provide --privateKeyFile and --publicCertificate";
+        } else if (!isValueNotNull(parameters, "--default-key") &&
+                    !isValueNotNull(parameters, "--privateKeyFile") &&
+                    !isValueNotNull(parameters, "--publicCertificate")) {
+            errorMessage += "No signing credentials given, either choose --default-key OR " +
+                    "provide --privateKeyFile and --publicCertificate";
+        } else {
+            if (!(isValueNotNull(parameters, "--privateKeyFile") &&
+                    isValueNotNull(parameters, "--publicCertificate"))) {
+                if (isValueNotNull(parameters, "--privateKeyFile")) {
+                    errorMessage += "A signing certificate is missing. ";
+                } else {
+                    errorMessage += "A private key is missing. ";
+                }
+            }
+        }
+    }
+}

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/CreateArgumentValidator.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/CreateArgumentValidator.java
@@ -27,7 +27,7 @@ public class CreateArgumentValidator implements IParametersValidator {
     public void validate(Map<String, Object> parameters) throws ParameterException {
 	    if (isValueNotNull(parameters,"--create")) {
             if (isValueNotNull(parameters,"--verify")) {
-                errorMessage += "Create and verify cannot be called together. ";
+                throw new ParameterException("Create and verify cannot be called together.");
             } else {
                 for (String arg : requiredArgs) {
                     if (!isValueNotNull(parameters, arg)) {

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/VerifyArgumentValidator.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/VerifyArgumentValidator.java
@@ -1,0 +1,58 @@
+package hirs.swid.utils;
+
+import com.beust.jcommander.IParametersValidator;
+import com.beust.jcommander.ParameterException;
+import lombok.extern.log4j.Log4j2;
+
+import java.util.Map;
+
+/**
+ * This class handles validating all arguments in the context of a verify function.
+ * The input arguments are checked that --create is not also selected and that all
+ * required inputs for --verify are present.
+ */
+@Log4j2
+public class VerifyArgumentValidator implements IParametersValidator {
+    String[] requiredArgs = {"--rimel", "--publicCertificate", "--truststore"};
+    String errorMessage = "";
+
+    /**
+     * This method validates the input parameter map.
+     * @param parameters
+     *            Name-value-pairs of all parameters (e.g. "-host":"localhost").
+     *
+     * @throws ParameterException
+     */
+    @Override
+    public void validate(Map<String, Object> parameters) throws ParameterException {
+	    if (isValueNotNull(parameters,"--verify")) {
+            if (isValueNotNull(parameters,"--create")) {
+                throw new ParameterException("Create and verify cannot be called together.");
+            } else {
+                for (String arg : requiredArgs) {
+                    if (!isValueNotNull(parameters, arg)) {
+                        errorMessage += arg + " is required to verify a base RIM. ";
+                    }
+                }
+            }
+        }
+        if (!errorMessage.isEmpty()) {
+            throw new ParameterException(errorMessage);
+        }
+    }
+
+    /**
+     * This method checks the given key for a null value
+     * @param parameters map
+     * @param key the key to check
+     * @return true if not null, else false
+     */
+    private boolean isValueNotNull(Map<String, Object> parameters, String key) {
+        Object object = parameters.get(key);
+        if (object == null) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+}

--- a/tools/tcg_rim_tool/src/test/java/hirs/swid/TestSwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/test/java/hirs/swid/TestSwidTagGateway.java
@@ -70,7 +70,7 @@ public class TestSwidTagGateway {
 				.getResourceAsStream(BASE_USER_CERT);
 		Assert.assertTrue(compareFileBytesToExpectedFile(DEFAULT_OUTPUT));
 		validator.setRim(DEFAULT_OUTPUT);
-		Assert.assertTrue(validator.validateSwidtagFile(DEFAULT_OUTPUT));
+		Assert.assertTrue(validator.validateRim(SIGNING_CERT_FILE));
 	}
 
 	/**
@@ -90,7 +90,7 @@ public class TestSwidTagGateway {
 				.getResourceAsStream(BASE_USER_CERT_EMBED);
 		Assert.assertTrue(compareFileBytesToExpectedFile(DEFAULT_OUTPUT));
 		validator.setRim(DEFAULT_OUTPUT);
-		Assert.assertTrue(validator.validateSwidtagFile(DEFAULT_OUTPUT));
+		Assert.assertTrue(validator.validateRim(SIGNING_CERT_FILE));
 	}
 
 	/**
@@ -106,7 +106,7 @@ public class TestSwidTagGateway {
 				.getResourceAsStream(BASE_DEFAULT_CERT);
 		Assert.assertTrue(compareFileBytesToExpectedFile(DEFAULT_OUTPUT));
 		validator.setRim(DEFAULT_OUTPUT);
-		Assert.assertTrue(validator.validateSwidtagFile(DEFAULT_OUTPUT));
+		Assert.assertTrue(validator.validateRim(SIGNING_CERT_FILE));
 	}
 
 	/**
@@ -124,7 +124,7 @@ public class TestSwidTagGateway {
 				.getResourceAsStream(BASE_RFC3339_TIMESTAMP);
 		Assert.assertTrue(compareFileBytesToExpectedFile(DEFAULT_OUTPUT));
 		validator.setRim(DEFAULT_OUTPUT);
-		Assert.assertTrue(validator.validateSwidtagFile(DEFAULT_OUTPUT));
+		Assert.assertTrue(validator.validateRim(SIGNING_CERT_FILE));
 	}
 
 	/**
@@ -142,7 +142,7 @@ public class TestSwidTagGateway {
 				.getResourceAsStream(BASE_RFC3852_TIMESTAMP);
 		Assert.assertTrue(compareFileBytesToExpectedFile(DEFAULT_OUTPUT));
 		validator.setRim(DEFAULT_OUTPUT);
-		Assert.assertTrue(validator.validateSwidtagFile(DEFAULT_OUTPUT));
+		Assert.assertTrue(validator.validateRim(SIGNING_CERT_FILE));
 	}
 
 	/**
@@ -155,7 +155,7 @@ public class TestSwidTagGateway {
 				.getResource(BASE_USER_CERT).getPath();
 		System.out.println("Validating file at " + filepath);
 		validator.setRim(DEFAULT_OUTPUT);
-		Assert.assertTrue(validator.validateSwidtagFile(filepath));
+		Assert.assertTrue(validator.validateRim(SIGNING_CERT_FILE));
 	}
 
 	/**


### PR DESCRIPTION
These changes require a public signing certificate for `rim --verify` operation.  The cert is used to check the <KeyName> value in the signature, and then to check the truststore's validity.  Major changes include:

- New VerifyArgumentValidator class to require `-p|--public-certificate` with `-v|--verify`
- Modified ReferenceManifestValidator class to implement checks with public signing cert
- Upgrade JCommander

Closes #726 