### PR TITLE
[#765] Adding ACA Rocky Container for CI System Tests

### DIFF
--- a/.ci/docker/Dockerfile.aca-rocky-ci
+++ b/.ci/docker/Dockerfile.aca-rocky-ci
@@ -1,0 +1,110 @@
+FROM rockylinux:9
+LABEL org.opencontainers.image.vendor NSA Laboratory for Advanced Cybersecurity Research
+LABEL org.opencontainers.image.source https://github.com/nsacyber/hirs
+LABEL org.opencontainers.image.description NSA\'s HIRS Attestation Certificate Authority. Expose port 8443 to access the portal from outside the container.
+
+# Purpose: This image is designed for HIRS ACA testing on Rocky 9. It is meant to be used in
+#          the .ci, and does not automatically start the ACA upon running the container.
+# Date Modified: 5/3/24
+# Notes: The image to be built should be named "aca-rocky-ci:latest".
+#        For local image build, use this command from the /HIRS/ directory to build the image:
+#           $ docker build -f ./.ci/docker/Dockerfile.aca-rocky-ci -t aca-rocky-ci:latest .
+#        For manually setting up and starting the ACA in the container, uncomment the CMD
+#        statement at the end of this Dockerfile, allowing those scripts to be executed upon
+#        running the container.
+
+# REF can be specified as a docker run environment variable to select the HIRS branch to work with
+ARG REF=main
+
+SHELL ["/bin/bash", "-c"]
+
+# Rocky 9 has a different channel for some apps
+RUN dnf install -y 'dnf-command(config-manager)' && dnf config-manager --set-enabled crb
+
+# Update and install OS-dependencies
+RUN dnf update -y
+# Dependencies were selected for these reasons:
+#   OS setup/Unknown direct impact for HIRS
+ENV HIRS_DNF_OS_SETUP="initscripts firewalld policycoreutils policycoreutils-python-utils net-tools"
+#   OS tools
+ENV HIRS_DNF_OS_TOOLS="git sudo vim wget"
+#   ACA compile
+ENV HIRS_DNF_ACA_COMPILE="java-17-openjdk-devel"
+#   ACA run
+ENV HIRS_DNF_ACA_RUN="mariadb-server"
+#   IBM TPM simulator compile
+ENV HIRS_DNF_TPM_COMPILE="tpm2-tools gcc cmake openssl-devel"
+#   IBM TSS compile
+ENV HIRS_DNF_TSS_COMPILE="autoconf automake libtool"
+# Download and install all dependencies at one time
+RUN dnf -y install $(echo "$HIRS_DNF_OS_SETUP") $(echo "$HIRS_DNF_OS_TOOLS") $(echo "$HIRS_DNF_ACA_COMPILE") $(echo "$HIRS_DNF_ACA_RUN") $(echo "$HIRS_DNF_TPM_COMPILE") $(echo "$HIRS_DNF_TSS_COMPILE")
+
+# Build IBM TPM Simulator
+RUN git clone https://github.com/kgoldman/ibmswtpm2 /ibmswtpm2
+WORKDIR /ibmswtpm2/src
+RUN make
+
+# Build IBM TPM tools
+RUN git clone https://github.com/kgoldman/ibmtss /ibmtss
+WORKDIR /ibmtss/utils
+RUN make -f makefiletpmc
+
+# The following script tests that the SW TPM and TSS were compiled in the docker image. And documents how to start the SW TPM after container launch using both IBM's tss and TPM2-TOOLS.
+RUN echo "#!/bin/bash" > /tmp/tpm_config && \
+    echo "/ibmswtpm2/src/tpm_server &" >> /tmp/tpm_config && \
+    echo "sleep 5" >> /tmp/tpm_config && \
+    echo "/ibmtss/utils/startup -c" >> /tmp/tpm_config && \
+    echo "tpm2_shutdown" >> /tmp/tpm_config && \
+    echo "tpm2_startup -c" >> /tmp/tpm_config && \
+    echo "/ibmtss/utils/shutdown -c" >> /tmp/tpm_config && \
+    bash /tmp/tpm_config && \
+    rm -rf /tmp/tpm_config
+
+EXPOSE 8443
+
+# Checkout HIRS
+RUN git clone -b ${REF} https://github.com/nsacyber/HIRS.git /repo
+
+# Defensive copy of the repo so it's easy to start fresh if needed
+RUN mkdir /hirs
+WORKDIR /repo
+RUN cp -r . /hirs
+
+# Run bootwar to cache build artifacts
+WORKDIR /hirs
+RUN ./gradlew bootWar
+
+# Add ACA TLS certification path to container OS
+# Allows the curl command in the HEALTHCHECK to work with TLS
+# These commands are placed into a script that can be run after aca_setup.sh on container launch.
+RUN echo "#!/bin/bash" > /tmp/hirs_add_aca_tls_path_to_os.sh && \
+    echo "cp /etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_intermediate_ca_rsa_3k_sha384.pem /etc/pki/ca-trust/source/anchors/" >> /tmp/hirs_add_aca_tls_path_to_os.sh && \
+    echo "cp /etc/hirs/certificates/HIRS/ecc_512_sha384_certs/HIRS_intermediate_ca_ecc_512_sha384.pem /etc/pki/ca-trust/source/anchors/" >> /tmp/hirs_add_aca_tls_path_to_os.sh && \
+    echo "cp /etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_root_ca_rsa_3k_sha384.pem /etc/pki/ca-trust/source/anchors/" >> /tmp/hirs_add_aca_tls_path_to_os.sh && \
+    echo "cp /etc/hirs/certificates/HIRS/ecc_512_sha384_certs/HIRS_root_ca_ecc_512_sha384.pem /etc/pki/ca-trust/source/anchors/"  >> /tmp/hirs_add_aca_tls_path_to_os.sh && \
+    echo "cp /etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_leaf_ca3_rsa_3k_sha384.pem /etc/pki/ca-trust/source/anchors/" >> /tmp/hirs_add_aca_tls_path_to_os.sh && \
+    echo "cp /etc/hirs/certificates/HIRS/ecc_512_sha384_certs/HIRS_leaf_ca3_ecc_512_sha384.pem /etc/pki/ca-trust/source/anchors/" >> /tmp/hirs_add_aca_tls_path_to_os.sh && \
+    echo "update-ca-trust" >> /tmp/hirs_add_aca_tls_path_to_os.sh
+RUN chmod +x /tmp/hirs_add_aca_tls_path_to_os.sh
+
+# The container will report a health state based on when embedded tomcat finishes loading. If the ACA isn't loaded after the timeout, the container will report that it is unhealthy.
+HEALTHCHECK --start-period=50s --interval=1s --timeout=90s CMD curl -f https://localhost:8443/HIRS_AttestationCAPortal/portal/index
+
+# The following script will clone and copy the referenced branch of HIRS off GitHub
+# If configured, run bootwar to cache build artifacts
+RUN echo "#!/bin/bash" > /tmp/auto_clone_branch && \
+    echo "cd /hirs" >> /tmp/auto_clone_branch && \
+    echo "git fetch origin && git pull origin main && git reset --hard" >> /tmp/auto_clone_branch && \
+    echo 'git checkout $1 && git reset --hard' >> /tmp/auto_clone_branch && \
+    echo 'if [ -n "${2}" ]; then ./gradlew bootWar; fi' >> /tmp/auto_clone_branch && \
+    echo "cd HIRS_Provisioner.NET/hirs" >> /tmp/auto_clone_branch && \
+    echo 'if [ -n "${2}" ]; then dotnet deb -r linux-x64 -c Release && dotnet rpm -r linux-x64 -c Release; fi' >> /tmp/auto_clone_branch && \
+    chmod 755 /tmp/auto_clone_branch
+
+# Reset working directory
+WORKDIR /hirs
+
+# On container launch, the database will be set up. Then bootRun should utilize build artifacts stored in the image.
+# NOTE: Uncomment the CMD command below before running this container locally or outside of CI, which will allow the ACA
+#       to automatically set up and start upon running the container.
+# CMD ["bash", "-c", "/hirs/package/linux/aca/aca_setup.sh --unattended && /tmp/hirs_add_aca_tls_path_to_os.sh && /hirs/package/linux/aca/aca_bootRun.sh"]

--- a/.ci/docker/Dockerfile.tpm2provisioner-dotnet-ci
+++ b/.ci/docker/Dockerfile.tpm2provisioner-dotnet-ci
@@ -3,11 +3,15 @@ LABEL org.opencontainers.image.vendor NSA Laboratory for Advanced Cybersecurity 
 LABEL org.opencontainers.image.source https://github.com/nsacyber/hirs
 LABEL org.opencontainers.image.description Tools for testing the build and deployment of HIRS projects.
 
-# Purpose: This image is designed for HIRS Provisioner.Net testing on Rocky 9.
+# Purpose: This image is designed for HIRS Provisioner.Net testing on Rocky 9. It is meant to be used in
+#          the .ci, and does not automatically start the Provisioner upon running the container.
 # Date Modified: 4/15/24
 # Notes: The image to be built should be named "tpm2provisioner-dotnet-ci:latest".
-#        For local build, use this command from the /HIRS/ directory to build the image:
-#        $ docker build -f ./.ci/docker/Dockerfile.tpm2provisioner_dotnet -t tpm2provisioner-dotnet-ci:latest .
+#        For local image build, use this command from the /HIRS/ directory to build the image:
+#           $ docker build -f ./.ci/docker/Dockerfile.tpm2provisioner_dotnet -t tpm2provisioner-dotnet-ci:latest .
+#        For manually running the Provisioner.Net using the TPM Simulator, first ensure that an ACA
+#        is running on port 8443. Then, run the setup script within this container using this command:
+#           $ ./.ci/setup/container/setup_tpm2provisioner_dotnet.sh
 
 # REF can be specified as a docker run environment variable to select the HIRS branch to work with
 ENV REF=main

--- a/.ci/docker/docker-compose-system-test.yml
+++ b/.ci/docker/docker-compose-system-test.yml
@@ -1,9 +1,10 @@
 services:
    aca:
-      image: ghcr.io/nsacyber/hirs/aca-rocky:5445278
+      image: ghcr.io/nsacyber/hirs/aca-rocky-ci:latest
       container_name: hirs-aca1
       volumes:
          - ../../:/HIRS
+      command: ["bash", "-c", "tail -f /dev/null;"]
       ports:
          - "${HIRS_ACA_PORTAL_PORT}:${HIRS_ACA_PORTAL_CONTAINER_PORT}"
       hostname: ${HIRS_ACA_HOSTNAME}

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -20,7 +20,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: ACA TPM2 Tests
         continue-on-error: true
         shell: bash
@@ -30,7 +30,7 @@ jobs:
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           bash .ci/system-tests/run_system_tests.sh ${GITHUB_REF#refs/heads/}
       - name: Archive System Test Log files
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: System_Test_Log_Files
           path: logs/


### PR DESCRIPTION
This PR is meant to add an ACA container built from Rocky 9 specifically meant for System Tests in the CI. It also follows up on [PR 748](https://github.com/nsacyber/HIRS/pull/748) to make minor additions to suit the new ACA containers, plus some improved comments and one renamed file.

The following files have been added/modified:

- `Dockerfile.aca-rocky-ci` is the Dockerfile used to create an image for the ACA built from Rocky 9, specifically to be used with the CI System Tests. It differs from `Dockerfile.aca-rocky` by NOT using a CMD statement at the end of the Dockerfile (it is now commented out) to start the ACA; instead, the ACA scripts are called from `run_system_tests.sh`. However, if the user wanted to use the CMD statement and use the container for other purposes, they can uncomment it at the end of the file as specified by the commented instructions. Also, this image has already been pushed to the nsacyber/HIRS GitHub package registry as `ghcr.io/nsacyber/hirs/aca-rocky-ci:latest`.
- `Dockerfile.tpm2provisioner_dotnet` (old name) has been renamed to `Dockerfile.tpm2provisioner-dotnet-ci` (new name) to have a consistent naming convention, as with `Dockerfile.aca-rocky-ci`. Also added some more comments to guide any users who want to build/run the container locally.
- `run_system_tests.sh` now calls for the execution of scripts to set up and start the ACA within the container pulled from `ghcr.io/nsacyber/hirs/aca-rocky-ci:latest`. It also checks out the current branch being pushed within the container's HIRS clone before starting the ACA. To confirm the branch for both the ACA and Provisioner, it will echo the current branch name within the HIRS cloned repo inside the containers, which will be output to the GitHub Action run (see lines 20 and 27 of `run_system_tests.sh`).
- `docker-compose-system-test.yml ` now pulls the new `ghcr.io/nsacyber/hirs/aca-rocky-ci:latest` image.
- `system_test.yml` now has updated Action uses (v3 -> v4), removing a warning that was there previously.

**To perform the test in GitHub actions:**

On this branch in remote repository, use a workflow dispatch by going: Actions > HIRS System Tests > Run workflow.