### PR TITLE
Event processing when no access to vendor-table.json Part 1/2

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureData.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureData.java
@@ -161,10 +161,10 @@ public class UefiSignatureData {
             sigInfo = status;
         } else {
             if (signatureType.getVendorTableReference().equals("EFI_CERT_SHA256_GUID")) {
-                sigInfo += "UEFI Signature Owner = " + efiVarGuid.toString() + "\n";
-                sigInfo += "  Binary Hash = " + HexUtils.byteArrayToHexString(binaryHash) + "\n";
+                sigInfo += "    UEFI Signature Owner = " + efiVarGuid.toString() + "\n";
+                sigInfo += "      Binary Hash = " + HexUtils.byteArrayToHexString(binaryHash) + "\n";
             } else {
-                sigInfo += "UEFI Signature Owner = " + efiVarGuid.toString() + "\n";
+                sigInfo += "    UEFI Signature Owner = " + efiVarGuid.toString() + "\n";
                 sigInfo += cert.toString();
             }
         }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureData.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureData.java
@@ -52,10 +52,6 @@ public class UefiSignatureData {
      */
     @Getter
     private boolean valid = false;
-//    /**
-//     * UEFI Certificate SHA1 hash.
-//     */
-//    private byte[] binaryHash = new byte[UefiConstants.SIZE_40];
     /**
      * UEFI Certificate SHA256 hash.
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureData.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureData.java
@@ -10,7 +10,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 
 /**
- * Class for processing the contents of a Secure Boot DB or DBX contents.
+ * Class for processing the contents of a Secure Boot PK, KEK, DB or DBX contents.
  * used for EFIVariables associated with Secure Boot
  * as defined by Section 32.4.1 Signature Database from the UEFI 2.8 specification
  * <p>
@@ -52,10 +52,14 @@ public class UefiSignatureData {
      */
     @Getter
     private boolean valid = false;
+//    /**
+//     * UEFI Certificate SHA1 hash.
+//     */
+//    private byte[] binaryHash = new byte[UefiConstants.SIZE_40];
     /**
-     * UEFI Certificate SHA1 hash.
+     * UEFI Certificate SHA256 hash.
      */
-    private byte[] binaryHash = new byte[UefiConstants.SIZE_40];
+    private byte[] binaryHash = new byte[UefiConstants.SIZE_32];
     /**
      * UEFI Signature data status.
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
@@ -219,7 +219,7 @@ public class UefiSignatureList {
         }
         else {
             sigInfo.append("   UEFI Signature List Type = " + signatureType.toString() + "\n");
-            sigInfo.append("   Number of items (certs, hashes, etc) = " + numberOfCerts + "\n");
+            sigInfo.append("   Number of Certs or Hashes in UEFI Signature List = " + numberOfCerts + "\n");
 
             for (int i = 0; i < sigList.size(); i++) {
                 UefiSignatureData certData = sigList.get(i);

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
@@ -214,18 +214,19 @@ public class UefiSignatureList {
         StringBuilder sigInfo = new StringBuilder();
 
         if (!signatureTypeValid) {
-            sigInfo.append("  *** Unknown UEFI Signature Type encountered: " + signatureType.toString() + "\n");
+            sigInfo.append("   *** Unknown UEFI Signature Type encountered:\n" +
+                    "       " + signatureType.toString() + "\n");
         }
         else {
-            sigInfo.append("  UEFI Signature List Type = " + signatureType.toString() + "\n");
-            sigInfo.append("  Number if items (certs, hashes, etc) = " + numberOfCerts + "\n");
+            sigInfo.append("   UEFI Signature List Type = " + signatureType.toString() + "\n");
+            sigInfo.append("   Number of items (certs, hashes, etc) = " + numberOfCerts + "\n");
 
             for (int i = 0; i < sigList.size(); i++) {
                 UefiSignatureData certData = sigList.get(i);
                 sigInfo.append(certData.toString());
             }
             if (!dataValid) {
-                sigInfo.append("  *** Invalid UEFI Signature data encountered: " + dataStatus + "\n");
+                sigInfo.append("   *** Invalid UEFI Signature data encountered: " + dataStatus + "\n");
             }
         }
         return sigInfo.toString();

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
@@ -47,11 +47,16 @@ public class UefiSignatureList {
     /**
      * Signature validity.
      */
-    private boolean valid = true;
+    @Getter
+    private boolean signatureTypeValid = false;
     /**
-     * Current status.
+     * Data validity.
      */
-    private String status = "Signature List is Valid";
+    private boolean dataValid = true;
+    /**
+     * Current status of Signature List data.
+     */
+    private String dataStatus = "Signature List data validity is undetermined yet";
     /**
      * Array List of Signature found in the list.
      */
@@ -110,17 +115,23 @@ public class UefiSignatureList {
         lists.read(guid);
         signatureType = new UefiGuid(guid);
 
+        // if signatureType is invalid, don't even process any of the data
+        // however, if signatureTYpe is valid, but some of the data later on is invalid, that will
+        // be caught when UefiSignatureData is processed
         if (!isValidSigListGUID(signatureType)) {
-            processSignatureData(lists);
+            //processSignatureData(lists);
+            signatureTypeValid = false;
         } else { // valid SigData Processing
-            byte[] lSize = new byte[UefiConstants.SIZE_4];
+            signatureTypeValid = true;
+
+            byte[] lSize = new byte[UefiConstants.SIZE_4];      // signature list size
             lists.read(lSize);
             listSize = HexUtils.leReverseInt(lSize);
 
-            byte[] hSize = new byte[UefiConstants.SIZE_4];
+            byte[] hSize = new byte[UefiConstants.SIZE_4];      // signature header size
             lists.read(hSize);
 
-            byte[] sSize = new byte[UefiConstants.SIZE_4];
+            byte[] sSize = new byte[UefiConstants.SIZE_4];      // signature size
             lists.read(sSize);
             signatureSize = listSize - UefiConstants.SIZE_28;
             sigData = new byte[signatureSize];
@@ -143,8 +154,8 @@ public class UefiSignatureList {
         while (efiSigDataIS.available() > 0) {
             UefiSignatureData tmpSigData = new UefiSignatureData(efiSigDataIS, signatureType);
             if (!tmpSigData.isValid()) {
-                valid = false;
-                status = tmpSigData.getStatus();
+                dataValid = false;
+                dataStatus = tmpSigData.getStatus();
                 break;
             }
             sigList.add(tmpSigData);
@@ -165,8 +176,8 @@ public class UefiSignatureList {
         while (sigDataIS.available() > 0) {
             UefiSignatureData tmpigData = new UefiSignatureData(sigDataIS, signatureType);
             if (!tmpigData.isValid()) {
-                valid = false;
-                status = tmpigData.getStatus();
+                dataValid = false;
+                dataStatus = tmpigData.getStatus();
                 break;
             }
             sigList.add(tmpigData);
@@ -201,15 +212,21 @@ public class UefiSignatureList {
      */
     public String toString() {
         StringBuilder sigInfo = new StringBuilder();
-        sigInfo.append("UEFI Signature List Type = " + signatureType.toString() + "\n");
-        sigInfo.append("Number if items = " + numberOfCerts + "\n");
 
-        for (int i = 0; i < sigList.size(); i++) {
-            UefiSignatureData certData = sigList.get(i);
-            sigInfo.append(certData.toString());
+        if (!signatureTypeValid) {
+            sigInfo.append("  *** Unknown UEFI Signature Type encountered: " + signatureType.toString() + "\n");
         }
-        if (!valid) {
-            sigInfo.append("*** Invalid UEFI Signature data encountered: " + status + "\n");
+        else {
+            sigInfo.append("  UEFI Signature List Type = " + signatureType.toString() + "\n");
+            sigInfo.append("  Number if items (certs, hashes, etc) = " + numberOfCerts + "\n");
+
+            for (int i = 0; i < sigList.size(); i++) {
+                UefiSignatureData certData = sigList.get(i);
+                sigInfo.append(certData.toString());
+            }
+            if (!dataValid) {
+                sigInfo.append("  *** Invalid UEFI Signature data encountered: " + dataStatus + "\n");
+            }
         }
         return sigInfo.toString();
     }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -163,8 +163,8 @@ public class UefiVariable {
      */
     public String toString() {
         StringBuilder efiVariable = new StringBuilder();
-        efiVariable.append("UEFI Variable Name:" + efiVarName + "\n");
-        efiVariable.append("UEFI Variable GUID = " + uefiVarGuid.toString() + "\n");
+        efiVariable.append("UEFI Variable Name: " + efiVarName + "\n");
+        efiVariable.append("UEFI Variable GUID: " + uefiVarGuid.toString() + "\n");
         if (efiVarName != "") {
             efiVariable.append("UEFI Variable Contents => " + "\n");
         }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -196,9 +196,9 @@ public class UefiVariable {
             default:
                 if (!tmpName.isEmpty()) {
                     efiVariable.append(String.format("Data not provided for "
-                                    + "UEFI variable named %s   \n", tmpName));
+                                    + "UEFI variable named %s   ", tmpName));
                 } else {
-                    efiVariable.append("Data not provided   \n");
+                    efiVariable.append("Data not provided   ");
                 }
         }
         for (UefiSignatureList uefiSigList : certSuperList) {

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -201,7 +201,15 @@ public class UefiVariable {
                     efiVariable.append("Data not provided   ");
                 }
         }
+
+        // Signature List output (if there are any Signature Lists)
+        if (certSuperList.size() > 0){
+            efiVariable.append("Number of UEFI Signature Lists = " + certSuperList.size() + "\n");
+        }
+        int certSuperListCnt = 1;
         for (UefiSignatureList uefiSigList : certSuperList) {
+            efiVariable.append("UEFI Signature List # " + certSuperListCnt++ + " of " +
+                    certSuperList.size() + ":\n");
             efiVariable.append(uefiSigList.toString());
         }
         if(invalidSignatureListEncountered) {
@@ -209,6 +217,7 @@ public class UefiVariable {
             efiVariable.append("*** Encountered invalid Signature Type - " +
                     "Stopped processing of this event data\n");
         }
+
         return efiVariable.toString();
     }
 

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -39,6 +39,14 @@ public class UefiVariable {
     @Getter
     private String efiVarName = "";
     /**
+     * Encountered invalid UEFI Signature List
+     */
+    private boolean invalidSignatureListEncountered = false;
+    /**
+     * Invalid UEFI Signature List
+     */
+    private String invalidSignatureListStatus = "";
+    /**
      * UEFI defined Boot Variable.
      */
     private UefiBootVariable bootv = null;
@@ -122,7 +130,7 @@ public class UefiVariable {
     }
 
     /**
-     * Processes the data as a UEFI defined Signature List.
+     * Processes the data as a list of UEFI defined Signature Lists.
      *
      * @param data the bye array holding the Signature List.
      * @throws java.security.cert.CertificateException If there a problem
@@ -138,6 +146,12 @@ public class UefiVariable {
         while (certData.available() > 0) {
             UefiSignatureList list;
             list = new UefiSignatureList(certData);
+//            efiVariableSigListContents += list.toString();
+            if(!list.isSignatureTypeValid()) {
+                invalidSignatureListEncountered = true;
+                invalidSignatureListStatus = list.toString();
+                break;
+            }
             certSuperList.add(list);
         }
     }
@@ -150,11 +164,11 @@ public class UefiVariable {
     public String toString() {
         StringBuilder efiVariable = new StringBuilder();
         efiVariable.append("UEFI Variable Name:" + efiVarName + "\n");
-        efiVariable.append("UEFI_GUID = " + uefiVarGuid.toString() + "\n ");
+        efiVariable.append("UEFI Variable GUID = " + uefiVarGuid.toString() + "\n");
         if (efiVarName != "") {
-            efiVariable.append("UEFI Variable Contents => " + "\n  ");
+            efiVariable.append("UEFI Variable Contents => " + "\n");
         }
-        String tmpName = efiVarName;
+        String tmpName = "";
         if (efiVarName.contains("Boot00")) {
             tmpName = "Boot00";
         } else {
@@ -164,6 +178,11 @@ public class UefiVariable {
             case "Shim":
             case "MokList":
                 efiVariable.append(printCert(uefiVariableData, 0));
+                break;
+            case "PK":
+            case "KEK":
+            case "db":
+            case "dbx":
                 break;
             case "Boot00":
                 efiVariable.append(bootv.toString());
@@ -177,13 +196,18 @@ public class UefiVariable {
             default:
                 if (!tmpName.isEmpty()) {
                     efiVariable.append(String.format("Data not provided for "
-                                    + "UEFI variable named %s   ", tmpName));
+                                    + "UEFI variable named %s   \n", tmpName));
                 } else {
-                    efiVariable.append("Data not provided   ");
+                    efiVariable.append("Data not provided   \n");
                 }
         }
         for (UefiSignatureList uefiSigList : certSuperList) {
             efiVariable.append(uefiSigList.toString());
+        }
+        if(invalidSignatureListEncountered) {
+            efiVariable.append(invalidSignatureListStatus);
+            efiVariable.append("*** Encountered invalid Signature Type - " +
+                    "Stopped processing of this event data\n");
         }
         return efiVariable.toString();
     }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiX509Cert.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiX509Cert.java
@@ -80,14 +80,14 @@ public class UefiX509Cert {
     public String toString() {
         X509Certificate x509Cert = (X509Certificate) cert;
         String certData = "";
-        certData += "  Certificate Serial Number = "
+        certData += "    Certificate Serial Number = "
                 + x509Cert.getSerialNumber().toString(UefiConstants.SIZE_16) + "\n";
-        certData += "  Subject DN = " + x509Cert.getSubjectX500Principal().getName() + "\n";
-        certData += "  Issuer DN = " + x509Cert.getIssuerX500Principal().getName() + "\n";
-        certData += "  Not Before Date = " + x509Cert.getNotBefore() + "\n";
-        certData += "  Not After Date = " + x509Cert.getNotAfter() + "\n";
-        certData += "  Signature Algorithm = " + x509Cert.getSigAlgName() + "\n";
-        certData += "  SHA1 Fingerprint =  " + getSHA1FingerPrint() + "\n";
+        certData += "    Subject DN = " + x509Cert.getSubjectX500Principal().getName() + "\n";
+        certData += "    Issuer DN = " + x509Cert.getIssuerX500Principal().getName() + "\n";
+        certData += "    Not Before Date = " + x509Cert.getNotBefore() + "\n";
+        certData += "    Not After Date = " + x509Cert.getNotAfter() + "\n";
+        certData += "    Signature Algorithm = " + x509Cert.getSigAlgName() + "\n";
+        certData += "    SHA1 Fingerprint =  " + getSHA1FingerPrint() + "\n";
         return certData;
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiX509Cert.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiX509Cert.java
@@ -80,14 +80,14 @@ public class UefiX509Cert {
     public String toString() {
         X509Certificate x509Cert = (X509Certificate) cert;
         String certData = "";
-        certData += "    Certificate Serial Number = "
+        certData += "      Certificate Serial Number = "
                 + x509Cert.getSerialNumber().toString(UefiConstants.SIZE_16) + "\n";
-        certData += "    Subject DN = " + x509Cert.getSubjectX500Principal().getName() + "\n";
-        certData += "    Issuer DN = " + x509Cert.getIssuerX500Principal().getName() + "\n";
-        certData += "    Not Before Date = " + x509Cert.getNotBefore() + "\n";
-        certData += "    Not After Date = " + x509Cert.getNotAfter() + "\n";
-        certData += "    Signature Algorithm = " + x509Cert.getSigAlgName() + "\n";
-        certData += "    SHA1 Fingerprint =  " + getSHA1FingerPrint() + "\n";
+        certData += "      Subject DN = " + x509Cert.getSubjectX500Principal().getName() + "\n";
+        certData += "      Issuer DN = " + x509Cert.getIssuerX500Principal().getName() + "\n";
+        certData += "      Not Before Date = " + x509Cert.getNotBefore() + "\n";
+        certData += "      Not After Date = " + x509Cert.getNotAfter() + "\n";
+        certData += "      Signature Algorithm = " + x509Cert.getSigAlgName() + "\n";
+        certData += "      SHA1 Fingerprint =  " + getSHA1FingerPrint() + "\n";
         return certData;
     }
 }

--- a/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
+++ b/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
@@ -11,6 +11,7 @@ import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+
 import hirs.utils.tpm.eventlog.TCGEventLog;
 import hirs.utils.tpm.eventlog.TpmPcrEvent;
 import hirs.utils.HexUtils;
@@ -50,7 +51,7 @@ final class Main {
                 try {
                     outputStream = new FileOutputStream(commander.getOutputFileName());
                     System.out.print("Writing to output file: " + commander.getOutputFileName()
-                     + "\n");
+                            + "\n");
                 } catch (Exception e) {
                     System.out.print("Error opening output file" + commander.getOutputFileName()
                             + "\nError was " + e.getMessage());
@@ -217,7 +218,7 @@ final class Main {
             }
         } catch (IOException e) {
             System.out.print("Error writing to output file: " + commander.getOutputFileName()
-           + "\n  error was: " + e.toString() + "\n");
+                    + "\n  error was: " + e.toString() + "\n");
             e.printStackTrace();
         }
     }
@@ -248,7 +249,7 @@ final class Main {
                     eventLog2.getEventList(), commander.getPcrNumber());
             if (errors.isEmpty() && !bHexFlag) {
                 sb.append("\nEvent Log " + logFileName1 + " MATCHED EventLog " + logFileName2
-                    + "\n");
+                        + "\n");
             } else {
                 if (!errors.isEmpty() && !bHexFlag) {
                     sb.append("\nEvent Log " + logFileName1
@@ -333,6 +334,7 @@ final class Main {
         }
         return matchFound;
     }
+
     /**
      * Diagnostic method for detecting flag settings.
      */


### PR DESCRIPTION
When eventlog tool is run as user (such as in a command prompt without sudo, or in an IDE which is run as the user), the vendor-table.json file is not accessible, and so valid GUID lookups return "unknown GUID reference". In some cases the code needs this GUID reference to determine the next piece of code that executes. If the GUID is valid but the code thinks it is invalid, it will not process the next chunk of data properly. 

This PR covers Change # 1 in the below. 

Changes needed:
1) do not process code with an unknown SignatureType in EFI_SIGNATURE_TYPE
2) when grabbing the file vendor-table.json from /etc/hirs/aca/default-properties/vendor-table.json, if the file is not accessible, then grab the file from code: /HIRS_AttestationCA/src/main/resources/vendor-table.json

Potential changes needed:
- allow root access to the tool without typing in a path
- if the vendor-table.json from code was used, print a msg noting that the file was not found, and the code file was used

Note for testing purposes: The file permission that it is missing is the "other" "execute" in the aca folder of this link: /etc/hirs/aca/default-properties/vendor-table.json. Minimum needed is 001. Since aca by default is 750, aca would need to be changed to 751 for testing purposes.