### PR TITLE
Fixed issue in DeviceInfoReportTest

### DIFF
--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/userdefined/report/DeviceInfoReportTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/userdefined/report/DeviceInfoReportTest.java
@@ -7,6 +7,7 @@ import hirs.attestationca.persist.entity.userdefined.info.NetworkInfo;
 import hirs.attestationca.persist.entity.userdefined.info.HardwareInfo;
 import hirs.attestationca.persist.entity.userdefined.info.FirmwareInfo;
 
+import hirs.utils.VersionHelper;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -21,7 +22,7 @@ public class DeviceInfoReportTest extends AbstractUserdefinedEntityTest {
     private final HardwareInfo hardwareInfo = createTestHardwareInfo();
     private final TPMInfo tpmInfo = createTPMInfo();
 
-    private static final String EXPECTED_CLIENT_VERSION = "Test.Version";
+    private static final String EXPECTED_CLIENT_VERSION = VersionHelper.getVersion();
 
     /**
      * Tests instantiation of a DeviceInfoReport.

--- a/HIRS_AttestationCA/src/test/resources/VERSION
+++ b/HIRS_AttestationCA/src/test/resources/VERSION
@@ -1,1 +1,0 @@
-Test.Version

--- a/HIRS_Utils/src/test/java/hirs/utils/VersionHelperTest.java
+++ b/HIRS_Utils/src/test/java/hirs/utils/VersionHelperTest.java
@@ -2,8 +2,7 @@ package hirs.utils;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Tests for VersionHelper.
@@ -11,21 +10,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class VersionHelperTest {
 
     /**
-     * Test that case where a version file does not exist.
-     */
-    @Test
-    public void testGetVersionFail() {
-        String actual = VersionHelper.getVersion("somefile");
-        assertTrue(actual.startsWith(""));
-    }
-
-    /**
-     * Test that a version file exists and can be read properly.
+     * Test that a version file exists in /opt/hirs or /etc/hirs and is not empty.
      */
     @Test
     public void testGetVersionDefault() {
-        String expected = "Test.Version";
-        String actual = VersionHelper.getVersion("VERSION");
-        assertEquals(expected, actual);
+        String actual = VersionHelper.getVersion();
+        assertNotNull(actual);
     }
 }

--- a/HIRS_Utils/src/test/resources/VERSION
+++ b/HIRS_Utils/src/test/resources/VERSION
@@ -1,1 +1,0 @@
-Test.Version


### PR DESCRIPTION
Closes #759 

Currently DeviceInfoReportTest is not passing due to a change in how version is implemented. This fix was originally a part of PR https://github.com/nsacyber/HIRS/pull/742 but due to that PR being on hold, moving this to its own PR.

Changes to fix error in unit test in DeviceInfoReportTest:
- HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/entity/userdefined/report/DeviceInfoReportTest.java
- HIRS_AttestationCA/src/test/resources/VERSION (removed)
- HIRS_Utils/src/test/java/hirs/utils/VersionHelperTest.java
- HIRS_Utils/src/test/resources/VERSION (removed)