### PR TITLE
[#745] Adding GZIP compression to Tomcat server

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/resources/application.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.properties
@@ -12,7 +12,7 @@ jakarta.persistence.sharedCache.mode = UNSPECIFIED
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 
 # Tomcat Config
-server.tomcat.additional-tld-skip-patterns=jakarta.persistence-api*.jar, jakarta.xml.bind-api*.jar, txw2*.jar, *commons*.jar,  *annotations*.jar, *checker*.jar, *lombok*.jar, *jsr*.jar, *guava*.jar, *access*.jar, *activation*.jar, *bcprov*.jar, *bcmail*.jar, *bcutil*.jar, *bcpkix*.jar, *json*.jar 
+server.tomcat.additional-tld-skip-patterns=jakarta.persistence-api*.jar, jakarta.xml.bind-api*.jar, txw2*.jar, *commons*.jar,  *annotations*.jar, *checker*.jar, *lombok*.jar, *jsr*.jar, *guava*.jar, *access*.jar, *activation*.jar, *bcprov*.jar, *bcmail*.jar, *bcutil*.jar, *bcpkix*.jar, *json*.jar
 server.tomcat.basedir=/opt/embeddedtomcat
 server.servlet.register-default-servlet=true
 server.servlet.context-path=/
@@ -38,3 +38,9 @@ server.ssl.key-alias=hirs_aca_tls_rsa_3k_sha384
 # ACA specific default properties
 aca.certificates.validity = 3652
 
+# Compression settings
+server.compression.enabled=true
+# Compression content types
+server.compression.mime-types=application/javascript,application/json,application/xml,text/css,text/html,text/plain,text/xml
+# Minimum response size for compression
+server.compression.min-response-size=2048

--- a/HIRS_AttestationCAPortal/src/main/resources/application.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.properties
@@ -12,7 +12,7 @@ jakarta.persistence.sharedCache.mode = UNSPECIFIED
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 
 # Tomcat Config
-server.tomcat.additional-tld-skip-patterns=jakarta.persistence-api*.jar, jakarta.xml.bind-api*.jar, txw2*.jar, *commons*.jar,  *annotations*.jar, *checker*.jar, *lombok*.jar, *jsr*.jar, *guava*.jar, *access*.jar, *activation*.jar, *bcprov*.jar, *bcmail*.jar, *bcutil*.jar, *bcpkix*.jar, *json*.jar
+server.tomcat.additional-tld-skip-patterns=jakarta.persistence-api*.jar, jakarta.xml.bind-api*.jar, txw2*.jar, *commons*.jar,  *annotations*.jar, *checker*.jar, *lombok*.jar, *jsr*.jar, *guava*.jar, *access*.jar, *activation*.jar, *bcprov*.jar, *bcmail*.jar, *bcutil*.jar, *bcpkix*.jar, *json*.jar 
 server.tomcat.basedir=/opt/embeddedtomcat
 server.servlet.register-default-servlet=true
 server.servlet.context-path=/


### PR DESCRIPTION
Modifies `application.properties` to allow GZIP compression on Tomcat, which should substantially reduce the size of ACA portal content. Closes #745.