### PR TITLE
create_aca_images workflow passes branch ref to dockerfiles

### DIFF
--- a/.ci/docker/Dockerfile.aca-rocky
+++ b/.ci/docker/Dockerfile.aca-rocky
@@ -3,6 +3,9 @@ LABEL org.opencontainers.image.vendor NSA Laboratory for Advanced Cybersecurity 
 LABEL org.opencontainers.image.source https://github.com/nsacyber/hirs
 LABEL org.opencontainers.image.description NSA\'s HIRS Attestation Certificate Authority. Expose port 8443 to access the portal from outside the container.
 
+# REF can be specified as a docker run environment variable to select the HIRS branch to work with
+ENV REF=main
+
 SHELL ["/bin/bash", "-c"]
 
 # Rocky 9 has a different channel for some apps
@@ -50,7 +53,7 @@ RUN echo "#!/bin/bash" > /tmp/tpm_config && \
 EXPOSE 8443
 
 # Checkout HIRS
-RUN git clone -b main https://github.com/nsacyber/HIRS.git /repo
+RUN git clone -b ${REF} https://github.com/nsacyber/HIRS.git /repo
 
 # Defensive copy of the repo so it's easy to start fresh if needed
 RUN mkdir /hirs

--- a/.ci/docker/Dockerfile.aca-rocky
+++ b/.ci/docker/Dockerfile.aca-rocky
@@ -4,7 +4,7 @@ LABEL org.opencontainers.image.source https://github.com/nsacyber/hirs
 LABEL org.opencontainers.image.description NSA\'s HIRS Attestation Certificate Authority. Expose port 8443 to access the portal from outside the container.
 
 # REF can be specified as a docker run environment variable to select the HIRS branch to work with
-ENV REF=main
+ARG REF=main
 
 SHELL ["/bin/bash", "-c"]
 

--- a/.ci/docker/Dockerfile.aca-windows
+++ b/.ci/docker/Dockerfile.aca-windows
@@ -10,7 +10,7 @@ LABEL org.opencontainers.image.description NSA\'s HIRS Attestation Certificate A
 LABEL org.opencontainers.image.base.name mcr.microsoft.com/powershell:${BASE_IMAGE_TAG}
 
 # REF can be specified as a docker run environment variable to select the HIRS branch to work with
-ENV REF=main
+ARG REF=main
 
 SHELL ["pwsh", "-Command"]
 

--- a/.ci/docker/Dockerfile.aca-windows
+++ b/.ci/docker/Dockerfile.aca-windows
@@ -9,6 +9,9 @@ LABEL org.opencontainers.image.source https://github.com/nsacyber/hirs
 LABEL org.opencontainers.image.description NSA\'s HIRS Attestation Certificate Authority in a Windows-native image. Expose port 8443 to access the portal from outside the container.
 LABEL org.opencontainers.image.base.name mcr.microsoft.com/powershell:${BASE_IMAGE_TAG}
 
+# REF can be specified as a docker run environment variable to select the HIRS branch to work with
+ENV REF=main
+
 SHELL ["pwsh", "-Command"]
 
 # Output Powershell Version
@@ -105,11 +108,11 @@ RUN setx PATH '%JAVA_HOME%\bin;C:\Program Files\MariaDB 11.1\bin;%GIT_HOME%\bin;
 # Echo PATH after update
 RUN echo $Env:PATH
 
-# Clone HIRS main
+# Clone HIRS main (or REF)
 WORKDIR C:/
 RUN git config --global --add core.autocrlf false
 RUN git config --global --add safe.directory '*'
-RUN git clone -b main https://github.com/nsacyber/hirs.git C:/repo
+RUN git clone -b ${REF} https://github.com/nsacyber/hirs.git C:/repo
 
 # Defensive copy of the repo so it's easy to start fresh if needed
 WORKDIR C:/repo

--- a/.github/workflows/create_aca_images.yml
+++ b/.github/workflows/create_aca_images.yml
@@ -51,7 +51,7 @@ jobs:
         echo "PUBLIC_IMAGE_TAG=$PUBLIC_IMAGE_NAME:$IMAGE_TAG_VAR" >> "$GITHUB_OUTPUT"
     - name: Print env
       run: |
-        echo GITHUB_REF=$GITHUB_REF
+        echo GITHUB_REF_NAME=$GITHUB_REF_NAME
         echo DOCKERFILE_ROCKY=$DOCKERFILE_ROCKY
         echo DOCKERFILE_WINDOWS=$DOCKERFILE_WINDOWS
         echo IMAGE_NAME_ROCKY=$IMAGE_NAME_ROCKY
@@ -87,7 +87,7 @@ jobs:
       with:
         context: "{{defaultContext}}:.ci/docker"
         file: Dockerfile.${{env.DOCKERFILE_ROCKY}}
-        build-args: REF=$GITHUB_REF
+        build-args: REF=$GITHUB_REF_NAME
         tags: ${{env.TAG}}
         push: true
         
@@ -110,7 +110,7 @@ jobs:
     - name: Build the docker image for ${{ github.repository }}
       run: |
         cd ./.ci/docker
-        docker build -e "REF=$GITHUB_REF" -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} .
+        docker build --build-arg "REF=$GITHUB_REF_NAME" -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} .
     
     - name: Push the docker image
       run: |
@@ -135,7 +135,7 @@ jobs:
     - name: Build the docker image for ${{ github.repository }}
       run: |
         cd ./.ci/docker
-        docker build -e "REF=$GITHUB_REF" -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} --build-arg BASE_IMAGE_TAG=lts-windowsservercore-1809 .
+        docker build --build-arg "REF=$GITHUB_REF_NAME" -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} --build-arg BASE_IMAGE_TAG=lts-windowsservercore-1809 .
         
     - name: Push the docker image
       run: |

--- a/.github/workflows/create_aca_images.yml
+++ b/.github/workflows/create_aca_images.yml
@@ -51,7 +51,7 @@ jobs:
         echo "PUBLIC_IMAGE_TAG=$PUBLIC_IMAGE_NAME:$IMAGE_TAG_VAR" >> "$GITHUB_OUTPUT"
     - name: Print env
       run: |
-        echo GITHUB_REF_NAME=$GITHUB_REF_NAME
+        echo GITHUB_REF_NAME=${{ github.ref_name }}
         echo DOCKERFILE_ROCKY=$DOCKERFILE_ROCKY
         echo DOCKERFILE_WINDOWS=$DOCKERFILE_WINDOWS
         echo IMAGE_NAME_ROCKY=$IMAGE_NAME_ROCKY
@@ -87,7 +87,7 @@ jobs:
       with:
         context: "{{defaultContext}}:.ci/docker"
         file: Dockerfile.${{env.DOCKERFILE_ROCKY}}
-        build-args: REF=$GITHUB_REF_NAME
+        build-args: REF=${{ github.ref_name }}
         tags: ${{env.TAG}}
         push: true
         
@@ -110,7 +110,7 @@ jobs:
     - name: Build the docker image for ${{ github.repository }}
       run: |
         cd ./.ci/docker
-        docker build --build-arg "REF=$GITHUB_REF_NAME" -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} .
+        docker build --build-arg "REF=${{ github.ref_name }}" -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} .
     
     - name: Push the docker image
       run: |
@@ -135,7 +135,7 @@ jobs:
     - name: Build the docker image for ${{ github.repository }}
       run: |
         cd ./.ci/docker
-        docker build --build-arg "REF=$GITHUB_REF_NAME" -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} --build-arg BASE_IMAGE_TAG=lts-windowsservercore-1809 .
+        docker build --build-arg "REF=${{ github.ref_name }}" -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} --build-arg BASE_IMAGE_TAG=lts-windowsservercore-1809 .
         
     - name: Push the docker image
       run: |

--- a/.github/workflows/create_aca_images.yml
+++ b/.github/workflows/create_aca_images.yml
@@ -51,6 +51,7 @@ jobs:
         echo "PUBLIC_IMAGE_TAG=$PUBLIC_IMAGE_NAME:$IMAGE_TAG_VAR" >> "$GITHUB_OUTPUT"
     - name: Print env
       run: |
+        echo GITHUB_REF=$GITHUB_REF
         echo DOCKERFILE_ROCKY=$DOCKERFILE_ROCKY
         echo DOCKERFILE_WINDOWS=$DOCKERFILE_WINDOWS
         echo IMAGE_NAME_ROCKY=$IMAGE_NAME_ROCKY
@@ -86,6 +87,7 @@ jobs:
       with:
         context: "{{defaultContext}}:.ci/docker"
         file: Dockerfile.${{env.DOCKERFILE_ROCKY}}
+        build-args: REF=$GITHUB_REF
         tags: ${{env.TAG}}
         push: true
         
@@ -108,7 +110,7 @@ jobs:
     - name: Build the docker image for ${{ github.repository }}
       run: |
         cd ./.ci/docker
-        docker build -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} .
+        docker build -e "REF=$GITHUB_REF" -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} .
     
     - name: Push the docker image
       run: |
@@ -133,7 +135,7 @@ jobs:
     - name: Build the docker image for ${{ github.repository }}
       run: |
         cd ./.ci/docker
-        docker build -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} --build-arg BASE_IMAGE_TAG=lts-windowsservercore-1809 .
+        docker build -e "REF=$GITHUB_REF" -f ./Dockerfile.${{env.DOCKERFILE_WINDOWS}} -t ${{env.TAG}} --build-arg BASE_IMAGE_TAG=lts-windowsservercore-1809 .
         
     - name: Push the docker image
       run: |


### PR DESCRIPTION
The dockerfiles were hard coded to build from main. These changes should allow the target branch to be built.