### PR TITLE
Modify rimtool to properly namespace timestamp elements

### DIFF
--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/SwidTagGateway.java
@@ -718,11 +718,13 @@ public class SwidTagGateway {
                 try {
                     byte[] counterSignature = Base64.getEncoder().encode(
                             Files.readAllBytes(Paths.get(timestampArgument)));
-                    timeStampElement = doc.createElementNS(SwidTagConstants.RFC3852_NS, "TimeStamp");
+                    timeStampElement = doc.createElementNS(SwidTagConstants.RFC3852_NS,
+                            SwidTagConstants.RFC3852_PFX + ":TimeStamp");
                     timeStampElement.setAttributeNS("http://www.w3.org/2000/xmlns/",
                             "xmlns:" + SwidTagConstants.RFC3852_PFX,
                             SwidTagConstants.RFC3852_NS);
-                    timeStampElement.setAttribute(SwidTagConstants.DATETIME,
+                    timeStampElement.setAttributeNS(SwidTagConstants.RFC3852_NS,
+                            SwidTagConstants.RFC3852_PFX + ":" + SwidTagConstants.DATETIME,
                             new String(counterSignature));
                 } catch (IOException e) {
                     e.printStackTrace();
@@ -730,15 +732,17 @@ public class SwidTagGateway {
                 }
                 break;
             case "RFC3339":
-                timeStampElement = doc.createElementNS(SwidTagConstants.RFC3339_NS, "TimeStamp");
+                timeStampElement = doc.createElementNS(SwidTagConstants.RFC3339_NS,
+                        SwidTagConstants.RFC3339_PFX + ":TimeStamp");
                 timeStampElement.setAttributeNS("http://www.w3.org/2000/xmlns/",
-                        "xmlns:" + SwidTagConstants.RFC3339_PFX,
-                        SwidTagConstants.RFC3339_NS);
+                        "xmlns:" + SwidTagConstants.RFC3339_PFX,                 SwidTagConstants.RFC3339_NS);
                 if (timestampArgument.isEmpty()) {
-                    timeStampElement.setAttribute(SwidTagConstants.DATETIME,
+                    timeStampElement.setAttributeNS(SwidTagConstants.RFC3339_NS,
+                            SwidTagConstants.RFC3339_PFX + ":" + SwidTagConstants.DATETIME,
                             LocalDateTime.now().toString());
                 } else {
-                    timeStampElement.setAttribute(SwidTagConstants.DATETIME,
+                    timeStampElement.setAttributeNS(SwidTagConstants.RFC3339_NS,
+                            SwidTagConstants.RFC3339_PFX + ":" + SwidTagConstants.DATETIME,
                             timestampArgument);
                 }
                 break;


### PR DESCRIPTION
These changes generate timestamp elements that pass validation:
`<SignatureProperty Id="TST" Target="RimSignature">`
`          <rcf3339:TimeStamp xmlns:rcf3339="https://www.ietf.org/rfc/rfc3339.txt" rcf3339:dateTime="2024-06-19T08:35:20.000Z"/>`
`</SignatureProperty>`

Closes #789 