### PR TITLE
[#707 #705] Delta Component compare part 2 and Policy Addition

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ComponentResultRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/ComponentResultRepository.java
@@ -18,6 +18,14 @@ public interface ComponentResultRepository extends JpaRepository<ComponentResult
     List<ComponentResult> findByBoardSerialNumber(String boardSerialNumber);
 
     /**
+     * Query based on the device serial number.
+     * @param boardSerialNumber variable holding the device serial number
+     * @param delta flag indicating if the component is associated with a delta certificate
+     * @return a list of component result.
+     */
+    List<ComponentResult> findByBoardSerialNumberAndDelta(String boardSerialNumber, boolean delta);
+
+    /**
      * Query based on certificate serial number and device serial number.
      * @param certificateSerialNumber certificate specific serial number
      * @param boardSerialNumber variable holding the device serial number

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/PolicySettings.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/PolicySettings.java
@@ -42,6 +42,9 @@ public class PolicySettings extends UserDefinedEntity {
     private boolean pcAttributeValidationEnabled = false;
 
     @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean ignoreRevisionEnabled = false;
+
+    @Column(nullable = false, columnDefinition = "boolean default false")
     private boolean firmwareValidationEnabled = false;
 
     @Column(nullable = false, columnDefinition = "boolean default false")

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
@@ -31,7 +31,9 @@ public class ComponentResult extends ArchivableEntity {
     private String manufacturer;
     @Setter
     private String model;
+    @Setter
     private String serialNumber;
+    @Setter
     private String revisionNumber;
     private boolean fieldReplaceable = false;
     // this is a string because component class doesn't inherit serializable.
@@ -42,6 +44,8 @@ public class ComponentResult extends ArchivableEntity {
     private AttributeStatus attributeStatus;
     private String componentAddress;
     private boolean version2 = false;
+    @Setter
+    private boolean delta = false;
     @Setter
     private boolean failedValidation;
     private String certificateType;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
@@ -26,6 +26,12 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ComponentResult extends ArchivableEntity {
 
+    // String value for the Manufacturer title
+    public static final String ATTRIBUTE_MANUFACTURER = "Manufacturer";
+    // String value for the Model title
+    public static final String ATTRIBUTE_MODEL = "Model";
+    // String value for the Serial title
+    public static final String ATTRIBUTE_SERIAL = "Serial";
     // String value for the revision title
     public static final String ATTRIBUTE_REVISION = "Revision";
     // embedded component info

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
@@ -26,6 +26,8 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ComponentResult extends ArchivableEntity {
 
+    // String value for the revision title
+    public static final String ATTRIBUTE_REVISION = "Revision";
     // embedded component info
     @Setter
     private String manufacturer;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/ComponentAttributeResult.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/ComponentAttributeResult.java
@@ -25,6 +25,9 @@ public class ComponentAttributeResult  extends ArchivableEntity {
     private UUID componentId;
     @Setter
     private UUID provisionSessionId;
+    // this is used to identify Revision for the ignore policy
+    @Setter
+    private String attribute;
     private String expectedValue;
     private String actualValue;
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/ComponentAttributeResult.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/ComponentAttributeResult.java
@@ -13,6 +13,9 @@ import java.util.UUID;
  * This is tied to the ComponentResult class.  If a component has a mismatched
  * value from what the device has listed, this class represents which attribute
  * of that component mismatched.
+ *
+ * If this is a delta issue, the component ID would be set to null if the
+ * remove or modified don't exist.
  */
 @Entity
 @Getter
@@ -32,6 +35,22 @@ public class ComponentAttributeResult  extends ArchivableEntity {
      * @param actualValue paccor value from the device
      */
     public ComponentAttributeResult(final UUID componentId,
+                                    final String expectedValue,
+                                    final String actualValue) {
+        this.componentId = componentId;
+        this.expectedValue = expectedValue;
+        this.actualValue = actualValue;
+    }
+
+    /**
+     * Default constructor that populates the expected and actual values.
+     * @param componentId id associated with component result
+     * @param provisionSessionId an id for the associated provision
+     * @param expectedValue platform certificate value
+     * @param actualValue paccor value from the device
+     */
+    public ComponentAttributeResult(final UUID componentId,
+                                    final UUID provisionSessionId,
                                     final String expectedValue,
                                     final String actualValue) {
         this.componentId = componentId;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/ComponentAttributeResult.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/ComponentAttributeResult.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.UUID;
 
@@ -67,5 +68,17 @@ public class ComponentAttributeResult  extends ArchivableEntity {
      */
     public boolean checkMatchedStatus() {
         return this.actualValue.equals(this.expectedValue);
+    }
+
+    /**
+     * For the state of the object, this shouldn't be negative.
+     * @return the string value of the attribute name
+     */
+    public String getAttribute() {
+        if (attribute == null) {
+            attribute = "";
+        }
+
+        return attribute;
     }
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
@@ -225,7 +225,13 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                             platformCredential.getSerialNumber().toString(),
                             platformCredential.getPlatformSerial());
             if (componentResults.isEmpty()) {
-                handlePlatformComponents(platformCredential);
+                savePlatformComponents(platformCredential);
+            } else {
+                componentResults.stream().forEach((componentResult) -> {
+                    componentResult.restore();
+                    componentResult.resetCreateTime();
+                    componentResultRepository.save(componentResult);
+                });
             }
         }
 
@@ -628,7 +634,7 @@ public class IdentityClaimProcessor extends AbstractProcessor {
         return true;
     }
 
-    private int handlePlatformComponents(final Certificate certificate) {
+    private void savePlatformComponents(final Certificate certificate) {
         PlatformCredential platformCredential;
         int componentResults = 0;
         if (certificate instanceof PlatformCredential) {
@@ -647,7 +653,6 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                 componentResults++;
             }
         }
-        return componentResults;
     }
 
     private int handleDeviceComponents(final String hostName, final String paccorString) {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
@@ -642,6 +642,7 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                         platformCredential.getPlatformChainType(),
                         componentIdentifier);
                 componentResult.setFailedValidation(false);
+                componentResult.setDelta(!platformCredential.isPlatformBase());
                 componentResultRepository.save(componentResult);
                 componentResults++;
             }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
@@ -636,7 +636,6 @@ public class IdentityClaimProcessor extends AbstractProcessor {
 
     private void savePlatformComponents(final Certificate certificate) {
         PlatformCredential platformCredential;
-        int componentResults = 0;
         if (certificate instanceof PlatformCredential) {
             platformCredential = (PlatformCredential) certificate;
             ComponentResult componentResult;
@@ -650,7 +649,6 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                 componentResult.setFailedValidation(false);
                 componentResult.setDelta(!platformCredential.isPlatformBase());
                 componentResultRepository.save(componentResult);
-                componentResults++;
             }
         }
     }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
@@ -124,7 +124,9 @@ public class SupplyChainValidationService {
         // Validate the Endorsement Credential
         if (getPolicySettings().isEcValidationEnabled()) {
             log.info("Beginning Endorsement Credential Validation...");
-            validations.add(ValidationService.evaluateEndorsementCredentialStatus(ec, this.caCredentialRepository, acceptExpiredCerts));
+            validations.add(ValidationService
+                    .evaluateEndorsementCredentialStatus(ec,
+                            this.caCredentialRepository, acceptExpiredCerts));
             // store the device with the credential
             if (ec != null) {
                 ec.setDeviceId(device.getId());
@@ -219,18 +221,16 @@ public class SupplyChainValidationService {
                     // There are delta certificates, so the code need to build a new list of
                     // certificate components to then compare against the device component list
                     aes.addAll(basePlatformScv.getCertificatesUsed());
-                    Iterator<PlatformCredential> it = pcs.iterator();
-                    while (it.hasNext()) {
-                        PlatformCredential pc = it.next();
-                        if (pc != null && !pc.isPlatformBase()) {
-                            attributeScv = ValidationService.evaluateDeltaAttributesStatus(
-                                    pc, device.getDeviceInfo(),
-                                    baseCredential, deltaMapping, certificateRepository);
-                            if (attributeScv.getValidationResult() == AppraisalStatus.Status.FAIL) {
-                                attrErrorMessage = String.format("%s%s%n", attrErrorMessage,
-                                        attributeScv.getMessage());
-                            }
-                        }
+
+                    attributeScv = ValidationService.evaluateDeltaAttributesStatus(
+                            device.getDeviceInfo(),
+                            baseCredential, deltaMapping, certificateRepository,
+                            componentResultRepository,
+                            componentAttributeRepository,
+                            componentInfos, provisionSessionId);
+                    if (attributeScv.getValidationResult() == AppraisalStatus.Status.FAIL) {
+                        attrErrorMessage = String.format("%s%s%n", attrErrorMessage,
+                                attributeScv.getMessage());
                     }
                 } else {
                     // validate attributes for a single base platform certificate

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
@@ -227,7 +227,8 @@ public class SupplyChainValidationService {
                             baseCredential, deltaMapping, certificateRepository,
                             componentResultRepository,
                             componentAttributeRepository,
-                            componentInfos, provisionSessionId);
+                            componentInfos, provisionSessionId,
+                            getPolicySettings().isIgnoreRevisionEnabled());
                     if (attributeScv.getValidationResult() == AppraisalStatus.Status.FAIL) {
                         attrErrorMessage = String.format("%s%s%n", attrErrorMessage,
                                 attributeScv.getMessage());
@@ -240,7 +241,8 @@ public class SupplyChainValidationService {
                     platformScv = ValidationService.evaluatePCAttributesStatus(
                             baseCredential, device.getDeviceInfo(), ec,
                             certificateRepository, componentResultRepository,
-                            componentAttributeRepository, componentInfos, provisionSessionId);
+                            componentAttributeRepository, componentInfos, provisionSessionId,
+                            getPolicySettings().isIgnoreRevisionEnabled());
                     validations.add(new SupplyChainValidation(
                             SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
                             platformScv.getValidationResult(), aes, platformScv.getMessage()));
@@ -390,7 +392,8 @@ public class SupplyChainValidationService {
         PolicySettings defaultSettings = this.policyRepository.findByName("Default");
 
         if (defaultSettings == null) {
-            defaultSettings = new PolicySettings("Default", "Settings are configured for no validation flags set.");
+            defaultSettings = new PolicySettings("Default",
+                    "Settings are configured for no validation flags set.");
         }
         return defaultSettings;
     }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
@@ -144,28 +144,27 @@ public class ValidationService {
     }
 
     public static SupplyChainValidation evaluateDeltaAttributesStatus(
-            final PlatformCredential delta,
             final DeviceInfoReport deviceInfoReport,
             final PlatformCredential base,
             final Map<PlatformCredential, SupplyChainValidation> deltaMapping,
-            final CertificateRepository certificateRepository) {
+            final CertificateRepository certificateRepository,
+            final ComponentResultRepository componentResultRepository,
+            final ComponentAttributeRepository componentAttributeRepository,
+            final List<ComponentInfo> componentInfos,
+            final UUID provisionSessionId) {
         final SupplyChainValidation.ValidationType validationType
                 = SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL_ATTRIBUTES;
 
-        if (delta == null) {
-            log.error("No delta certificate to validate");
-            return buildValidationRecord(validationType,
-                    AppraisalStatus.Status.FAIL, "Delta platform certificate is missing",
-                    null, Level.ERROR);
-        }
         log.info("Validating delta platform certificate attributes");
-        AppraisalStatus result = CertificateAttributeScvValidator.
-                validateDeltaPlatformCredentialAttributes(delta, deviceInfoReport,
-                        base, deltaMapping);
+        AppraisalStatus result = CredentialValidator.
+                validateDeltaPlatformCredentialAttributes(deviceInfoReport,
+                        base, deltaMapping, componentInfos,
+                        componentResultRepository, componentAttributeRepository,
+                        provisionSessionId);
         switch (result.getAppStatus()) {
             case PASS:
                 return buildValidationRecord(validationType, AppraisalStatus.Status.PASS,
-                        result.getMessage(), delta, Level.INFO);
+                        result.getMessage(), base, Level.INFO);
             case FAIL:
                 if (!result.getAdditionalInfo().isEmpty()) {
                     base.setComponentFailures(result.getAdditionalInfo());
@@ -173,13 +172,13 @@ public class ValidationService {
                     certificateRepository.save(base);
                 }
                 // we are adding things to componentFailures
-                certificateRepository.save(delta);
+//                certificateRepository.save(delta);
                 return buildValidationRecord(validationType, AppraisalStatus.Status.FAIL,
-                        result.getMessage(), delta, Level.WARN);
+                        result.getMessage(), base, Level.WARN);
             case ERROR:
             default:
                 return buildValidationRecord(validationType, AppraisalStatus.Status.ERROR,
-                        result.getMessage(), delta, Level.ERROR);
+                        result.getMessage(), base, Level.ERROR);
         }
     }
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
@@ -160,7 +160,7 @@ public class ValidationService {
                 validateDeltaPlatformCredentialAttributes(deviceInfoReport,
                         base, deltaMapping, componentInfos,
                         componentResultRepository, componentAttributeRepository,
-                        provisionSessionId);
+                        provisionSessionId, ignoreRevisionAttribute);
         switch (result.getAppStatus()) {
             case PASS:
                 return buildValidationRecord(validationType, AppraisalStatus.Status.PASS,

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
@@ -109,7 +109,7 @@ public class ValidationService {
             final ComponentResultRepository componentResultRepository,
             final ComponentAttributeRepository componentAttributeRepository,
             final List<ComponentInfo> componentInfos,
-            final UUID provisionSessionId) {
+            final UUID provisionSessionId, final boolean ignoreRevisionAttribute) {
         final SupplyChainValidation.ValidationType validationType
                 = SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL_ATTRIBUTES;
 
@@ -123,7 +123,7 @@ public class ValidationService {
         AppraisalStatus result = CredentialValidator.
                 validatePlatformCredentialAttributes(pc, deviceInfoReport, ec,
                         componentResultRepository, componentAttributeRepository,
-                        componentInfos, provisionSessionId);
+                        componentInfos, provisionSessionId, ignoreRevisionAttribute);
         switch (result.getAppStatus()) {
             case PASS:
                 return buildValidationRecord(validationType, AppraisalStatus.Status.PASS,
@@ -151,7 +151,7 @@ public class ValidationService {
             final ComponentResultRepository componentResultRepository,
             final ComponentAttributeRepository componentAttributeRepository,
             final List<ComponentInfo> componentInfos,
-            final UUID provisionSessionId) {
+            final UUID provisionSessionId, final boolean ignoreRevisionAttribute) {
         final SupplyChainValidation.ValidationType validationType
                 = SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL_ATTRIBUTES;
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/CredentialHelper.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/CredentialHelper.java
@@ -13,14 +13,23 @@ import java.util.List;
 import java.util.ListIterator;
 
 @Log4j2
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class CredentialHelper {
 
+    /**
+     * Small method to check if the certificate is a PEM.
+     * @param possiblePEM header information
+     * @return true if it is.
+     */
     public static boolean isPEM(final String possiblePEM) {
         return possiblePEM.contains(CertificateVariables.PEM_HEADER)
                 || possiblePEM.contains(CertificateVariables.PEM_ATTRIBUTE_HEADER);
     }
 
+    /**
+     * Small method to check if there are multi pem files
+     * @param possiblePEM header information
+     * @return true if it is.
+     */
     public static boolean isMultiPEM(final String possiblePEM) {
         boolean multiPem = false;
         int iniIndex = possiblePEM.indexOf(CertificateVariables.PEM_HEADER);
@@ -34,6 +43,11 @@ public final class CredentialHelper {
         return multiPem;
     }
 
+    /**
+     * Method to remove header footer information from PEM
+     * @param pemFile string representation of the file
+     * @return a cleaned up raw byte object
+     */
     public static byte[] stripPemHeaderFooter(final String pemFile) {
         String strippedFile;
         strippedFile = pemFile.replace(CertificateVariables.PEM_HEADER, "");
@@ -43,13 +57,19 @@ public final class CredentialHelper {
         return Base64.decode(strippedFile);
     }
 
+    /**
+     * The method is used to remove unwanted spaces and other artifacts from the certificate.
+     * @param certificateBytes raw byte form
+     * @return a cleaned up byte form
+     */
     @SuppressWarnings("magicnumber")
     public static byte[] trimCertificate(final byte[] certificateBytes) {
         int certificateStart = 0;
         int certificateLength = 0;
         ByteBuffer certificateByteBuffer = ByteBuffer.wrap(certificateBytes);
 
-        StringBuilder malformedCertStringBuilder = new StringBuilder(CertificateVariables.MALFORMED_CERT_MESSAGE);
+        StringBuilder malformedCertStringBuilder = new StringBuilder(
+                CertificateVariables.MALFORMED_CERT_MESSAGE);
         while (certificateByteBuffer.hasRemaining()) {
             // Check if there isn't an ASN.1 structure in the provided bytes
             if (certificateByteBuffer.remaining() <= 2) {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/PciIds.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/PciIds.java
@@ -5,11 +5,8 @@ import com.github.marandus.pciid.model.Vendor;
 import com.github.marandus.pciid.service.PciIdsDatabase;
 import com.google.common.base.Strings;
 import hirs.attestationca.persist.entity.userdefined.certificate.ComponentResult;
-import hirs.attestationca.persist.entity.userdefined.certificate.attributes.ComponentClass;
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.ComponentIdentifier;
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.V2.ComponentIdentifierV2;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
 import lombok.extern.log4j.Log4j2;
 import org.bouncycastle.asn1.ASN1UTF8String;
@@ -27,7 +24,6 @@ import java.util.List;
  * Provide Java access to PCI IDs.
  */
 @Log4j2
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PciIds {
     /**
      * This pci ids file can be in different places on different distributions.
@@ -150,8 +146,10 @@ public final class PciIds {
             final String compClassValue = component.getComponentClass().getCategory();
             if (compClassValue.equals(COMPCLASS_TCG_CAT_NIC)
                     || compClassValue.equals(COMPCLASS_TCG_CAT_GFX)) {
-                DERUTF8String manufacturer = (DERUTF8String) translateVendor(component.getComponentManufacturer());
-                DERUTF8String model = (DERUTF8String) translateDevice(component.getComponentManufacturer(),
+                DERUTF8String manufacturer = (DERUTF8String) translateVendor(
+                        component.getComponentManufacturer());
+                DERUTF8String model = (DERUTF8String) translateDevice(
+                        component.getComponentManufacturer(),
                         component.getComponentModel());
 
                 newComponent = new ComponentIdentifierV2(component.getComponentClass(),

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
@@ -376,10 +376,12 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
         List<ComponentResult> remainingComponentResults = checkDeviceHashMap(
                 componentInfos, compiledComponentList);
 
+        List<UUID> componentIdList = new ArrayList<>();
         int numOfAttributes = 0;
         if (!remainingComponentResults.isEmpty()) {
             List<ComponentAttributeResult> attributeResults = checkComponentClassMap(
                     componentInfos, remainingComponentResults);
+            numOfAttributes = attributeResults.size();
             boolean saveAttributeResult;
             for (ComponentAttributeResult componentAttributeResult : attributeResults) {
                 saveAttributeResult = true;
@@ -391,17 +393,18 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
                     componentAttributeResult.setProvisionSessionId(provisionSessionId);
                     componentAttributeRepository.save(componentAttributeResult);
                     fieldValidation &= componentAttributeResult.checkMatchedStatus();
+                    componentIdList.add(componentAttributeResult.getComponentId());
+                } else {
+                    numOfAttributes--;
                 }
             }
-            numOfAttributes = attributeResults.size();
         }
 
         StringBuilder additionalInfo = new StringBuilder();
         if (!remainingComponentResults.isEmpty()) {
-            resultMessage.append(String.format("There are %d components not matched%n",
-                    remainingComponentResults.size()));
-            resultMessage.append(String.format("\twith %d total attributes mismatched.",
-                    numOfAttributes));
+            resultMessage.append(String.format("There are %d component(s) not matched%n "
+                            + "with %d total attributes mismatched.",
+                    componentIdList.stream().distinct().count(), numOfAttributes));
         }
 
         if (fieldValidation) {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
@@ -264,10 +264,14 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
         // first create hash map based on hashCode
         List<ComponentResult> remainingComponentResults = checkDeviceHashMap(
                 componentInfos, componentResults);
+        //this is used to get a unique count
+        List<UUID> componentIdList = new ArrayList<>();
         int numOfAttributes = 0;
         if (!remainingComponentResults.isEmpty()) {
             List<ComponentAttributeResult> attributeResults = checkComponentClassMap(
                     componentInfos, remainingComponentResults);
+
+            numOfAttributes = attributeResults.size();
             boolean saveAttributeResult;
             for (ComponentAttributeResult componentAttributeResult : attributeResults) {
                  saveAttributeResult = true;
@@ -279,17 +283,18 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
                     componentAttributeResult.setProvisionSessionId(provisionSessionId);
                     componentAttributeRepository.save(componentAttributeResult);
                     fieldValidation &= componentAttributeResult.checkMatchedStatus();
+                    componentIdList.add(componentAttributeResult.getComponentId());
+                } else {
+                    numOfAttributes--;
                 }
             }
-            numOfAttributes = attributeResults.size();
         }
 
         StringBuilder additionalInfo = new StringBuilder();
-        if (!remainingComponentResults.isEmpty()) {
-            resultMessage.append(String.format("There are %d components not matched%n",
-                    remainingComponentResults.size()));
-            resultMessage.append(String.format("\twith %d total attributes mismatched.",
-                    numOfAttributes));
+        if (numOfAttributes > 0) {
+            resultMessage.append(String.format("There are %d component(s) not matched%n "
+                            + "with %d total attributes mismatched.",
+                    componentIdList.stream().distinct().count(), numOfAttributes));
         }
 
         passesValidation &= fieldValidation;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
@@ -157,6 +157,7 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
      * @param componentAttributeRepository db access to component attribute match status
      * @param componentInfos               list of device components
      * @param provisionSessionId           UUID associated with the SCV Summary
+     * @param ignoreRevisionAttribute policy flag to ignore the revision attribute
      * @return either PASS or FAIL
      */
     public static AppraisalStatus validatePlatformCredentialAttributesV2p0(
@@ -165,7 +166,7 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
             final ComponentResultRepository componentResultRepository,
             final ComponentAttributeRepository componentAttributeRepository,
             final List<ComponentInfo> componentInfos,
-            final UUID provisionSessionId) {
+            final UUID provisionSessionId, final boolean ignoreRevisionAttribute) {
         boolean passesValidation = true;
         StringBuilder resultMessage = new StringBuilder();
         HardwareInfo hardwareInfo = deviceInfoReport.getHardwareInfo();
@@ -269,9 +270,12 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
                     componentInfos, remainingComponentResults);
 
             for (ComponentAttributeResult componentAttributeResult : attributeResults) {
-                componentAttributeResult.setProvisionSessionId(provisionSessionId);
-                componentAttributeRepository.save(componentAttributeResult);
-                fieldValidation &= componentAttributeResult.checkMatchedStatus();
+                if (componentAttributeResult.getAttribute().equalsIgnoreCase(ComponentResult.ATTRIBUTE_REVISION)
+                        && !ignoreRevisionAttribute) {
+                    componentAttributeResult.setProvisionSessionId(provisionSessionId);
+                    componentAttributeRepository.save(componentAttributeResult);
+                    fieldValidation &= componentAttributeResult.checkMatchedStatus();
+                }
             }
             numOfAttributes = attributeResults.size();
         }
@@ -935,8 +939,13 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
         }
 
         if (!componentInfo.getComponentRevision().equals(componentResult.getRevisionNumber())) {
-            attributeResults.add(new ComponentAttributeResult(componentResult.getId(),
-                    componentResult.getRevisionNumber(), componentInfo.getComponentRevision()));
+            ComponentAttributeResult revisionAttribute = new ComponentAttributeResult(
+                    componentResult.getId(), componentResult.getRevisionNumber(),
+                    componentInfo.getComponentRevision());
+            // this could be a boolean, but then it is too specific to revision, this leaves it open
+            // for future changes
+            revisionAttribute.setAttribute(ComponentResult.ATTRIBUTE_REVISION);
+            attributeResults.add(revisionAttribute);
         }
 
         return attributeResults;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
@@ -266,13 +266,16 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
                 componentInfos, componentResults);
         int numOfAttributes = 0;
         if (!remainingComponentResults.isEmpty()) {
-
             List<ComponentAttributeResult> attributeResults = checkComponentClassMap(
                     componentInfos, remainingComponentResults);
-
+            boolean saveAttributeResult;
             for (ComponentAttributeResult componentAttributeResult : attributeResults) {
-                if (componentAttributeResult.getAttribute().equalsIgnoreCase(ComponentResult.ATTRIBUTE_REVISION)
-                        && !ignoreRevisionAttribute) {
+                 saveAttributeResult = true;
+                if (ignoreRevisionAttribute) {
+                   saveAttributeResult = !componentAttributeResult.getAttribute()
+                           .equalsIgnoreCase(ComponentResult.ATTRIBUTE_REVISION);
+                }
+                if (saveAttributeResult) {
                     componentAttributeResult.setProvisionSessionId(provisionSessionId);
                     componentAttributeRepository.save(componentAttributeResult);
                     fieldValidation &= componentAttributeResult.checkMatchedStatus();
@@ -372,11 +375,14 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
         if (!remainingComponentResults.isEmpty()) {
             List<ComponentAttributeResult> attributeResults = checkComponentClassMap(
                     componentInfos, remainingComponentResults);
-
+            boolean saveAttributeResult;
             for (ComponentAttributeResult componentAttributeResult : attributeResults) {
-                if (componentAttributeResult.getAttribute()
-                        .equalsIgnoreCase(ComponentResult.ATTRIBUTE_REVISION)
-                        && !ignoreRevisionAttribute) {
+                saveAttributeResult = true;
+                if (ignoreRevisionAttribute) {
+                    saveAttributeResult = !componentAttributeResult.getAttribute()
+                            .equalsIgnoreCase(ComponentResult.ATTRIBUTE_REVISION);
+                }
+                if (saveAttributeResult) {
                     componentAttributeResult.setProvisionSessionId(provisionSessionId);
                     componentAttributeRepository.save(componentAttributeResult);
                     fieldValidation &= componentAttributeResult.checkMatchedStatus();

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
@@ -12,12 +12,14 @@ import hirs.attestationca.persist.enums.AppraisalStatus;
 import lombok.extern.log4j.Log4j2;
 import org.bouncycastle.cert.X509AttributeCertificateHolder;
 
+import java.awt.*;
 import java.io.IOException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -264,10 +266,6 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
                 log.error(message);
                 return new AppraisalStatus(FAIL, message);
             }
-        }
-        if (componentInfos.isEmpty()) {
-            message = baseErrorMessage + "a list of device components";
-            return new AppraisalStatus(FAIL, message);
         }
 
         // parse out the provided delta and its specific chain.

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
@@ -268,6 +268,11 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
             }
         }
 
+        if (componentInfos.isEmpty()) {
+            message = baseErrorMessage + "a list of device components";
+            return new AppraisalStatus(FAIL, message);
+        }
+
         // parse out the provided delta and its specific chain.
         List<ComponentResult> origPcComponents = componentResultRepository
                 .findByCertificateSerialNumberAndBoardSerialNumber(

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
@@ -242,7 +242,7 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
             final List<ComponentInfo> componentInfos,
             final ComponentResultRepository componentResultRepository,
             final ComponentAttributeRepository componentAttributeRepository,
-            final UUID provisionSessionId) {
+            final UUID provisionSessionId, final boolean ignoreRevisionAttribute) {
         final String baseErrorMessage = "Can't validate platform credential attributes without ";
         String message;
 
@@ -282,6 +282,6 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
         return CertificateAttributeScvValidator.validateDeltaAttributesChainV2p0(
                 deviceInfoReport, deltaMapping, origPcComponents, componentInfos,
                 componentResultRepository,
-                componentAttributeRepository, provisionSessionId);
+                componentAttributeRepository, provisionSessionId, ignoreRevisionAttribute);
     }
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
@@ -12,14 +12,12 @@ import hirs.attestationca.persist.enums.AppraisalStatus;
 import lombok.extern.log4j.Log4j2;
 import org.bouncycastle.cert.X509AttributeCertificateHolder;
 
-import java.awt.*;
 import java.io.IOException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -173,7 +171,8 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
      * @param componentResultRepository db access to component result of mismatching
      * @param componentAttributeRepository  db access to component attribute match status
      * @param componentInfos list of device components
-     * @param provisionSessionId the session id to share
+     * @param provisionSessionId UUID associated with this run of the provision
+     * @param ignoreRevisionAttribute policy flag to ignore the revision attribute
      * @return The result of the validation.
      */
     public static AppraisalStatus validatePlatformCredentialAttributes(
@@ -183,7 +182,7 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
             final ComponentResultRepository componentResultRepository,
             final ComponentAttributeRepository componentAttributeRepository,
             final List<ComponentInfo> componentInfos,
-            final UUID provisionSessionId) {
+            final UUID provisionSessionId, final boolean ignoreRevisionAttribute) {
         final String baseErrorMessage = "Can't validate platform credential attributes without ";
         String message;
         if (platformCredential == null) {
@@ -215,7 +214,8 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
         if (PlatformCredential.CERTIFICATE_TYPE_2_0.equals(credentialType)) {
             return CertificateAttributeScvValidator.validatePlatformCredentialAttributesV2p0(
                     platformCredential, deviceInfoReport, componentResultRepository,
-                    componentAttributeRepository, componentInfos, provisionSessionId);
+                    componentAttributeRepository, componentInfos, provisionSessionId,
+                    ignoreRevisionAttribute);
         }
         return CertificateAttributeScvValidator.validatePlatformCredentialAttributesV1p2(
                 platformCredential, deviceInfoReport);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CredentialValidator.java
@@ -2,6 +2,8 @@ package hirs.attestationca.persist.validation;
 
 import hirs.attestationca.persist.entity.manager.ComponentAttributeRepository;
 import hirs.attestationca.persist.entity.manager.ComponentResultRepository;
+import hirs.attestationca.persist.entity.userdefined.SupplyChainValidation;
+import hirs.attestationca.persist.entity.userdefined.certificate.ComponentResult;
 import hirs.attestationca.persist.entity.userdefined.certificate.EndorsementCredential;
 import hirs.attestationca.persist.entity.userdefined.certificate.PlatformCredential;
 import hirs.attestationca.persist.entity.userdefined.info.ComponentInfo;
@@ -18,6 +20,7 @@ import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static hirs.attestationca.persist.enums.AppraisalStatus.Status.ERROR;
@@ -168,6 +171,7 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
      * @param componentResultRepository db access to component result of mismatching
      * @param componentAttributeRepository  db access to component attribute match status
      * @param componentInfos list of device components
+     * @param provisionSessionId the session id to share
      * @return The result of the validation.
      */
     public static AppraisalStatus validatePlatformCredentialAttributes(
@@ -213,5 +217,68 @@ public class CredentialValidator extends SupplyChainCredentialValidator {
         }
         return CertificateAttributeScvValidator.validatePlatformCredentialAttributesV1p2(
                 platformCredential, deviceInfoReport);
+    }
+
+    /**
+     * Checks if the delta credential's attributes are valid.
+     * @param deviceInfoReport The device info report containing
+     *                         serial number of the platform to be validated.
+     * @param basePlatformCredential the base credential from the same identity request
+     *      *                              as the delta credential.
+     * @param deltaMapping delta certificates associated with the
+     *      *                          delta supply validation.
+     * @param componentInfos list of device components
+     * @param componentResultRepository repository for component results
+     * @param componentAttributeRepository repository for the attribute status
+     * @param provisionSessionId the session id to share
+     * @return the result of the validation.
+     */
+    public static AppraisalStatus validateDeltaPlatformCredentialAttributes(
+            final DeviceInfoReport deviceInfoReport,
+            final PlatformCredential basePlatformCredential,
+            final Map<PlatformCredential, SupplyChainValidation> deltaMapping,
+            final List<ComponentInfo> componentInfos,
+            final ComponentResultRepository componentResultRepository,
+            final ComponentAttributeRepository componentAttributeRepository,
+            final UUID provisionSessionId) {
+        final String baseErrorMessage = "Can't validate platform credential attributes without ";
+        String message;
+
+        // this needs to be a loop for all deltas, link to issue #110
+        // check that they don't have the same serial number
+        for (PlatformCredential pc : deltaMapping.keySet()) {
+            if (!basePlatformCredential.getPlatformSerial()
+                    .equals(pc.getPlatformSerial())) {
+                message = String.format("Base and Delta platform serial "
+                                + "numbers do not match (%s != %s)",
+                        pc.getPlatformSerial(),
+                        basePlatformCredential.getPlatformSerial());
+                log.error(message);
+                return new AppraisalStatus(FAIL, message);
+            }
+            // none of the deltas should have the serial number of the base
+            if (!pc.isPlatformBase() && basePlatformCredential.getSerialNumber()
+                    .equals(pc.getSerialNumber())) {
+                message = String.format("Delta Certificate with same serial number as base. (%s)",
+                        pc.getSerialNumber());
+                log.error(message);
+                return new AppraisalStatus(FAIL, message);
+            }
+        }
+        if (componentInfos.isEmpty()) {
+            message = baseErrorMessage + "a list of device components";
+            return new AppraisalStatus(FAIL, message);
+        }
+
+        // parse out the provided delta and its specific chain.
+        List<ComponentResult> origPcComponents = componentResultRepository
+                .findByCertificateSerialNumberAndBoardSerialNumber(
+                        basePlatformCredential.getSerialNumber().toString(),
+                        basePlatformCredential.getPlatformSerial());
+
+        return CertificateAttributeScvValidator.validateDeltaAttributesChainV2p0(
+                deviceInfoReport, deltaMapping, origPcComponents, componentInfos,
+                componentResultRepository,
+                componentAttributeRepository, provisionSessionId);
     }
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
@@ -35,6 +35,15 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
 
     private static PcrValidator pcrValidator;
 
+    /**
+     *
+     * @param device
+     * @param policySettings
+     * @param referenceManifestRepository
+     * @param referenceDigestValueRepository
+     * @param caCredentialRepository
+     * @return
+     */
     @SuppressWarnings("methodlength")
     public static AppraisalStatus validateFirmware(
             final Device device, final PolicySettings policySettings,

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/PcrValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/PcrValidator.java
@@ -149,10 +149,12 @@ public class PcrValidator {
             } else {
                 if (policySettings.isIgnoreGptEnabled() && tpe.getEventTypeStr().contains(EVT_EFI_GPT)) {
                     log.info(String.format("GPT Ignored -> %s", tpe));
-                } else if (policySettings.isIgnoreOsEvtEnabled() && (tpe.getEventTypeStr().contains(EVT_EFI_BOOT)
+                } else if (policySettings.isIgnoreOsEvtEnabled() && (
+                        tpe.getEventTypeStr().contains(EVT_EFI_BOOT)
                         || tpe.getEventTypeStr().contains(EVT_EFI_VAR))) {
                     log.info(String.format("OS Evt Ignored -> %s", tpe));
-                } else if (policySettings.isIgnoreOsEvtEnabled() && (tpe.getEventTypeStr().contains(EVT_EFI_CFG)
+                } else if (policySettings.isIgnoreOsEvtEnabled() && (
+                        tpe.getEventTypeStr().contains(EVT_EFI_CFG)
                         && tpe.getEventContentStr().contains("SecureBoot"))) {
                     log.info(String.format("OS Evt Config Ignored -> %s", tpe));
                 } else {
@@ -208,12 +210,11 @@ public class PcrValidator {
                 tpmQuote, pcrComposite);
 
         try {
-            /**
-             * The calculated string is being used in the contains method
-             * because the TPM Quote's hash isn't just for PCR values,
-             * it contains the calculated digest of the PCRs, along with
-             * other information.
-             */
+
+              // The calculated string is being used in the contains method
+              // because the TPM Quote's hash isn't just for PCR values,
+              // it contains the calculated digest of the PCRs, along with
+              // other information.
             String calculatedString = Hex.encodeHexString(
                     pcrInfoShort.getCalculatedDigest());
             validated = quoteString.contains(calculatedString);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidator.java
@@ -38,6 +38,9 @@ import java.util.Set;
 @NoArgsConstructor
 public class SupplyChainCredentialValidator  {
 
+    /**
+     * used to identify and clear a nuc
+     */
     public static final int NUC_VARIABLE_BIT = 159;
     /**
      * AppraisalStatus message for a valid endorsement credential appraisal.
@@ -233,7 +236,8 @@ public class SupplyChainCredentialValidator  {
      * @throws SupplyChainValidatorException tried to validate using null certificates
      */
     public static String validateCertChain(final X509Certificate cert,
-                                           final Set<X509Certificate> additionalCerts) throws SupplyChainValidatorException {
+                                           final Set<X509Certificate> additionalCerts)
+            throws SupplyChainValidatorException {
         if (cert == null || additionalCerts == null) {
             throw new SupplyChainValidatorException(
                     "Certificate or validation certificates are null");
@@ -337,7 +341,8 @@ public class SupplyChainCredentialValidator  {
      * @throws SupplyChainValidatorException tried to validate using null certificates
      */
     public static boolean issuerMatchesSubjectDN(final X509AttributeCertificateHolder cert,
-                                                 final X509Certificate signingCert) throws SupplyChainValidatorException {
+                                                 final X509Certificate signingCert)
+            throws SupplyChainValidatorException {
         if (cert == null || signingCert == null) {
             throw new SupplyChainValidatorException("Certificate or signing certificate is null");
         }
@@ -362,7 +367,8 @@ public class SupplyChainCredentialValidator  {
      * @throws SupplyChainValidatorException tried to validate using null certificates
      */
     public static boolean issuerMatchesSubjectDN(final X509Certificate cert,
-                                                 final X509Certificate signingCert) throws SupplyChainValidatorException {
+                                                 final X509Certificate signingCert)
+            throws SupplyChainValidatorException {
         if (cert == null || signingCert == null) {
             throw new SupplyChainValidatorException("Certificate or signing certificate is null");
         }
@@ -389,7 +395,8 @@ public class SupplyChainCredentialValidator  {
      * @throws SupplyChainValidatorException tried to validate using null certificates
      */
     public static boolean signatureMatchesPublicKey(final X509Certificate cert,
-                                                    final X509Certificate signingCert) throws SupplyChainValidatorException {
+                                                    final X509Certificate signingCert)
+            throws SupplyChainValidatorException {
         if (cert == null || signingCert == null) {
             throw new SupplyChainValidatorException("Certificate or signing certificate is null");
         }
@@ -424,7 +431,8 @@ public class SupplyChainCredentialValidator  {
      * @throws SupplyChainValidatorException tried to validate using null certificates
      */
     public static boolean signatureMatchesPublicKey(final X509AttributeCertificateHolder cert,
-                                                    final X509Certificate signingCert) throws SupplyChainValidatorException {
+                                                    final X509Certificate signingCert)
+            throws SupplyChainValidatorException {
         if (signingCert == null) {
             throw new SupplyChainValidatorException("Signing certificate is null");
         }
@@ -442,7 +450,8 @@ public class SupplyChainCredentialValidator  {
      * @throws SupplyChainValidatorException tried to validate using null certificates
      */
     public static boolean signatureMatchesPublicKey(final X509AttributeCertificateHolder cert,
-                                                    final PublicKey signingKey) throws SupplyChainValidatorException {
+                                                    final PublicKey signingKey)
+            throws SupplyChainValidatorException {
         if (cert == null || signingKey == null) {
             throw new SupplyChainValidatorException("Certificate or signing certificate is null");
         }

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidatorTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidatorTest.java
@@ -1893,12 +1893,12 @@ public class SupplyChainCredentialValidatorTest {
                 SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
                 AppraisalStatus.Status.PASS, certsUsed, ""));
 
-        AppraisalStatus result = CertificateAttributeScvValidator
-                .validateDeltaPlatformCredentialAttributes(delta2,
-                        deviceInfoReport, base, chainCredentials);
-        assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
-        assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
-                result.getMessage());
+//        AppraisalStatus result = CredentialValidator
+//                .validateDeltaPlatformCredentialAttributes(delta2,
+//                        deviceInfoReport, base, chainCredentials);
+//        assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
+//        assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
+//                result.getMessage());
     }
 
     /**
@@ -2004,14 +2004,14 @@ public class SupplyChainCredentialValidatorTest {
                 SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
                 AppraisalStatus.Status.PASS, certsUsed, ""));
 
-        AppraisalStatus result = CertificateAttributeScvValidator
-                .validateDeltaPlatformCredentialAttributes(delta1,
-                        deviceInfoReport, base, chainCredentials);
-        assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
-        assertEquals("There are unmatched components:\n"
-                + "Manufacturer=Intel Corporation, Model=82580 Gigabit Network "
-                + "Connection-faulty, Serial=90:e2:ba:31:83:10, Revision=;\n",
-                result.getMessage());
+//        AppraisalStatus result = CredentialValidator
+//                .validateDeltaPlatformCredentialAttributes(delta1,
+//                        deviceInfoReport, base, chainCredentials);
+//        assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
+//        assertEquals("There are unmatched components:\n"
+//                + "Manufacturer=Intel Corporation, Model=82580 Gigabit Network "
+//                + "Connection-faulty, Serial=90:e2:ba:31:83:10, Revision=;\n",
+//                result.getMessage());
     }
 
     /**

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidatorTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidatorTest.java
@@ -1774,124 +1774,124 @@ public class SupplyChainCredentialValidatorTest {
 //    @Test
     public final void testValidateDeltaPlatformCredentialAttributes()
             throws IOException, URISyntaxException {
-        DeviceInfoReport deviceInfoReport = setupDeviceInfoReportWithComponents(
-                SAMPLE_PACCOR_OUTPUT_TXT);
+//        DeviceInfoReport deviceInfoReport = setupDeviceInfoReportWithComponents(
+//                SAMPLE_PACCOR_OUTPUT_TXT);
 
-        PlatformCredential base = mock(PlatformCredential.class);
-        PlatformCredential delta1 = mock(PlatformCredential.class);
-        PlatformCredential delta2 = mock(PlatformCredential.class);
-
-        ComponentIdentifierV2 compId1 = new ComponentIdentifierV2(
-                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
-                        .getResource(JSON_FILE)).toURI()), "0x00010002"),
-                new DERUTF8String("Intel"),
-                new DERUTF8String("Core i7"), new DERUTF8String("Not Specified"),
-                new DERUTF8String("Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz"), null,
-                ASN1Boolean.TRUE, new ArrayList<>(0), null, null,
-                null);
-        ComponentIdentifierV2 compId2 = new ComponentIdentifierV2(
-                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
-                        .getResource(JSON_FILE)).toURI()), "0x00050004"),
-                new DERUTF8String("Intel Corporation"),
-                new DERUTF8String("Ethernet Connection I217-V-faulty"),
-                new DERUTF8String("23:94:17:ba:86:5e"), new DERUTF8String("00"), null,
-                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
-                null);
-        ComponentIdentifierV2 compId3 = new ComponentIdentifierV2(
-                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
-                        .getResource(JSON_FILE)).toURI()), "0x00090002"),
-                new DERUTF8String("Intel Corporation"),
-                new DERUTF8String("82580 Gigabit Network Connection-faulty"),
-                new DERUTF8String("90:e2:ba:31:83:10"), new DERUTF8String(""), null,
-                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
-                null);
-        ComponentIdentifierV2 deltaCompId2 = new ComponentIdentifierV2(
-                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
-                        .getResource(JSON_FILE)).toURI()), "0x00050004"),
-                new DERUTF8String("Intel Corporation"),
-                new DERUTF8String("Ethernet Connection I217-V"),
-                new DERUTF8String("23:94:17:ba:86:5e"), new DERUTF8String("00"), null,
-                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
-                AttributeStatus.ADDED);
-        ComponentIdentifierV2 deltaCompId3 = new ComponentIdentifierV2(
-                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
-                        .getResource(JSON_FILE)).toURI()), "0x00090002"),
-                new DERUTF8String("Intel Corporation"),
-                new DERUTF8String("82580 Gigabit Network Connection"),
-                new DERUTF8String("90:e2:ba:31:83:10"), new DERUTF8String(""), null,
-                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
-                AttributeStatus.ADDED);
-
-        ComponentIdentifierV2 ciV21Faulty = new ComponentIdentifierV2();
-        ComponentIdentifierV2 ciV22Faulty = new ComponentIdentifierV2();
-        ciV21Faulty.setComponentManufacturer(compId2.getComponentManufacturer());
-        ciV21Faulty.setComponentClass(compId2.getComponentClass());
-        ciV21Faulty.setComponentModel(compId2.getComponentModel());
-        ciV21Faulty.setComponentSerial(compId2.getComponentSerial());
-        ciV21Faulty.setComponentRevision(compId2.getComponentRevision());
-        ciV21Faulty.setComponentManufacturerId(compId2.getComponentManufacturerId());
-        ciV21Faulty.setFieldReplaceable(compId2.getFieldReplaceable());
-        ciV21Faulty.setComponentAddress(compId2.getComponentAddress());
-        ciV21Faulty.setAttributeStatus(AttributeStatus.REMOVED);
-        ciV22Faulty.setComponentManufacturer(compId3.getComponentManufacturer());
-        ciV22Faulty.setComponentClass(compId3.getComponentClass());
-        ciV22Faulty.setComponentModel(compId3.getComponentModel());
-        ciV22Faulty.setComponentSerial(compId3.getComponentSerial());
-        ciV22Faulty.setComponentRevision(compId3.getComponentRevision());
-        ciV22Faulty.setComponentManufacturerId(compId3.getComponentManufacturerId());
-        ciV22Faulty.setFieldReplaceable(compId3.getFieldReplaceable());
-        ciV22Faulty.setComponentAddress(compId3.getComponentAddress());
-        ciV22Faulty.setAttributeStatus(AttributeStatus.REMOVED);
-
-        List<ComponentIdentifier> compList = new ArrayList<>(3);
-        compList.add(compId1);
-        compList.add(compId2);
-        compList.add(compId3);
-
-        List<ComponentIdentifier> delta1List = new ArrayList<>(2);
-        delta1List.add(ciV21Faulty);
-        delta1List.add(deltaCompId2);
-        List<ComponentIdentifier> delta2List = new ArrayList<>(2);
-        delta1List.add(ciV22Faulty);
-        delta1List.add(deltaCompId3);
-
-        when(base.isPlatformBase()).thenReturn(true);
-        when(delta1.isPlatformBase()).thenReturn(false);
-        when(delta2.isPlatformBase()).thenReturn(false);
-        when(base.getManufacturer()).thenReturn("innotek GmbH");
-        when(base.getModel()).thenReturn("VirtualBox");
-        when(base.getVersion()).thenReturn("1.2");
-        when(base.getPlatformSerial()).thenReturn("62UIAE5");
-        when(delta1.getPlatformSerial()).thenReturn("62UIAE5");
-        when(delta2.getPlatformSerial()).thenReturn("62UIAE5");
-        when(base.getPlatformChainType()).thenReturn("base");
-        when(delta1.getPlatformChainType()).thenReturn("delta");
-        when(delta2.getPlatformChainType()).thenReturn("delta");
-        when(base.getSerialNumber()).thenReturn(BigInteger.valueOf(01));
-        when(delta1.getSerialNumber()).thenReturn(BigInteger.valueOf(39821));
-        when(delta2.getSerialNumber()).thenReturn(BigInteger.valueOf(39822));
-        when(delta1.getHolderSerialNumber()).thenReturn(BigInteger.valueOf(02));
-        when(delta2.getHolderSerialNumber()).thenReturn(BigInteger.valueOf(39821));
-        when(base.getComponentIdentifiers()).thenReturn(compList);
-        when(delta1.getComponentIdentifiers()).thenReturn(delta1List);
-        when(delta2.getComponentIdentifiers()).thenReturn(delta2List);
-
-        Map<PlatformCredential, SupplyChainValidation> chainCredentials = new HashMap<>(0);
-        List<ArchivableEntity> certsUsed = new ArrayList<>();
-        certsUsed.add(base);
-        chainCredentials.put(base, new SupplyChainValidation(
-                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
-                AppraisalStatus.Status.PASS, certsUsed, ""));
-        certsUsed.clear();
-        certsUsed.add(delta1);
-        chainCredentials.put(delta1, new SupplyChainValidation(
-                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
-                AppraisalStatus.Status.PASS, certsUsed, ""));
-        certsUsed.clear();
-        certsUsed.add(delta2);
-        chainCredentials.put(delta2, new SupplyChainValidation(
-                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
-                AppraisalStatus.Status.PASS, certsUsed, ""));
+//        PlatformCredential base = mock(PlatformCredential.class);
+//        PlatformCredential delta1 = mock(PlatformCredential.class);
+//        PlatformCredential delta2 = mock(PlatformCredential.class);
+//
+//        ComponentIdentifierV2 compId1 = new ComponentIdentifierV2(
+//                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
+//                        .getResource(JSON_FILE)).toURI()), "0x00010002"),
+//                new DERUTF8String("Intel"),
+//                new DERUTF8String("Core i7"), new DERUTF8String("Not Specified"),
+//                new DERUTF8String("Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz"), null,
+//                ASN1Boolean.TRUE, new ArrayList<>(0), null, null,
+//                null);
+//        ComponentIdentifierV2 compId2 = new ComponentIdentifierV2(
+//                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
+//                        .getResource(JSON_FILE)).toURI()), "0x00050004"),
+//                new DERUTF8String("Intel Corporation"),
+//                new DERUTF8String("Ethernet Connection I217-V-faulty"),
+//                new DERUTF8String("23:94:17:ba:86:5e"), new DERUTF8String("00"), null,
+//                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
+//                null);
+//        ComponentIdentifierV2 compId3 = new ComponentIdentifierV2(
+//                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
+//                        .getResource(JSON_FILE)).toURI()), "0x00090002"),
+//                new DERUTF8String("Intel Corporation"),
+//                new DERUTF8String("82580 Gigabit Network Connection-faulty"),
+//                new DERUTF8String("90:e2:ba:31:83:10"), new DERUTF8String(""), null,
+//                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
+//                null);
+//        ComponentIdentifierV2 deltaCompId2 = new ComponentIdentifierV2(
+//                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
+//                        .getResource(JSON_FILE)).toURI()), "0x00050004"),
+//                new DERUTF8String("Intel Corporation"),
+//                new DERUTF8String("Ethernet Connection I217-V"),
+//                new DERUTF8String("23:94:17:ba:86:5e"), new DERUTF8String("00"), null,
+//                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
+//                AttributeStatus.ADDED);
+//        ComponentIdentifierV2 deltaCompId3 = new ComponentIdentifierV2(
+//                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
+//                        .getResource(JSON_FILE)).toURI()), "0x00090002"),
+//                new DERUTF8String("Intel Corporation"),
+//                new DERUTF8String("82580 Gigabit Network Connection"),
+//                new DERUTF8String("90:e2:ba:31:83:10"), new DERUTF8String(""), null,
+//                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
+//                AttributeStatus.ADDED);
+//
+//        ComponentIdentifierV2 ciV21Faulty = new ComponentIdentifierV2();
+//        ComponentIdentifierV2 ciV22Faulty = new ComponentIdentifierV2();
+//        ciV21Faulty.setComponentManufacturer(compId2.getComponentManufacturer());
+//        ciV21Faulty.setComponentClass(compId2.getComponentClass());
+//        ciV21Faulty.setComponentModel(compId2.getComponentModel());
+//        ciV21Faulty.setComponentSerial(compId2.getComponentSerial());
+//        ciV21Faulty.setComponentRevision(compId2.getComponentRevision());
+//        ciV21Faulty.setComponentManufacturerId(compId2.getComponentManufacturerId());
+//        ciV21Faulty.setFieldReplaceable(compId2.getFieldReplaceable());
+//        ciV21Faulty.setComponentAddress(compId2.getComponentAddress());
+//        ciV21Faulty.setAttributeStatus(AttributeStatus.REMOVED);
+//        ciV22Faulty.setComponentManufacturer(compId3.getComponentManufacturer());
+//        ciV22Faulty.setComponentClass(compId3.getComponentClass());
+//        ciV22Faulty.setComponentModel(compId3.getComponentModel());
+//        ciV22Faulty.setComponentSerial(compId3.getComponentSerial());
+//        ciV22Faulty.setComponentRevision(compId3.getComponentRevision());
+//        ciV22Faulty.setComponentManufacturerId(compId3.getComponentManufacturerId());
+//        ciV22Faulty.setFieldReplaceable(compId3.getFieldReplaceable());
+//        ciV22Faulty.setComponentAddress(compId3.getComponentAddress());
+//        ciV22Faulty.setAttributeStatus(AttributeStatus.REMOVED);
+//
+//        List<ComponentIdentifier> compList = new ArrayList<>(3);
+//        compList.add(compId1);
+//        compList.add(compId2);
+//        compList.add(compId3);
+//
+//        List<ComponentIdentifier> delta1List = new ArrayList<>(2);
+//        delta1List.add(ciV21Faulty);
+//        delta1List.add(deltaCompId2);
+//        List<ComponentIdentifier> delta2List = new ArrayList<>(2);
+//        delta1List.add(ciV22Faulty);
+//        delta1List.add(deltaCompId3);
+//
+//        when(base.isPlatformBase()).thenReturn(true);
+//        when(delta1.isPlatformBase()).thenReturn(false);
+//        when(delta2.isPlatformBase()).thenReturn(false);
+//        when(base.getManufacturer()).thenReturn("innotek GmbH");
+//        when(base.getModel()).thenReturn("VirtualBox");
+//        when(base.getVersion()).thenReturn("1.2");
+//        when(base.getPlatformSerial()).thenReturn("62UIAE5");
+//        when(delta1.getPlatformSerial()).thenReturn("62UIAE5");
+//        when(delta2.getPlatformSerial()).thenReturn("62UIAE5");
+//        when(base.getPlatformChainType()).thenReturn("base");
+//        when(delta1.getPlatformChainType()).thenReturn("delta");
+//        when(delta2.getPlatformChainType()).thenReturn("delta");
+//        when(base.getSerialNumber()).thenReturn(BigInteger.valueOf(01));
+//        when(delta1.getSerialNumber()).thenReturn(BigInteger.valueOf(39821));
+//        when(delta2.getSerialNumber()).thenReturn(BigInteger.valueOf(39822));
+//        when(delta1.getHolderSerialNumber()).thenReturn(BigInteger.valueOf(02));
+//        when(delta2.getHolderSerialNumber()).thenReturn(BigInteger.valueOf(39821));
+//        when(base.getComponentIdentifiers()).thenReturn(compList);
+//        when(delta1.getComponentIdentifiers()).thenReturn(delta1List);
+//        when(delta2.getComponentIdentifiers()).thenReturn(delta2List);
+//
+//        Map<PlatformCredential, SupplyChainValidation> chainCredentials = new HashMap<>(0);
+//        List<ArchivableEntity> certsUsed = new ArrayList<>();
+//        certsUsed.add(base);
+//        chainCredentials.put(base, new SupplyChainValidation(
+//                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
+//                AppraisalStatus.Status.PASS, certsUsed, ""));
+//        certsUsed.clear();
+//        certsUsed.add(delta1);
+//        chainCredentials.put(delta1, new SupplyChainValidation(
+//                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
+//                AppraisalStatus.Status.PASS, certsUsed, ""));
+//        certsUsed.clear();
+//        certsUsed.add(delta2);
+//        chainCredentials.put(delta2, new SupplyChainValidation(
+//                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
+//                AppraisalStatus.Status.PASS, certsUsed, ""));
 
 //        AppraisalStatus result = CredentialValidator
 //                .validateDeltaPlatformCredentialAttributes(delta2,
@@ -1910,99 +1910,99 @@ public class SupplyChainCredentialValidatorTest {
 //    @Test
     public final void testValidateChainFailure()
             throws IOException, URISyntaxException {
-        DeviceInfoReport deviceInfoReport = setupDeviceInfoReportWithComponents(
-                SAMPLE_PACCOR_OUTPUT_TXT);
+//        DeviceInfoReport deviceInfoReport = setupDeviceInfoReportWithComponents(
+//                SAMPLE_PACCOR_OUTPUT_TXT);
 
-        PlatformCredential base = mock(PlatformCredential.class);
-        PlatformCredential delta1 = mock(PlatformCredential.class);
-
-        ComponentIdentifierV2 compId1 = new ComponentIdentifierV2(
-                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
-                        .getResource(JSON_FILE)).toURI()), "0x00010002"),
-                new DERUTF8String("Intel"),
-                new DERUTF8String("Core i7"), new DERUTF8String("Not Specified"),
-                new DERUTF8String("Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz"), null,
-                ASN1Boolean.TRUE, new ArrayList<>(0), null, null,
-                null);
-        ComponentIdentifierV2 compId2 = new ComponentIdentifierV2(
-                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
-                        .getResource(JSON_FILE)).toURI()), "0x00050004"),
-                new DERUTF8String("Intel Corporation"),
-                new DERUTF8String("Ethernet Connection I217-V-faulty"),
-                new DERUTF8String("23:94:17:ba:86:5e"), new DERUTF8String("00"), null,
-                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
-                null);
-        ComponentIdentifierV2 compId3 = new ComponentIdentifierV2(
-                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
-                        .getResource(JSON_FILE)).toURI()), "0x00090002"),
-                new DERUTF8String("Intel Corporation"),
-                new DERUTF8String("82580 Gigabit Network Connection-faulty"),
-                new DERUTF8String("90:e2:ba:31:83:10"), new DERUTF8String(""), null,
-                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
-                null);
-        ComponentIdentifierV2 deltaCompId2 = new ComponentIdentifierV2(
-                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
-                        .getResource(JSON_FILE)).toURI()), "0x00050004"),
-                new DERUTF8String("Intel Corporation"),
-                new DERUTF8String("Ethernet Connection I217-V"),
-                new DERUTF8String("23:94:17:ba:86:5e"), new DERUTF8String("00"), null,
-                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
-                AttributeStatus.ADDED);
-
-        ComponentIdentifierV2 ciV21Faulty = new ComponentIdentifierV2();
-        ComponentIdentifierV2 ciV22Faulty = new ComponentIdentifierV2();
-        ciV21Faulty.setComponentManufacturer(compId2.getComponentManufacturer());
-        ciV21Faulty.setComponentModel(compId2.getComponentModel());
-        ciV21Faulty.setComponentSerial(compId2.getComponentSerial());
-        ciV21Faulty.setComponentRevision(compId2.getComponentRevision());
-        ciV21Faulty.setComponentManufacturerId(compId2.getComponentManufacturerId());
-        ciV21Faulty.setFieldReplaceable(compId2.getFieldReplaceable());
-        ciV21Faulty.setComponentAddress(compId2.getComponentAddress());
-        ciV21Faulty.setAttributeStatus(AttributeStatus.REMOVED);
-        ciV22Faulty.setComponentManufacturer(compId3.getComponentManufacturer());
-        ciV22Faulty.setComponentModel(compId3.getComponentModel());
-        ciV22Faulty.setComponentSerial(compId3.getComponentSerial());
-        ciV22Faulty.setComponentRevision(compId3.getComponentRevision());
-        ciV22Faulty.setComponentManufacturerId(compId3.getComponentManufacturerId());
-        ciV22Faulty.setFieldReplaceable(compId3.getFieldReplaceable());
-        ciV22Faulty.setComponentAddress(compId3.getComponentAddress());
-        ciV22Faulty.setAttributeStatus(AttributeStatus.REMOVED);
-
-        List<ComponentIdentifier> compList = new ArrayList<>(3);
-        compList.add(compId1);
-        compList.add(compId2);
-        compList.add(compId3);
-
-        List<ComponentIdentifier> delta1List = new ArrayList<>(2);
-        delta1List.add(ciV21Faulty);
-        delta1List.add(deltaCompId2);
-
-        when(base.isPlatformBase()).thenReturn(true);
-        when(delta1.isPlatformBase()).thenReturn(false);
-        when(base.getManufacturer()).thenReturn("innotek GmbH");
-        when(base.getModel()).thenReturn("VirtualBox");
-        when(base.getVersion()).thenReturn("1.2");
-        when(base.getPlatformSerial()).thenReturn("0");
-        when(delta1.getPlatformSerial()).thenReturn("0");
-        when(base.getPlatformChainType()).thenReturn("base");
-        when(delta1.getPlatformChainType()).thenReturn("delta");
-        when(base.getSerialNumber()).thenReturn(BigInteger.ZERO);
-        when(delta1.getSerialNumber()).thenReturn(BigInteger.ONE);
-        when(delta1.getHolderSerialNumber()).thenReturn(BigInteger.ZERO);
-        when(base.getComponentIdentifiers()).thenReturn(compList);
-        when(delta1.getComponentIdentifiers()).thenReturn(delta1List);
-
-        Map<PlatformCredential, SupplyChainValidation> chainCredentials = new HashMap<>(0);
-        List<ArchivableEntity> certsUsed = new ArrayList<>();
-        certsUsed.add(base);
-        chainCredentials.put(base, new SupplyChainValidation(
-                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
-                AppraisalStatus.Status.PASS, certsUsed, ""));
-        certsUsed.clear();
-        certsUsed.add(delta1);
-        chainCredentials.put(delta1, new SupplyChainValidation(
-                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
-                AppraisalStatus.Status.PASS, certsUsed, ""));
+//        PlatformCredential base = mock(PlatformCredential.class);
+//        PlatformCredential delta1 = mock(PlatformCredential.class);
+//
+//        ComponentIdentifierV2 compId1 = new ComponentIdentifierV2(
+//                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
+//                        .getResource(JSON_FILE)).toURI()), "0x00010002"),
+//                new DERUTF8String("Intel"),
+//                new DERUTF8String("Core i7"), new DERUTF8String("Not Specified"),
+//                new DERUTF8String("Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz"), null,
+//                ASN1Boolean.TRUE, new ArrayList<>(0), null, null,
+//                null);
+//        ComponentIdentifierV2 compId2 = new ComponentIdentifierV2(
+//                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
+//                        .getResource(JSON_FILE)).toURI()), "0x00050004"),
+//                new DERUTF8String("Intel Corporation"),
+//                new DERUTF8String("Ethernet Connection I217-V-faulty"),
+//                new DERUTF8String("23:94:17:ba:86:5e"), new DERUTF8String("00"), null,
+//                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
+//                null);
+//        ComponentIdentifierV2 compId3 = new ComponentIdentifierV2(
+//                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
+//                        .getResource(JSON_FILE)).toURI()), "0x00090002"),
+//                new DERUTF8String("Intel Corporation"),
+//                new DERUTF8String("82580 Gigabit Network Connection-faulty"),
+//                new DERUTF8String("90:e2:ba:31:83:10"), new DERUTF8String(""), null,
+//                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
+//                null);
+//        ComponentIdentifierV2 deltaCompId2 = new ComponentIdentifierV2(
+//                new ComponentClass(Paths.get(Objects.requireNonNull(this.getClass()
+//                        .getResource(JSON_FILE)).toURI()), "0x00050004"),
+//                new DERUTF8String("Intel Corporation"),
+//                new DERUTF8String("Ethernet Connection I217-V"),
+//                new DERUTF8String("23:94:17:ba:86:5e"), new DERUTF8String("00"), null,
+//                ASN1Boolean.FALSE, new ArrayList<>(0), null, null,
+//                AttributeStatus.ADDED);
+//
+//        ComponentIdentifierV2 ciV21Faulty = new ComponentIdentifierV2();
+//        ComponentIdentifierV2 ciV22Faulty = new ComponentIdentifierV2();
+//        ciV21Faulty.setComponentManufacturer(compId2.getComponentManufacturer());
+//        ciV21Faulty.setComponentModel(compId2.getComponentModel());
+//        ciV21Faulty.setComponentSerial(compId2.getComponentSerial());
+//        ciV21Faulty.setComponentRevision(compId2.getComponentRevision());
+//        ciV21Faulty.setComponentManufacturerId(compId2.getComponentManufacturerId());
+//        ciV21Faulty.setFieldReplaceable(compId2.getFieldReplaceable());
+//        ciV21Faulty.setComponentAddress(compId2.getComponentAddress());
+//        ciV21Faulty.setAttributeStatus(AttributeStatus.REMOVED);
+//        ciV22Faulty.setComponentManufacturer(compId3.getComponentManufacturer());
+//        ciV22Faulty.setComponentModel(compId3.getComponentModel());
+//        ciV22Faulty.setComponentSerial(compId3.getComponentSerial());
+//        ciV22Faulty.setComponentRevision(compId3.getComponentRevision());
+//        ciV22Faulty.setComponentManufacturerId(compId3.getComponentManufacturerId());
+//        ciV22Faulty.setFieldReplaceable(compId3.getFieldReplaceable());
+//        ciV22Faulty.setComponentAddress(compId3.getComponentAddress());
+//        ciV22Faulty.setAttributeStatus(AttributeStatus.REMOVED);
+//
+//        List<ComponentIdentifier> compList = new ArrayList<>(3);
+//        compList.add(compId1);
+//        compList.add(compId2);
+//        compList.add(compId3);
+//
+//        List<ComponentIdentifier> delta1List = new ArrayList<>(2);
+//        delta1List.add(ciV21Faulty);
+//        delta1List.add(deltaCompId2);
+//
+//        when(base.isPlatformBase()).thenReturn(true);
+//        when(delta1.isPlatformBase()).thenReturn(false);
+//        when(base.getManufacturer()).thenReturn("innotek GmbH");
+//        when(base.getModel()).thenReturn("VirtualBox");
+//        when(base.getVersion()).thenReturn("1.2");
+//        when(base.getPlatformSerial()).thenReturn("0");
+//        when(delta1.getPlatformSerial()).thenReturn("0");
+//        when(base.getPlatformChainType()).thenReturn("base");
+//        when(delta1.getPlatformChainType()).thenReturn("delta");
+//        when(base.getSerialNumber()).thenReturn(BigInteger.ZERO);
+//        when(delta1.getSerialNumber()).thenReturn(BigInteger.ONE);
+//        when(delta1.getHolderSerialNumber()).thenReturn(BigInteger.ZERO);
+//        when(base.getComponentIdentifiers()).thenReturn(compList);
+//        when(delta1.getComponentIdentifiers()).thenReturn(delta1List);
+//
+//        Map<PlatformCredential, SupplyChainValidation> chainCredentials = new HashMap<>(0);
+//        List<ArchivableEntity> certsUsed = new ArrayList<>();
+//        certsUsed.add(base);
+//        chainCredentials.put(base, new SupplyChainValidation(
+//                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
+//                AppraisalStatus.Status.PASS, certsUsed, ""));
+//        certsUsed.clear();
+//        certsUsed.add(delta1);
+//        chainCredentials.put(delta1, new SupplyChainValidation(
+//                SupplyChainValidation.ValidationType.PLATFORM_CREDENTIAL,
+//                AppraisalStatus.Status.PASS, certsUsed, ""));
 
 //        AppraisalStatus result = CredentialValidator
 //                .validateDeltaPlatformCredentialAttributes(delta1,

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidatorTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/validation/SupplyChainCredentialValidatorTest.java
@@ -345,7 +345,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -377,7 +377,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                Collections.emptyList(), UUID.randomUUID());
+                Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -408,7 +408,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -441,7 +441,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -473,7 +473,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -504,7 +504,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -535,7 +535,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc,
                         deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -570,7 +570,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(
                         pc, deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals(expectedMessage, result.getMessage());
     }
@@ -603,7 +603,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(
                         pc, deviceInfoReport, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals(expectedMessage, result.getMessage());
     }
@@ -984,7 +984,7 @@ public class SupplyChainCredentialValidatorTest {
 
         AppraisalStatus result =
                 CredentialValidator.validatePlatformCredentialAttributes(pc, null, ec, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals(expectedMessage, result.getMessage());
     }
@@ -1241,7 +1241,7 @@ public class SupplyChainCredentialValidatorTest {
 
         AppraisalStatus appraisalStatus = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential, deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS,
                 appraisalStatus.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
@@ -1261,7 +1261,7 @@ public class SupplyChainCredentialValidatorTest {
 
         AppraisalStatus appraisalStatus = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential, deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, appraisalStatus.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 appraisalStatus.getMessage());
@@ -1283,7 +1283,7 @@ public class SupplyChainCredentialValidatorTest {
 
         AppraisalStatus appraisalStatus = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential, deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, appraisalStatus.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 appraisalStatus.getMessage());
@@ -1307,7 +1307,7 @@ public class SupplyChainCredentialValidatorTest {
 
         AppraisalStatus appraisalStatus = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential, deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, appraisalStatus.getAppStatus());
     }
 
@@ -1324,7 +1324,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1332,7 +1332,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Platform manufacturer did not match\n", result.getMessage());
 
@@ -1340,7 +1340,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1348,7 +1348,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(result.getAppStatus(), AppraisalStatus.Status.FAIL);
         assertEquals(result.getMessage(), "Platform model did not match\n");
 
@@ -1356,7 +1356,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1364,13 +1364,13 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         platformCredential = setupMatchingPlatformCredential(deviceInfoReport);
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1378,7 +1378,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1387,7 +1387,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1398,7 +1398,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component manufacturer is empty\n", result.getMessage());
 
@@ -1406,7 +1406,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1416,7 +1416,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component model is empty\n", result.getMessage());
 
@@ -1436,7 +1436,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1444,7 +1444,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Platform manufacturer did not match\n", result.getMessage());
 
@@ -1452,7 +1452,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1460,7 +1460,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Platform model did not match\n", result.getMessage());
 
@@ -1468,7 +1468,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1476,7 +1476,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Platform serial did not match\n", result.getMessage());
 
@@ -1484,7 +1484,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                Collections.emptyList(), UUID.randomUUID());
+                Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1492,7 +1492,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Platform version did not match\n", result.getMessage());
 
@@ -1500,7 +1500,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1511,7 +1511,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component manufacturer is empty\n"
                 + "There are unmatched components:\n"
@@ -1523,7 +1523,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1533,7 +1533,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component model is empty\n", result.getMessage());
     }
@@ -1552,7 +1552,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1574,7 +1574,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("There are unmatched components:\n"
                 + "Manufacturer=ACME, Model=TNT, Serial=2, Revision=1.1;\n",
@@ -1600,7 +1600,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1608,7 +1608,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1628,7 +1628,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1641,7 +1641,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component manufacturer is empty\n"
                 + "There are unmatched components:\n"
@@ -1653,7 +1653,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1665,7 +1665,7 @@ public class SupplyChainCredentialValidatorTest {
         result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.FAIL, result.getAppStatus());
         assertEquals("Component model is empty\n", result.getMessage());
     }
@@ -1695,7 +1695,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1726,7 +1726,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());
@@ -1759,7 +1759,7 @@ public class SupplyChainCredentialValidatorTest {
         AppraisalStatus result = CertificateAttributeScvValidator
                 .validatePlatformCredentialAttributesV2p0(platformCredential,
                         deviceInfoReport, null, null,
-                        Collections.emptyList(), UUID.randomUUID());
+                        Collections.emptyList(), UUID.randomUUID(), false);
         assertEquals(AppraisalStatus.Status.PASS, result.getAppStatus());
         assertEquals(SupplyChainCredentialValidator.PLATFORM_ATTRIBUTES_VALID,
                 result.getMessage());

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/PolicyPageModel.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/PolicyPageModel.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 
 /**
  * PolicyPage model object to demonstrate data exchange between policy.jsp page
- * form form and controller.
+ * form and controller.
  */
 @Setter
 @Getter
@@ -19,6 +19,7 @@ public class PolicyPageModel {
     private boolean enableEcValidation;
     private boolean enablePcCertificateValidation;
     private boolean enablePcCertificateAttributeValidation;
+    private boolean enableIgnoreRevisionAttribute;
     private boolean enableFirmwareValidation;
     private boolean issueAttestationCertificate;
     private boolean issueDevIdCertificate;
@@ -32,6 +33,7 @@ public class PolicyPageModel {
     // Variables to get policy settings from page
     private String pcValidate;
     private String pcAttributeValidate;
+    private String ignoreRevisionAttribute;
     private String ecValidate;
     private String fmValidate;
     private String attestationCertificateIssued;
@@ -59,6 +61,7 @@ public class PolicyPageModel {
         this.enableEcValidation = policy.isEcValidationEnabled();
         this.enablePcCertificateValidation = policy.isPcValidationEnabled();
         this.enablePcCertificateAttributeValidation = policy.isPcAttributeValidationEnabled();
+        this.enableIgnoreRevisionAttribute = policy.isIgnoreRevisionEnabled();
         this.enableFirmwareValidation = policy.isFirmwareValidationEnabled();
         this.issueAttestationCertificate = policy.isIssueAttestationCertificate();
         this.issueDevIdCertificate = policy.isIssueDevIdCertificate();

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
@@ -973,9 +973,9 @@ public class CertificatePageController extends PageController<NoPageParams> {
         log.error(failMessage);
     }
 
-    private int handlePlatformComponents(final Certificate certificate) {
+    private void handlePlatformComponents(final Certificate certificate) {
         PlatformCredential platformCredential;
-        int componentResults = 0;
+
         if (certificate instanceof PlatformCredential) {
             platformCredential = (PlatformCredential) certificate;
             ComponentResult componentResult;
@@ -987,10 +987,8 @@ public class CertificatePageController extends PageController<NoPageParams> {
                         platformCredential.getPlatformChainType(),
                         componentIdentifier);
                 componentResultRepository.save(componentResult);
-                componentResults++;
             }
         }
-        return componentResults;
     }
 
     private void deleteComponentResults(final String platformSerial) {

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
@@ -983,13 +983,16 @@ public class CertificatePageController extends PageController<NoPageParams> {
                             platformCredential.getSerialNumber().toString(),
                             platformCredential.getPlatformSerial());
             if (componentResults.isEmpty()) {
+                ComponentResult componentResult;
                 for (ComponentIdentifier componentIdentifier : platformCredential
                         .getComponentIdentifiers()) {
-                    componentResultRepository.save(
-                            new ComponentResult(platformCredential.getPlatformSerial(),
+                    componentResult = new ComponentResult(platformCredential.getPlatformSerial(),
                             platformCredential.getSerialNumber().toString(),
                             platformCredential.getPlatformChainType(),
-                            componentIdentifier));
+                            componentIdentifier);
+                    componentResult.setFailedValidation(false);
+                    componentResult.setDelta(!platformCredential.isPlatformBase());
+                    componentResultRepository.save(componentResult);
                 }
             } else {
                 for (ComponentResult componentResult : componentResults) {

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificatePageController.java
@@ -978,15 +978,25 @@ public class CertificatePageController extends PageController<NoPageParams> {
 
         if (certificate instanceof PlatformCredential) {
             platformCredential = (PlatformCredential) certificate;
-            ComponentResult componentResult;
-            for (ComponentIdentifier componentIdentifier : platformCredential
-                    .getComponentIdentifiers()) {
-
-                componentResult = new ComponentResult(platformCredential.getPlatformSerial(),
-                        platformCredential.getSerialNumber().toString(),
-                        platformCredential.getPlatformChainType(),
-                        componentIdentifier);
-                componentResultRepository.save(componentResult);
+            List<ComponentResult> componentResults = componentResultRepository
+                    .findByCertificateSerialNumberAndBoardSerialNumber(
+                            platformCredential.getSerialNumber().toString(),
+                            platformCredential.getPlatformSerial());
+            if (componentResults.isEmpty()) {
+                for (ComponentIdentifier componentIdentifier : platformCredential
+                        .getComponentIdentifiers()) {
+                    componentResultRepository.save(
+                            new ComponentResult(platformCredential.getPlatformSerial(),
+                            platformCredential.getSerialNumber().toString(),
+                            platformCredential.getPlatformChainType(),
+                            componentIdentifier));
+                }
+            } else {
+                for (ComponentResult componentResult : componentResults) {
+                    componentResult.restore();
+                    componentResult.resetCreateTime();
+                    componentResultRepository.save(componentResult);
+                }
             }
         }
     }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/IndexPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/IndexPageController.java
@@ -14,7 +14,8 @@ import org.springframework.web.servlet.ModelAndView;
  */
 @Controller
 @Log4j2
-@RequestMapping(value={"/", "/HIRS_AttestationCAPortal", "/HIRS_AttestationCAPortal/", "/HIRS_AttestationCAPortal/portal/index"})
+@RequestMapping(value = {"/", "/HIRS_AttestationCAPortal",
+        "/HIRS_AttestationCAPortal/", "/HIRS_AttestationCAPortal/portal/index"})
 public class IndexPageController extends PageController<NoPageParams> {
 
     /**

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -366,7 +366,9 @@ public final class CertificateStringMapBuilder {
             data.put("CPSuri", certificate.getCPSuri());
             //Component Identifier - attempt to translate hardware IDs
             List<ComponentResult> compResults = componentResultRepository
-                    .findByBoardSerialNumber(certificate.getPlatformSerial());
+                    .findByCertificateSerialNumberAndBoardSerialNumber(
+                            certificate.getSerialNumber().toString(),
+                            certificate.getPlatformSerial());
             if (PciIds.DB.isReady()) {
                 compResults = PciIds.translateResults(compResults);
             }

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
@@ -653,16 +653,12 @@
                                                                         <span class="fieldValue">${address.getAddressValueString()}</span><br/>
                                                                     </c:forEach>
                                                                     <c:choose>
-                                                                        <c:when test="${component.isDelta()}">
-                                                                             <c:choose>
-                                                                                 <c:when test="${component.isFieldReplaceable()=='TRUE'}">
-                                                                                       <span class="label label-success">Replaceable</span><br/>
-                                                                                  </c:when>
-                                                                                  <c:otherwise>
-                                                                                       <span class="label label-danger">Irreplaceable</span><br/>
-                                                                                  </c:otherwise>
-                                                                             </c:choose>
-                                                                        </c:when>
+                                                                       <c:when test="${component.isFieldReplaceable()=='TRUE'}">
+                                                                           <span class="label label-success">Replaceable</span><br/>
+                                                                       </c:when>
+                                                                       <c:otherwise>
+                                                                           <span class="label label-danger">Irreplaceable</span><br/>
+                                                                       </c:otherwise>
                                                                     </c:choose>
                                                                     <c:if test="${component.isVersion2()}">
                                                                         <c:if test="${not empty component.getIssuerDN()}">

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
@@ -653,12 +653,16 @@
                                                                         <span class="fieldValue">${address.getAddressValueString()}</span><br/>
                                                                     </c:forEach>
                                                                     <c:choose>
-                                                                        <c:when test="${component.isFieldReplaceable()=='TRUE'}">
-                                                                            <span class="label label-success">Replaceable</span><br/>
+                                                                        <c:when test="${component.isDelta()}">
+                                                                             <c:choose>
+                                                                                 <c:when test="${component.isFieldReplaceable()=='TRUE'}">
+                                                                                       <span class="label label-success">Replaceable</span><br/>
+                                                                                  </c:when>
+                                                                                  <c:otherwise>
+                                                                                       <span class="label label-danger">Irreplaceable</span><br/>
+                                                                                  </c:otherwise>
+                                                                             </c:choose>
                                                                         </c:when>
-                                                                        <c:otherwise>
-                                                                            <span class="label label-danger">Irreplaceable</span><br/>
-                                                                        </c:otherwise>
                                                                     </c:choose>
                                                                     <c:if test="${component.isVersion2()}">
                                                                         <c:if test="${not empty component.getIssuerDN()}">

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/policy.jsp
@@ -58,8 +58,22 @@
                                 </div>
                             </my:editor>
                         </li>
-                    </ul>
                 </form:form>
+                        <form:form method="POST" modelAttribute="initialData" action="policy/update-revision-ignore">
+                            <ul>
+                                <li>Ignore Component Revision Attribute: ${initialData.enableIgnoreRevisionAttribute ? 'Enabled' : 'Disabled'}
+                                    <my:editor id="ignoreRevisionPolicyEditor" label="Edit Settings">
+                                        <div class="radio">
+                                          <label><input id="revisionTop" type="radio" name="ignoreRevisionAttribute" ${initialData.enableIgnoreRevisionAttribute ? 'checked' : ''} value="checked"/> Ignore Component Revision Attribute enabled</label>
+                                        </div>
+                                        <div class="radio">
+                                          <label><input id="revisionBot" type="radio" name="ignoreRevisionAttribute" ${initialData.enableIgnoreRevisionAttribute ? '' : 'checked'}  value="unchecked"/> Ignore Component Revision Attribute disabled</label>
+                                        </div>
+                                    </my:editor>
+                                </li>
+                            </ul>
+                        </form:form>
+                    </ul>
             </div>
 
             <%-- Firmware validation --%>


### PR DESCRIPTION
This is a combined PR for #732 and #730.  There is a linger issue that will be noted in #705 with the delta comparison.

This is a continuation of the PR for #723  and issue #705 . These changes set up fixing the delta part of the provisioning of the attributes.

This is the second part which covers the delta portion of this code.

Issue #707 from 
PR #732 
![image](https://github.com/nsacyber/HIRS/assets/24922493/6f51f948-3792-44fa-a329-2b68a7e4ae08)

Added UI features and back end code to handle the new policy which doesn't include the revision comparison as part of the final validation pass/fail.

this closes #707 