### PR TITLE
[#707] Add Policy to Ignore Component Revision

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/PolicySettings.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/PolicySettings.java
@@ -42,6 +42,9 @@ public class PolicySettings extends UserDefinedEntity {
     private boolean pcAttributeValidationEnabled = false;
 
     @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean ignoreRevisionEnabled = false;
+
+    @Column(nullable = false, columnDefinition = "boolean default false")
     private boolean firmwareValidationEnabled = false;
 
     @Column(nullable = false, columnDefinition = "boolean default false")

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
@@ -26,6 +26,8 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ComponentResult extends ArchivableEntity {
 
+    // String value for the revision title
+    public static final String ATTRIBUTE_REVISION = "Revision";
     // embedded component info
     @Setter
     private String manufacturer;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/ComponentAttributeResult.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/ComponentAttributeResult.java
@@ -22,6 +22,9 @@ public class ComponentAttributeResult  extends ArchivableEntity {
     private UUID componentId;
     @Setter
     private UUID provisionSessionId;
+    // this is used to identify Revision for the ignore policy
+    @Setter
+    private String attribute;
     private String expectedValue;
     private String actualValue;
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
@@ -225,7 +225,8 @@ public class SupplyChainValidationService {
                         if (pc != null && !pc.isPlatformBase()) {
                             attributeScv = ValidationService.evaluateDeltaAttributesStatus(
                                     pc, device.getDeviceInfo(),
-                                    baseCredential, deltaMapping, certificateRepository);
+                                    baseCredential, deltaMapping, certificateRepository,
+                                    getPolicySettings().isIgnoreRevisionEnabled());
                             if (attributeScv.getValidationResult() == AppraisalStatus.Status.FAIL) {
                                 attrErrorMessage = String.format("%s%s%n", attrErrorMessage,
                                         attributeScv.getMessage());
@@ -240,7 +241,8 @@ public class SupplyChainValidationService {
                     platformScv = ValidationService.evaluatePCAttributesStatus(
                             baseCredential, device.getDeviceInfo(), ec,
                             certificateRepository, componentResultRepository,
-                            componentAttributeRepository, componentInfos, provisionSessionId);
+                            componentAttributeRepository, componentInfos, provisionSessionId,
+                            getPolicySettings().isIgnoreRevisionEnabled());
                     validations.add(new SupplyChainValidation(
                             SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
                             platformScv.getValidationResult(), aes, platformScv.getMessage()));
@@ -390,7 +392,8 @@ public class SupplyChainValidationService {
         PolicySettings defaultSettings = this.policyRepository.findByName("Default");
 
         if (defaultSettings == null) {
-            defaultSettings = new PolicySettings("Default", "Settings are configured for no validation flags set.");
+            defaultSettings = new PolicySettings("Default",
+                    "Settings are configured for no validation flags set.");
         }
         return defaultSettings;
     }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
@@ -109,7 +109,7 @@ public class ValidationService {
             final ComponentResultRepository componentResultRepository,
             final ComponentAttributeRepository componentAttributeRepository,
             final List<ComponentInfo> componentInfos,
-            final UUID provisionSessionId) {
+            final UUID provisionSessionId, final boolean ignoreRevisionAttribute) {
         final SupplyChainValidation.ValidationType validationType
                 = SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL_ATTRIBUTES;
 
@@ -123,7 +123,7 @@ public class ValidationService {
         AppraisalStatus result = CredentialValidator.
                 validatePlatformCredentialAttributes(pc, deviceInfoReport, ec,
                         componentResultRepository, componentAttributeRepository,
-                        componentInfos, provisionSessionId);
+                        componentInfos, provisionSessionId, ignoreRevisionAttribute);
         switch (result.getAppStatus()) {
             case PASS:
                 return buildValidationRecord(validationType, AppraisalStatus.Status.PASS,
@@ -148,7 +148,8 @@ public class ValidationService {
             final DeviceInfoReport deviceInfoReport,
             final PlatformCredential base,
             final Map<PlatformCredential, SupplyChainValidation> deltaMapping,
-            final CertificateRepository certificateRepository) {
+            final CertificateRepository certificateRepository,
+            final boolean ignoreRevisionAttribute) {
         final SupplyChainValidation.ValidationType validationType
                 = SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL_ATTRIBUTES;
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
@@ -168,6 +168,8 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
      * @param componentResultRepository db access to component result of mismatching
      * @param componentAttributeRepository  db access to component attribute match status
      * @param componentInfos list of device components
+     * @param provisionSessionId UUID associated with this run of the provision
+     * @param ignoreRevisionAttribute policy flag to ignore the revision attribute
      * @return The result of the validation.
      */
     public static AppraisalStatus validatePlatformCredentialAttributes(
@@ -177,7 +179,7 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
             final ComponentResultRepository componentResultRepository,
             final ComponentAttributeRepository componentAttributeRepository,
             final List<ComponentInfo> componentInfos,
-            final UUID provisionSessionId) {
+            final UUID provisionSessionId, final boolean ignoreRevisionAttribute) {
         final String baseErrorMessage = "Can't validate platform credential attributes without ";
         String message;
         if (platformCredential == null) {
@@ -209,7 +211,8 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
         if (PlatformCredential.CERTIFICATE_TYPE_2_0.equals(credentialType)) {
             return CertificateAttributeScvValidator.validatePlatformCredentialAttributesV2p0(
                     platformCredential, deviceInfoReport, componentResultRepository,
-                    componentAttributeRepository, componentInfos, provisionSessionId);
+                    componentAttributeRepository, componentInfos, provisionSessionId,
+                    ignoreRevisionAttribute);
         }
         return CertificateAttributeScvValidator.validatePlatformCredentialAttributesV1p2(
                 platformCredential, deviceInfoReport);

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidatorTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidatorTest.java
@@ -345,7 +345,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -377,7 +377,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                Collections.emptyList(), UUID.randomUUID());
+                Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -408,7 +408,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -441,7 +441,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -473,7 +473,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -504,7 +504,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -535,7 +535,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -570,7 +570,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(
                         pc, deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals(expectedMessage, result.getMessage());
     }
@@ -603,7 +603,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(
                         pc, deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals(expectedMessage, result.getMessage());
     }
@@ -984,7 +984,7 @@ public class SupplyChainCredentialValidatorTest {
 
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc, null, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals(expectedMessage, result.getMessage());
     }
@@ -1241,7 +1241,7 @@ public class SupplyChainCredentialValidatorTest {
 
         AppraisalStatus appraisalStatus = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential, deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS,
                 appraisalStatus.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
@@ -1261,7 +1261,7 @@ public class SupplyChainCredentialValidatorTest {
 
         AppraisalStatus appraisalStatus = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential, deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, appraisalStatus.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 appraisalStatus.getMessage());
@@ -1283,7 +1283,7 @@ public class SupplyChainCredentialValidatorTest {
 
         AppraisalStatus appraisalStatus = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential, deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, appraisalStatus.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 appraisalStatus.getMessage());
@@ -1307,7 +1307,7 @@ public class SupplyChainCredentialValidatorTest {
 
         AppraisalStatus appraisalStatus = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential, deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, appraisalStatus.getAppStatus());
     }
 
@@ -1324,7 +1324,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1332,7 +1332,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Platform manufacturer did not match\n", result.getMessage());
 
@@ -1340,7 +1340,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1348,7 +1348,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(result.getAppStatus(), AppraisalStatus.Status.FAIL);
         assertEquals(result.getMessage(), "Platform model did not match\n");
 
@@ -1356,7 +1356,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1364,13 +1364,13 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         platformCredential = setupMatchingPlatformCredential(deviceInfoReport);
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1378,7 +1378,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1387,7 +1387,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1398,7 +1398,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component manufacturer is empty\n", result.getMessage());
 
@@ -1406,7 +1406,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1416,7 +1416,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component model is empty\n", result.getMessage());
 
@@ -1436,7 +1436,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1444,7 +1444,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Platform manufacturer did not match\n", result.getMessage());
 
@@ -1452,7 +1452,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1460,7 +1460,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Platform model did not match\n", result.getMessage());
 
@@ -1468,7 +1468,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1476,7 +1476,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Platform serial did not match\n", result.getMessage());
 
@@ -1484,7 +1484,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                Collections.emptyList(), UUID.randomUUID());
+                Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1492,7 +1492,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Platform version did not match\n", result.getMessage());
 
@@ -1500,7 +1500,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1511,7 +1511,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component manufacturer is empty\n"
                 + "There are unmatched components:\n"
@@ -1523,7 +1523,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1533,7 +1533,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component model is empty\n", result.getMessage());
     }
@@ -1552,7 +1552,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1574,7 +1574,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("There are unmatched components:\n"
                 + "Manufacturer=ACME, Model=TNT, Serial=2, Revision=1.1;\n",
@@ -1600,7 +1600,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1608,7 +1608,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1628,7 +1628,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1641,7 +1641,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component manufacturer is empty\n"
                 + "There are unmatched components:\n"
@@ -1653,7 +1653,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1665,7 +1665,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component model is empty\n", result.getMessage());
     }
@@ -1695,7 +1695,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1726,7 +1726,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1759,7 +1759,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/PolicyPageModel.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/PolicyPageModel.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 
 /**
  * PolicyPage model object to demonstrate data exchange between policy.jsp page
- * form form and controller.
+ * form and controller.
  */
 @Setter
 @Getter
@@ -19,6 +19,7 @@ public class PolicyPageModel {
     private boolean enableEcValidation;
     private boolean enablePcCertificateValidation;
     private boolean enablePcCertificateAttributeValidation;
+    private boolean enableIgnoreRevisionAttribute;
     private boolean enableFirmwareValidation;
     private boolean issueAttestationCertificate;
     private boolean issueDevIdCertificate;
@@ -32,6 +33,7 @@ public class PolicyPageModel {
     // Variables to get policy settings from page
     private String pcValidate;
     private String pcAttributeValidate;
+    private String ignoreRevisionAttribute;
     private String ecValidate;
     private String fmValidate;
     private String attestationCertificateIssued;
@@ -59,6 +61,7 @@ public class PolicyPageModel {
         this.enableEcValidation = policy.isEcValidationEnabled();
         this.enablePcCertificateValidation = policy.isPcValidationEnabled();
         this.enablePcCertificateAttributeValidation = policy.isPcAttributeValidationEnabled();
+        this.enableIgnoreRevisionAttribute = policy.isIgnoreRevisionEnabled();
         this.enableFirmwareValidation = policy.isFirmwareValidationEnabled();
         this.issueAttestationCertificate = policy.isIssueAttestationCertificate();
         this.issueDevIdCertificate = policy.isIssueDevIdCertificate();

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/IndexPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/IndexPageController.java
@@ -14,7 +14,8 @@ import org.springframework.web.servlet.ModelAndView;
  */
 @Controller
 @Log4j2
-@RequestMapping(value={"/", "/HIRS_AttestationCAPortal", "/HIRS_AttestationCAPortal/", "/HIRS_AttestationCAPortal/portal/index"})
+@RequestMapping(value = {"/", "/HIRS_AttestationCAPortal",
+        "/HIRS_AttestationCAPortal/", "/HIRS_AttestationCAPortal/portal/index"})
 public class IndexPageController extends PageController<NoPageParams> {
 
     /**

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PolicyPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PolicyPageController.java
@@ -64,7 +64,8 @@ public class PolicyPageController extends PageController<NoPageParams> {
         this.policyRepository = policyRepository;
 
         if (this.policyRepository.findByName("Default") == null) {
-            this.policyRepository.saveAndFlush(new PolicySettings("Default", "Settings are configured for no validation flags set."));
+            this.policyRepository.saveAndFlush(new PolicySettings("Default",
+                    "Settings are configured for no validation flags set."));
         }
     }
 
@@ -973,7 +974,8 @@ public class PolicyPageController extends PageController<NoPageParams> {
         PolicySettings defaultSettings = this.policyRepository.findByName("Default");
 
         if (defaultSettings == null) {
-            defaultSettings = new PolicySettings("Default", "Settings are configured for no validation flags set.");
+            defaultSettings = new PolicySettings("Default",
+                    "Settings are configured for no validation flags set.");
         }
         return defaultSettings;
     }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PolicyPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PolicyPageController.java
@@ -194,6 +194,57 @@ public class PolicyPageController extends PageController<NoPageParams> {
     }
 
     /**
+     * Updates the ignore component revision attribute setting and
+     * redirects back to the original page.
+     *
+     * @param ppModel The data posted by the form mapped into an object.
+     * @param attr RedirectAttributes used to forward data back to the original
+     * page.
+     * @return View containing the url and parameters
+     * @throws URISyntaxException if malformed URI
+     */
+    @RequestMapping(value = "update-revision-ignore", method = RequestMethod.POST)
+    public RedirectView updateIgnoreRevisionAttribute(@ModelAttribute final PolicyPageModel ppModel,
+                                        final RedirectAttributes attr) throws URISyntaxException {
+        // set the data received to be populated back into the form
+        Map<String, Object> model = new HashMap<>();
+        PageMessages messages = new PageMessages();
+        String successMessage;
+        boolean ignoreRevisionAttributeOptionEnabled = ppModel.getIgnoreRevisionAttribute()
+                .equalsIgnoreCase(ENABLED_CHECKED_PARAMETER_VALUE);
+
+        try {
+            PolicySettings policy = getDefaultPolicyAndSetInModel(ppModel, model);
+
+            //If Ignore Revision is enabled without PC Attributes, disallow change
+            if (ignoreRevisionAttributeOptionEnabled && !policy.isPcAttributeValidationEnabled()) {
+                handleUserError(model, messages,
+                        "Ignore Component Revision Attribute can not be "
+                                + "enabled without PC Attribute validation policy enabled.");
+                return redirectToSelf(new NoPageParams(), model, attr);
+            }
+
+            // set the policy option and create success message
+            if (ignoreRevisionAttributeOptionEnabled) {
+                policy.setIgnoreRevisionEnabled(true);
+                successMessage = "Ignore Component Revision enabled";
+            } else {
+                policy.setIgnoreRevisionEnabled(false);
+                successMessage = "Ignore Component Revision disabled";
+            }
+
+            savePolicyAndApplySuccessMessage(ppModel, model, messages, successMessage, policy);
+        } catch (PolicyManagerException pmEx) {
+            handlePolicyManagerUpdateError(model, messages, pmEx,
+                    "Error changing ACA Component Revision Attribute policy",
+                    "Error updating policy. \n" + pmEx.getMessage());
+        }
+
+        // return the redirect
+        return redirectToSelf(new NoPageParams(), model, attr);
+    }
+
+    /**
      * Updates the Attestation Certificate generation policy setting and redirects
      * back to the original page.
      *

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
@@ -59,19 +59,19 @@
                             </my:editor>
                         </li>
                         <form:form method="POST" modelAttribute="initialData" action="policy/update-revision-ignore">
-                        <ul>
-                            <li>Ignore component revision attribute: ${initialData.enableIgnoreRevisionAttribute ? 'Enabled' : 'Disabled'}
-                                 <my:editor id="ignoreRevisionPolicyEditor" label="Edit Settings">
-                                      <div class="radio">
+                            <ul>
+                                <li>Ignore Component Revision Attribute: ${initialData.enableIgnoreRevisionAttribute ? 'Enabled' : 'Disabled'}
+                                    <my:editor id="ignoreRevisionPolicyEditor" label="Edit Settings">
+                                        <div class="radio">
                                           <label><input id="revisionTop" type="radio" name="ignoreRevisionAttribute" ${initialData.enableIgnoreRevisionAttribute ? 'checked' : ''} value="checked"/> Platform Credential Attributes will be validated</label>
-                                      </div>
-                                      <div class="radio">
+                                        </div>
+                                        <div class="radio">
                                           <label><input id="revisionBot" type="radio" name="ignoreRevisionAttribute" ${initialData.enableIgnoreRevisionAttribute ? '' : 'checked'}  value="unchecked"/> Platform Credential Attributes will not be validated</label>
-                                      </div>
-                                 </my:editor>
-                            </li>
-                        </ul>
-                </form:form>
+                                        </div>
+                                    </my:editor>
+                                </li>
+                            </ul>
+                        </form:form>
                     </ul>
                 </form:form>
             </div>

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
@@ -58,6 +58,20 @@
                                 </div>
                             </my:editor>
                         </li>
+                        <form:form method="POST" modelAttribute="initialData" action="policy/update-revision-ignore">
+                        <ul>
+                            <li>Ignore component revision attribute: ${initialData.enableIgnoreRevisionAttribute ? 'Enabled' : 'Disabled'}
+                                 <my:editor id="ignoreRevisionPolicyEditor" label="Edit Settings">
+                                      <div class="radio">
+                                          <label><input id="revisionTop" type="radio" name="ignoreRevisionAttribute" ${initialData.enableIgnoreRevisionAttribute ? 'checked' : ''} value="checked"/> Platform Credential Attributes will be validated</label>
+                                      </div>
+                                      <div class="radio">
+                                          <label><input id="revisionBot" type="radio" name="ignoreRevisionAttribute" ${initialData.enableIgnoreRevisionAttribute ? '' : 'checked'}  value="unchecked"/> Platform Credential Attributes will not be validated</label>
+                                      </div>
+                                 </my:editor>
+                            </li>
+                        </ul>
+                </form:form>
                     </ul>
                 </form:form>
             </div>

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
@@ -58,22 +58,22 @@
                                 </div>
                             </my:editor>
                         </li>
+                </form:form>
                         <form:form method="POST" modelAttribute="initialData" action="policy/update-revision-ignore">
                             <ul>
                                 <li>Ignore Component Revision Attribute: ${initialData.enableIgnoreRevisionAttribute ? 'Enabled' : 'Disabled'}
                                     <my:editor id="ignoreRevisionPolicyEditor" label="Edit Settings">
                                         <div class="radio">
-                                          <label><input id="revisionTop" type="radio" name="ignoreRevisionAttribute" ${initialData.enableIgnoreRevisionAttribute ? 'checked' : ''} value="checked"/> Platform Credential Attributes will be validated</label>
+                                          <label><input id="revisionTop" type="radio" name="ignoreRevisionAttribute" ${initialData.enableIgnoreRevisionAttribute ? 'checked' : ''} value="checked"/> Ignore Component Revision Attribute enabled</label>
                                         </div>
                                         <div class="radio">
-                                          <label><input id="revisionBot" type="radio" name="ignoreRevisionAttribute" ${initialData.enableIgnoreRevisionAttribute ? '' : 'checked'}  value="unchecked"/> Platform Credential Attributes will not be validated</label>
+                                          <label><input id="revisionBot" type="radio" name="ignoreRevisionAttribute" ${initialData.enableIgnoreRevisionAttribute ? '' : 'checked'}  value="unchecked"/> Ignore Component Revision Attribute disabled</label>
                                         </div>
                                     </my:editor>
                                 </li>
                             </ul>
                         </form:form>
                     </ul>
-                </form:form>
             </div>
 
             <%-- Firmware validation --%>


### PR DESCRIPTION
![image](https://github.com/nsacyber/HIRS/assets/24922493/6f51f948-3792-44fa-a329-2b68a7e4ae08)

Added UI features and back end code to handle the new policy which doesn't include the revision comparison as part of the final validation pass/fail.