### PR TITLE
[#761] Format ACA page certificate dates in UTC

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/endorsement-key-credentials.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/endorsement-key-credentials.jsp
@@ -64,14 +64,14 @@
                             data: 'beginValidity',
                             searchable:false,
                             render: function (data, type, full, meta) {
-                                return formatDateTime(full.beginValidity);
+                                return formatCertificateDate(full.beginValidity);
                             }
                         },
                         {
                             data: 'endValidity',
                             searchable:false,
                             render: function (data, type, full, meta) {
-                                return formatDateTime(full.endValidity);
+                                return formatCertificateDate(full.endValidity);
                             }
                         },
                         {

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/issued-certificates.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/issued-certificates.jsp
@@ -56,14 +56,14 @@
                             data: 'beginValidity',
                             searchable:false,
                             render: function (data, type, full, meta) {
-                                return formatDateTime(data);
+                                return formatCertificateDate(data);
                             }
                         },
                         {
                             data: 'endValidity',
                             searchable:false,
                             render: function (data, type, full, meta) {
-                                return formatDateTime(data);
+                                return formatCertificateDate(data);
                             }
                         },
                         {

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/platform-credentials.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/platform-credentials.jsp
@@ -79,14 +79,14 @@
                             data: 'beginValidity',
                             searchable:false,
                             render: function (data, type, full, meta) {
-                                return formatDateTime(full.beginValidity);
+                                return formatCertificateDate(full.beginValidity);
                             }
                         },
                         {
                             data: 'endValidity',
                             searchable:false,
                             render: function (data, type, full, meta) {
-                                return formatDateTime(full.endValidity);
+                                return formatCertificateDate(full.endValidity);
                             }
                         },
                         {

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/trust-chain.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/trust-chain.jsp
@@ -101,7 +101,7 @@
 
                 //Format validity time
                 $("#validity span").each(function(){
-                    $(this).text(formatDateTime($(this).text()));
+                    $(this).text(formatCertificateDate($(this).text()));
                 });
 
                 //Convert byte array to string
@@ -120,14 +120,14 @@
                             data: 'beginValidity',
                             searchable:false,
                             render: function (data, type, full, meta) {
-                                return formatDateTime(full.beginValidity);
+                                return formatCertificateDate(full.beginValidity);
                             }
                         },
                         {
                             data: 'endValidity',
                             searchable:false,
                             render: function (data, type, full, meta) {
-                                return formatDateTime(full.endValidity);
+                                return formatCertificateDate(full.endValidity);
                             }
                         },
                         {

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/validation-reports.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/validation-reports.jsp
@@ -100,7 +100,7 @@
                         name: 'createTime',
                         searchable: false,
                         render: function (data, type, full, meta) {
-                            return formatDateTime(full.createTime);
+                            return formatCertificateDate(full.createTime);
                         }
                     },
                     {


### PR DESCRIPTION
Format certificate timestamps on ACA pages using UTC time (and the GMT time zone) to prevent confusion, instead of the current behavior which displays certificate dates in the user's local time.

Closes #761.