### PR TITLE
[#787] Saving attestation certificate to file

### DIFF
--- a/HIRS_Provisioner.NET/hirs/src/provisioner/Provisioner.cs
+++ b/HIRS_Provisioner.NET/hirs/src/provisioner/Provisioner.cs
@@ -14,9 +14,8 @@ namespace hirs {
         private Settings settings = null;
         private IHirsDeviceInfoCollector deviceInfoCollector = null;
         private IHirsAcaClient acaClient = null;
-
-        public const string DefaultCertLocationLinux = "/boot/efi/EFI/tcg/cert/attestation/";
-        public const string DefaultCertFileName = "attestationkey.pem";
+        
+        private const string DefaultCertFileName = "attestationkey.pem";
 
 
         public Provisioner() {
@@ -283,15 +282,11 @@ namespace hirs {
                     }
                     if (cr.HasCertificate) {
                         certificate = cr.Certificate.ToByteArray(); // contains certificate
-                        String certificateFilePath = null;
-                        String certificateDirPath = null;
-                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
-                            certificateDirPath = DefaultCertLocationLinux;
-                            certificateFilePath = DefaultCertLocationLinux + DefaultCertFileName;
-                        }
-                        if (certificateFilePath != null) {
+                        String certificateDirPath = settings.efi_prefix;
+                        if (certificateDirPath != null) {
+                            String certificateFilePath =  certificateFilePath = certificateDirPath + DefaultCertFileName;
                             try {
-                                if (certificateDirPath != null && !Directory.Exists(certificateDirPath)) {
+                                if (!Directory.Exists(certificateDirPath)) {
                                     Directory.CreateDirectory(certificateDirPath);
                                 }
                                 File.WriteAllBytes(certificateFilePath, certificate);

--- a/HIRS_Provisioner.NET/hirs/src/provisioner/Provisioner.cs
+++ b/HIRS_Provisioner.NET/hirs/src/provisioner/Provisioner.cs
@@ -15,6 +15,10 @@ namespace hirs {
         private IHirsDeviceInfoCollector deviceInfoCollector = null;
         private IHirsAcaClient acaClient = null;
 
+        public const string DefaultCertLocationLinux = "/boot/efi/EFI/tcg/cert/attestation/";
+        public const string DefaultCertFileName = "attestationkey.pem";
+
+
         public Provisioner() {
         }
 
@@ -279,6 +283,24 @@ namespace hirs {
                     }
                     if (cr.HasCertificate) {
                         certificate = cr.Certificate.ToByteArray(); // contains certificate
+                        String certificateFilePath = null;
+                        String certificateDirPath = null;
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+                            certificateDirPath = DefaultCertLocationLinux;
+                            certificateFilePath = DefaultCertLocationLinux + DefaultCertFileName;
+                        }
+                        if (certificateFilePath != null) {
+                            try {
+                                if (certificateDirPath != null && !Directory.Exists(certificateDirPath)) {
+                                    Directory.CreateDirectory(certificateDirPath);
+                                }
+                                File.WriteAllBytes(certificateFilePath, certificate);
+                                Log.Debug("Certificate written to local file system: ", certificateFilePath);
+                            }
+                            catch (Exception) {
+                                Log.Debug("Failed to write certificate to local file system.");
+                            }
+                        }
                         Log.Debug("Printing attestation key certificate: " + BitConverter.ToString(certificate));
                     }
                 } else {


### PR DESCRIPTION
Saves the attestation certificate generated by the provisioner to the local file system. Closes #787.