### PR TITLE
V3 boot run debug option

### DIFF
--- a/HIRS_AttestationCAPortal/build.gradle
+++ b/HIRS_AttestationCAPortal/build.gradle
@@ -22,7 +22,7 @@ java {
 
 bootRun {
   if (project.hasProperty('debug')) {
-    jvmArgs "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:9123"
+    jvmArgs project.debug
   }
 }
 

--- a/HIRS_AttestationCAPortal/build.gradle
+++ b/HIRS_AttestationCAPortal/build.gradle
@@ -20,6 +20,12 @@ java {
     }
 }
 
+bootRun {
+  if (project.hasProperty('debug')) {
+    jvmArgs "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:9123"
+  }
+}
+
 configurations {
     compileOnly {
         extendsFrom annotationProcessor

--- a/package/linux/aca/aca_bootRun.sh
+++ b/package/linux/aca/aca_bootRun.sh
@@ -14,6 +14,7 @@ SCRIPT_DIR=$( dirname -- "$( readlink -f -- "$0"; )"; )
 LOG_FILE=/dev/null
 GRADLE_WRAPPER="./gradlew"
 DEPLOYED_WAR=false
+DEBUG_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:9123"
 
 # Check for sudo or root user 
 if [ "$EUID" -ne 0 ]
@@ -134,7 +135,7 @@ if [ -z "$USE_WAR" ]; then
   echo "Booting the ACA from local build..."
   if [ "$DEBUG_ACA" == YES ]; then
     echo "... in debug"
-    ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE" -Pdebug
+    ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE" -Pdebug="$DEBUG_OPTIONS"
   else
     ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE"
   fi
@@ -142,7 +143,7 @@ else
   echo "Booting the ACA from a war file..."
   if [ "$DEBUG_ACA" == YES ]; then
     echo "... in debug"
-    java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:9123  -jar  $WAR_PATH --spring.config.location=$SPRING_PROP_FILE &
+    java $DEBUG_OPTIONS  -jar  $WAR_PATH --spring.config.location=$SPRING_PROP_FILE &
   else
     java -jar  $WAR_PATH --spring.config.location=$SPRING_PROP_FILE &
   fi

--- a/package/linux/aca/aca_bootRun.sh
+++ b/package/linux/aca/aca_bootRun.sh
@@ -130,16 +130,21 @@ WEB_TLS_PARAMS="--server.ssl.key-store-password=$hirs_pki_password \
 # uncomment to show spring boot and hibernate properties used as gradle arguments
 #echo "--args=\"$CONNECTOR_PARAMS $WEB_TLS_PARAMS\""
 
-if [ "$DEBUG_ACA" == YES ]; then
-  echo "Booting with debug mode..."
-  ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE" -Pdebug
-elif [ -z "$USE_WAR" ]; then
+if [ -z "$USE_WAR" ]; then
   echo "Booting the ACA from local build..."
- # ./gradlew bootRun --args="$CONNECTOR_PARAMS$WEB_TLS_PARAMS"  
-./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE"
+  if [ "$DEBUG_ACA" == YES ]; then
+    echo "... in debug"
+    ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE" -Pdebug
+  else
+    ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE"
+  fi
 else
   echo "Booting the ACA from a war file..."
- # java -jar $WAR_PATH $CONNECTOR_PARAMS$WEB_TLS_PARAMS &
-java -jar  $WAR_PATH --spring.config.location=$SPRING_PROP_FILE &
-exit 0
+  if [ "$DEBUG_ACA" == YES ]; then
+    echo "... in debug"
+    java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:9123  -jar  $WAR_PATH --spring.config.location=$SPRING_PROP_FILE &
+  else
+    java -jar  $WAR_PATH --spring.config.location=$SPRING_PROP_FILE &
+  fi
+  exit 0
 fi

--- a/package/linux/aca/aca_bootRun.sh
+++ b/package/linux/aca/aca_bootRun.sh
@@ -27,6 +27,7 @@ help () {
   echo "  options:"
   echo "     -p  | --path   Path to the HIRS_AttestationCAPortal.war file"
   echo "     -w  | --war    Use deployed war file"
+  echo "     -d  | --debug  Launch the JVM with a debug port open"
   echo "     -h  | --help   Print this help"
   echo
 }
@@ -48,6 +49,10 @@ while [[ $# -gt 0 ]]; do
       shift # past argument
       WAR_PATH="/opt/hirs/aca/HIRS_AttestationCAPortal.war"
       DEPLOYED_WAR=true
+      ;;
+    -d|--debug)
+      DEBUG_ACA=YES
+      shift
       ;;
     -h|--help)
       help     
@@ -125,7 +130,10 @@ WEB_TLS_PARAMS="--server.ssl.key-store-password=$hirs_pki_password \
 # uncomment to show spring boot and hibernate properties used as gradle arguments
 #echo "--args=\"$CONNECTOR_PARAMS $WEB_TLS_PARAMS\""
 
-if [ -z "$USE_WAR" ]; then
+if [ "$DEBUG_ACA" == YES ]; then
+  echo "Booting with debug mode..."
+  ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE" -Pdebug
+elif [ -z "$USE_WAR" ]; then
   echo "Booting the ACA from local build..."
  # ./gradlew bootRun --args="$CONNECTOR_PARAMS$WEB_TLS_PARAMS"  
 ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE"

--- a/package/win/aca/aca_bootRun.ps1
+++ b/package/win/aca/aca_bootRun.ps1
@@ -10,6 +10,7 @@ $ACA_COMMON_SCRIPT=(Join-Path $APP_HOME 'aca_common.ps1')
 $ALG="RSA" # or "ECC"
 $GRADLE_WRAPPER='./gradlew'
 $DEPLOYED_WAR=$null
+$DEBUG_OPTIONS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:9123'
 
 # Load other scripts
 . $ACA_COMMON_SCRIPT
@@ -78,7 +79,7 @@ if ($w -or $war) {
 	echo "Booting the ACA from a war file..." | WriteAndLog
     if ($d -or $debug) {
         echo "... in debug"
-        java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:9123 -jar $DEPLOYED_WAR --spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES
+        java $DEBUG_OPTIONS -jar $DEPLOYED_WAR --spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES
     } else {
 	    java -jar $DEPLOYED_WAR --spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES
     }
@@ -86,7 +87,7 @@ if ($w -or $war) {
     echo "Booting the ACA from local build..." | WriteAndLog
     if ($d -or $debug) {
         echo "... in debug"
-        ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES" -Pdebug
+        ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES" -Pdebug="$$DEBUG_OPTIONS"
     } else {
 	    ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES"
     }

--- a/package/win/aca/aca_bootRun.ps1
+++ b/package/win/aca/aca_bootRun.ps1
@@ -74,13 +74,21 @@ if (!$DEPLOYED_WAR) {
 }
 
 $SPRING_PROP_FILE_FORWARDSLASHES=($global:HIRS_DATA_SPRING_PROP_FILE | ChangeBackslashToForwardSlash)
-if ($d -or $debug) {
-  echo "Booting with debug mode..."
-  ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE" -Pdebug
-elseif ($w -or $war) {
+if ($w -or $war) {
 	echo "Booting the ACA from a war file..." | WriteAndLog
-	java -jar $DEPLOYED_WAR --spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES
+    if ($d -or $debug) {
+        echo "... in debug"
+        java -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:9123 -jar $DEPLOYED_WAR --spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES
+    } else {
+	    java -jar $DEPLOYED_WAR --spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES
+    }
 } else  {
     echo "Booting the ACA from local build..." | WriteAndLog
-	./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES"
+    if ($d -or $debug) {
+        echo "... in debug"
+        ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES" -Pdebug
+    } else {
+	    ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES"
+    }
+	
 }

--- a/package/win/aca/aca_bootRun.ps1
+++ b/package/win/aca/aca_bootRun.ps1
@@ -1,6 +1,7 @@
 param (
     [string]$p, [string]$path = $null,
 	[switch]$w, [switch]$war = $false,
+	[switch]$d, [switch]$debug = $false,
 	[switch]$h, [switch]$help = $false
 )
 
@@ -34,6 +35,7 @@ if ($p) {
 	$path = $p
 }
 $war = $w -or $war
+$debug = $d -or $debug
 $help = $h -or $help
 
 if(!(New-Object Security.Principal.WindowsPrincipal(
@@ -49,6 +51,7 @@ if ($help) {
   echo "  options:"
   echo "     -p  | --path   Path to the HIRS_AttestationCAPortal.war file"
   echo "     -w  | --war    Use deployed war file"
+  echo "     -d  | --debug  Launch the JVM with a debug port open"
   echo "     -h  | --help   Print this help"
   exit 1
 }
@@ -71,7 +74,10 @@ if (!$DEPLOYED_WAR) {
 }
 
 $SPRING_PROP_FILE_FORWARDSLASHES=($global:HIRS_DATA_SPRING_PROP_FILE | ChangeBackslashToForwardSlash)
-if ($w -or $war) {
+if ($d -or $debug) {
+  echo "Booting with debug mode..."
+  ./gradlew bootRun --args="--spring.config.location=$SPRING_PROP_FILE" -Pdebug
+elseif ($w -or $war) {
 	echo "Booting the ACA from a war file..." | WriteAndLog
 	java -jar $DEPLOYED_WAR --spring.config.location=$SPRING_PROP_FILE_FORWARDSLASHES
 } else  {


### PR DESCRIPTION
Added a --debug flag to the aca_bootRun.sh and aca_bootRun.ps1 scripts.
Added a variable DEBUG_OPTIONS to our boot run scripts that contains the JVM configuration string necessary to open a debug port in the JVM.
Configured HIRS_AttestationCAPortal/build.gradle to pass a debug string to bootRun if the script is started with the --debug command line option.
Debug mode also works if the bootRun script is started using the spring boot war (executable jar) arguments.

These commands should work the same on either package/linux/aca_bootRun.sh or package/windows/aca_bootRun.ps1.

| Script (.sh or .ps1) | |
| --- | --- |
| aca_bootRun.sh | Launches the ACA using spring boot |
| aca_bootRun.sh -d | Launches the ACA using spring boot and opens a debug port in the JVM specified in DEBUG_OPTIONS |
| aca_bootRun.sh -w | Launches the ACA from the war |
| aca_bootRun.sh -d -w | Launches the ACA from the war and opens a debug port in the JVM specified in DEBUG_OPTIONS |