### PR TITLE
updated build to include HIRS_UTILS

### DIFF
--- a/tools/tcg_eventlog_tool/build.gradle
+++ b/tools/tcg_eventlog_tool/build.gradle
@@ -57,6 +57,9 @@ jar {
                  'Class-Path':configurations.runtimeClasspath.files.collect { it.getName() }.join(' ')
            )
      }
+     from {
+		configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+	 }
      //jar name format: [archiveBaseName]-[archiveAppendix]-[archiveVersion]-[archiveClassifier].[archiveExtension]
      archiveVersion = jarVersion
 }


### PR DESCRIPTION
Creates a "Fat jar" for running without linking in HIRS_Utils.jar for the tcg_eventlog_tool.