### PR TITLE
Move part of PciIds from AttestationCA back to Utils

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/AcaPciIds.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/AcaPciIds.java
@@ -14,7 +14,8 @@ import org.bouncycastle.asn1.DERUTF8String;
 import java.util.ArrayList;
 import java.util.List;
 
-import static hirs.utils.PciIds.DB;
+import static hirs.utils.PciIds.translateDevice;
+import static hirs.utils.PciIds.translateVendor;
 
 /**
  * Provide Java access to PCI IDs.
@@ -128,88 +129,5 @@ public final class AcaPciIds {
                     componentResult.getModel()));
         }
         return newComponent;
-    }
-
-    /**
-     * Look up the vendor name from the PCI IDs list, if the input string contains an ID.
-     * If any part of this fails, return the original manufacturer value.
-     * @param refManufacturer DERUTF8String, likely from a ComponentIdentifier
-     * @return DERUTF8String with the discovered vendor name, or the original manufacturer value.
-     */
-    public static ASN1UTF8String translateVendor(final ASN1UTF8String refManufacturer) {
-        ASN1UTF8String manufacturer = refManufacturer;
-        if (manufacturer != null && manufacturer.getString().trim().matches("^[0-9A-Fa-f]{4}$")) {
-            Vendor ven = DB.findVendor(manufacturer.getString().toLowerCase());
-            if (ven != null && !Strings.isNullOrEmpty(ven.getName())) {
-                manufacturer = new DERUTF8String(ven.getName());
-            }
-        }
-        return manufacturer;
-    }
-
-    /**
-     * Look up the vendor name from the PCI IDs list, if the input string contains an ID.
-     * If any part of this fails, return the original manufacturer value.
-     * @param refManufacturer String, likely from a ComponentResult
-     * @return String with the discovered vendor name, or the original manufacturer value.
-     */
-    public static String translateVendor(final String refManufacturer) {
-        String manufacturer = refManufacturer;
-        if (manufacturer != null && manufacturer.trim().matches("^[0-9A-Fa-f]{4}$")) {
-            Vendor ven = DB.findVendor(manufacturer.toLowerCase());
-            if (ven != null && !Strings.isNullOrEmpty(ven.getName())) {
-                manufacturer = ven.getName();
-            }
-        }
-        return manufacturer;
-    }
-
-    /**
-     * Look up the device name from the PCI IDs list, if the input strings contain IDs.
-     * The Device lookup requires the Vendor ID AND the Device ID to be valid values.
-     * If any part of this fails, return the original model value.
-     * @param refManufacturer ASN1UTF8String, likely from a ComponentIdentifier
-     * @param refModel ASN1UTF8String, likely from a ComponentIdentifier
-     * @return ASN1UTF8String with the discovered device name, or the original model value.
-     */
-    public static ASN1UTF8String translateDevice(final ASN1UTF8String refManufacturer,
-                                                final ASN1UTF8String refModel) {
-        ASN1UTF8String manufacturer = refManufacturer;
-        ASN1UTF8String model = refModel;
-        if (manufacturer != null
-                && model != null
-                && manufacturer.getString().trim().matches("^[0-9A-Fa-f]{4}$")
-                && model.getString().trim().matches("^[0-9A-Fa-f]{4}$")) {
-            Device dev = DB.findDevice(manufacturer.getString().toLowerCase(),
-                    model.getString().toLowerCase());
-            if (dev != null && !Strings.isNullOrEmpty(dev.getName())) {
-                model = new DERUTF8String(dev.getName());
-            }
-        }
-        return model;
-    }
-
-    /**
-     * Look up the device name from the PCI IDs list, if the input strings contain IDs.
-     * The Device lookup requires the Vendor ID AND the Device ID to be valid values.
-     * If any part of this fails, return the original model value.
-     * @param refManufacturer String, likely from a ComponentResult
-     * @param refModel String, likely from a ComponentResult
-     * @return String with the discovered device name, or the original model value.
-     */
-    public static String translateDevice(final String refManufacturer,
-                                         final String refModel) {
-        String model = refModel;
-        if (refManufacturer != null
-                && model != null
-                && refManufacturer.trim().matches("^[0-9A-Fa-f]{4}$")
-                && model.trim().matches("^[0-9A-Fa-f]{4}$")) {
-            Device dev = DB.findDevice(refManufacturer.toLowerCase(),
-                    model.toLowerCase());
-            if (dev != null && !Strings.isNullOrEmpty(dev.getName())) {
-                model = dev.getName();
-            }
-        }
-        return model;
     }
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/AcaPciIds.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/AcaPciIds.java
@@ -2,7 +2,6 @@ package hirs.attestationca.persist.util;
 
 import com.github.marandus.pciid.model.Device;
 import com.github.marandus.pciid.model.Vendor;
-import com.github.marandus.pciid.service.PciIdsDatabase;
 import com.google.common.base.Strings;
 import hirs.attestationca.persist.entity.userdefined.certificate.ComponentResult;
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.ComponentIdentifier;
@@ -12,71 +11,16 @@ import lombok.extern.log4j.Log4j2;
 import org.bouncycastle.asn1.ASN1UTF8String;
 import org.bouncycastle.asn1.DERUTF8String;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+
+import static hirs.utils.PciIds.DB;
 
 /**
  * Provide Java access to PCI IDs.
  */
 @Log4j2
 public final class AcaPciIds {
-    /**
-     * This pci ids file can be in different places on different distributions.
-     */
-    public static final List<String> PCI_IDS_PATH =
-            Collections.unmodifiableList(new ArrayList<>() {
-                private static final long serialVersionUID = 1L;
-                {
-                    add("/usr/share/hwdata/pci.ids");
-                    add("/usr/share/misc/pci.ids");
-                    add("/tmp/pci.ids");
-                }
-            });
-
-    /**
-     * The PCI IDs Database object.
-     *
-     * This only needs to be loaded one time.
-     *
-     * The pci ids library protects the data inside the object by making it immutable.
-     */
-    public static final PciIdsDatabase DB = new PciIdsDatabase();
-
-    static {
-        if (!DB.isReady()) {
-            String dbFile = null;
-            for (final String path : PCI_IDS_PATH) {
-                if ((new File(path)).exists()) {
-                    log.info("PCI IDs file was found {}", path);
-                    dbFile = path;
-                    break;
-                }
-            }
-            if (dbFile != null) {
-                InputStream is = null;
-                try {
-                    is = new FileInputStream(new File(dbFile));
-                    DB.loadStream(is);
-                } catch (IOException e) {
-                    // DB will not be ready, hardware IDs will not be translated
-                    dbFile = null;
-                } finally {
-                    if (is != null) {
-                        try {
-                            is.close();
-                        } catch (IOException e) {
-                            dbFile = null;
-                        }
-                    }
-                }
-            }
-        }
-    }
 
     /**
      * The Component Class TCG Registry OID.

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/AcaPciIds.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/AcaPciIds.java
@@ -1,14 +1,10 @@
 package hirs.attestationca.persist.util;
 
-import com.github.marandus.pciid.model.Device;
-import com.github.marandus.pciid.model.Vendor;
-import com.google.common.base.Strings;
 import hirs.attestationca.persist.entity.userdefined.certificate.ComponentResult;
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.ComponentIdentifier;
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.V2.ComponentIdentifierV2;
 
 import lombok.extern.log4j.Log4j2;
-import org.bouncycastle.asn1.ASN1UTF8String;
 import org.bouncycastle.asn1.DERUTF8String;
 
 import java.util.ArrayList;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/AcaPciIds.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/AcaPciIds.java
@@ -24,7 +24,7 @@ import java.util.List;
  * Provide Java access to PCI IDs.
  */
 @Log4j2
-public final class PciIds {
+public final class AcaPciIds {
     /**
      * This pci ids file can be in different places on different distributions.
      */

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
@@ -14,6 +14,7 @@ import hirs.attestationca.persist.entity.userdefined.info.HardwareInfo;
 import hirs.attestationca.persist.entity.userdefined.report.DeviceInfoReport;
 import hirs.attestationca.persist.enums.AppraisalStatus;
 import hirs.attestationca.persist.util.AcaPciIds;
+import hirs.utils.PciIds;
 import hirs.utils.enums.DeviceInfoEnums;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -445,7 +446,7 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
             // is to be displayed as the failure
             fullDeltaChainComponents.clear();
             for (ComponentIdentifier ci : subCompIdList) {
-                if (ci.isVersion2() && AcaPciIds.DB.isReady()) {
+                if (ci.isVersion2() && PciIds.DB.isReady()) {
                     ci = AcaPciIds.translate((ComponentIdentifierV2) ci);
                 }
                 log.error("Unmatched component: " + ci);
@@ -606,7 +607,7 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
 
             int unmatchedComponentCounter = 1;
             for (ComponentIdentifier unmatchedComponent : pcUnmatchedComponents) {
-                if (unmatchedComponent.isVersion2() && AcaPciIds.DB.isReady()) {
+                if (unmatchedComponent.isVersion2() && PciIds.DB.isReady()) {
                     unmatchedComponent =
                             AcaPciIds.translate((ComponentIdentifierV2) unmatchedComponent);
                 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/CertificateAttributeScvValidator.java
@@ -13,7 +13,7 @@ import hirs.attestationca.persist.entity.userdefined.info.ComponentInfo;
 import hirs.attestationca.persist.entity.userdefined.info.HardwareInfo;
 import hirs.attestationca.persist.entity.userdefined.report.DeviceInfoReport;
 import hirs.attestationca.persist.enums.AppraisalStatus;
-import hirs.attestationca.persist.util.PciIds;
+import hirs.attestationca.persist.util.AcaPciIds;
 import hirs.utils.enums.DeviceInfoEnums;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -445,8 +445,8 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
             // is to be displayed as the failure
             fullDeltaChainComponents.clear();
             for (ComponentIdentifier ci : subCompIdList) {
-                if (ci.isVersion2() && PciIds.DB.isReady()) {
-                    ci = PciIds.translate((ComponentIdentifierV2) ci);
+                if (ci.isVersion2() && AcaPciIds.DB.isReady()) {
+                    ci = AcaPciIds.translate((ComponentIdentifierV2) ci);
                 }
                 log.error("Unmatched component: " + ci);
                 fullDeltaChainComponents.add(ci);
@@ -606,9 +606,9 @@ public class CertificateAttributeScvValidator extends SupplyChainCredentialValid
 
             int unmatchedComponentCounter = 1;
             for (ComponentIdentifier unmatchedComponent : pcUnmatchedComponents) {
-                if (unmatchedComponent.isVersion2() && PciIds.DB.isReady()) {
+                if (unmatchedComponent.isVersion2() && AcaPciIds.DB.isReady()) {
                     unmatchedComponent =
-                            PciIds.translate((ComponentIdentifierV2) unmatchedComponent);
+                            AcaPciIds.translate((ComponentIdentifierV2) unmatchedComponent);
                 }
                 log.error("Unmatched component " + unmatchedComponentCounter++ + ": "
                         + unmatchedComponent);

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -14,6 +14,7 @@ import hirs.attestationca.persist.entity.userdefined.certificate.attributes.Comp
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.PlatformConfiguration;
 import hirs.attestationca.persist.util.AcaPciIds;
 import hirs.utils.BouncyCastleUtils;
+import hirs.utils.PciIds;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -371,7 +372,7 @@ public final class CertificateStringMapBuilder {
                     .findByCertificateSerialNumberAndBoardSerialNumber(
                             certificate.getSerialNumber().toString(),
                             certificate.getPlatformSerial());
-            if (AcaPciIds.DB.isReady()) {
+            if (PciIds.DB.isReady()) {
                 compResults = AcaPciIds.translateResults(compResults);
             }
             data.put("componentResults", compResults);
@@ -381,7 +382,7 @@ public final class CertificateStringMapBuilder {
             if (platformConfiguration != null) {
                 //Component Identifier - attempt to translate hardware IDs
                 List<ComponentIdentifier> comps = platformConfiguration.getComponentIdentifier();
-                if (AcaPciIds.DB.isReady()) {
+                if (PciIds.DB.isReady()) {
                     comps = AcaPciIds.translate(comps);
                 }
                 data.put("componentsIdentifier", comps);

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -12,7 +12,7 @@ import hirs.attestationca.persist.entity.userdefined.certificate.IssuedAttestati
 import hirs.attestationca.persist.entity.userdefined.certificate.PlatformCredential;
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.ComponentIdentifier;
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.PlatformConfiguration;
-import hirs.attestationca.persist.util.PciIds;
+import hirs.attestationca.persist.util.AcaPciIds;
 import hirs.utils.BouncyCastleUtils;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -371,8 +371,8 @@ public final class CertificateStringMapBuilder {
                     .findByCertificateSerialNumberAndBoardSerialNumber(
                             certificate.getSerialNumber().toString(),
                             certificate.getPlatformSerial());
-            if (PciIds.DB.isReady()) {
-                compResults = PciIds.translateResults(compResults);
+            if (AcaPciIds.DB.isReady()) {
+                compResults = AcaPciIds.translateResults(compResults);
             }
             data.put("componentResults", compResults);
 
@@ -381,8 +381,8 @@ public final class CertificateStringMapBuilder {
             if (platformConfiguration != null) {
                 //Component Identifier - attempt to translate hardware IDs
                 List<ComponentIdentifier> comps = platformConfiguration.getComponentIdentifier();
-                if (PciIds.DB.isReady()) {
-                    comps = PciIds.translate(comps);
+                if (AcaPciIds.DB.isReady()) {
+                    comps = AcaPciIds.translate(comps);
                 }
                 data.put("componentsIdentifier", comps);
                 //Component Identifier URI

--- a/HIRS_Utils/build.gradle
+++ b/HIRS_Utils/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation libs.commons.lang3
     implementation libs.commons.io
     implementation libs.minimal.json
+    implementation libs.pci
 
     implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
     implementation 'org.apache.logging.log4j:log4j-api:2.19.0'

--- a/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
@@ -1,6 +1,7 @@
 package hirs.utils;
 
 import com.github.marandus.pciid.model.Device;
+import com.github.marandus.pciid.model.DeviceClass;
 import com.github.marandus.pciid.model.Vendor;
 import com.github.marandus.pciid.service.PciIdsDatabase;
 import com.google.common.base.Strings;
@@ -156,5 +157,25 @@ public final class PciIds {
             }
         }
         return model;
+    }
+
+    /**
+     * Look up the device class name from the PCI IDs list, if the input string contains an ID.
+     * If any part of this fails, return the original manufacturer value.
+     * @param refDeviceClass String
+     * @return String with the discovered vendor name, or the original manufacturer value.
+     */
+    public static String translateDeviceClass(final String refDeviceClass) {
+        String deviceClass = refDeviceClass;
+        if (deviceClass != null && deviceClass.trim().matches("^[0-9A-Fa-f]{6}$")) {
+            DeviceClass devC = DB.findDeviceClass(deviceClass.toLowerCase());
+            DeviceClass devD = DB.findDeviceClass("010802");
+            System.out.println("XXXX: " + devC);
+            System.out.println("YYYY: " + devD);
+            if (devC != null && !Strings.isNullOrEmpty(devC.getName())) {
+                deviceClass = devC.getName();
+            }
+        }
+        return deviceClass;
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
@@ -1,4 +1,73 @@
 package hirs.utils;
 
-public class PciIds {
+import com.github.marandus.pciid.service.PciIdsDatabase;
+import lombok.extern.log4j.Log4j2;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Provide Java access to PCI IDs.
+ */
+@Log4j2
+public final class PciIds {
+
+    /**
+     * This pci ids file can be in different places on different distributions.
+     */
+    public static final List<String> PCI_IDS_PATH =
+            Collections.unmodifiableList(new ArrayList<>() {
+                private static final long serialVersionUID = 1L;
+                {
+                    add("/usr/share/hwdata/pci.ids");
+                    add("/usr/share/misc/pci.ids");
+                    add("/tmp/pci.ids");
+                }
+            });
+
+    /**
+     * The PCI IDs Database object.
+     *
+     * This only needs to be loaded one time.
+     *
+     * The pci ids library protects the data inside the object by making it immutable.
+     */
+    public static final PciIdsDatabase DB = new PciIdsDatabase();
+
+    static {
+        if (!DB.isReady()) {
+            String dbFile = null;
+            for (final String path : PCI_IDS_PATH) {
+                if ((new File(path)).exists()) {
+                    log.info("PCI IDs file was found {}", path);
+                    dbFile = path;
+                    break;
+                }
+            }
+            if (dbFile != null) {
+                InputStream is = null;
+                try {
+                    is = new FileInputStream(new File(dbFile));
+                    DB.loadStream(is);
+                } catch (IOException e) {
+                    // DB will not be ready, hardware IDs will not be translated
+                    dbFile = null;
+                } finally {
+                    if (is != null) {
+                        try {
+                            is.close();
+                        } catch (IOException e) {
+                            dbFile = null;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
@@ -1,0 +1,4 @@
+package hirs.utils;
+
+public class PciIds {
+}

--- a/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
@@ -1,7 +1,12 @@
 package hirs.utils;
 
+import com.github.marandus.pciid.model.Device;
+import com.github.marandus.pciid.model.Vendor;
 import com.github.marandus.pciid.service.PciIdsDatabase;
+import com.google.common.base.Strings;
 import lombok.extern.log4j.Log4j2;
+import org.bouncycastle.asn1.ASN1UTF8String;
+import org.bouncycastle.asn1.DERUTF8String;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -70,4 +75,86 @@ public final class PciIds {
         }
     }
 
+    /**
+     * Look up the vendor name from the PCI IDs list, if the input string contains an ID.
+     * If any part of this fails, return the original manufacturer value.
+     * @param refManufacturer DERUTF8String, likely from a ComponentIdentifier
+     * @return DERUTF8String with the discovered vendor name, or the original manufacturer value.
+     */
+    public static ASN1UTF8String translateVendor(final ASN1UTF8String refManufacturer) {
+        ASN1UTF8String manufacturer = refManufacturer;
+        if (manufacturer != null && manufacturer.getString().trim().matches("^[0-9A-Fa-f]{4}$")) {
+            Vendor ven = DB.findVendor(manufacturer.getString().toLowerCase());
+            if (ven != null && !Strings.isNullOrEmpty(ven.getName())) {
+                manufacturer = new DERUTF8String(ven.getName());
+            }
+        }
+        return manufacturer;
+    }
+
+    /**
+     * Look up the vendor name from the PCI IDs list, if the input string contains an ID.
+     * If any part of this fails, return the original manufacturer value.
+     * @param refManufacturer String, likely from a ComponentResult
+     * @return String with the discovered vendor name, or the original manufacturer value.
+     */
+    public static String translateVendor(final String refManufacturer) {
+        String manufacturer = refManufacturer;
+        if (manufacturer != null && manufacturer.trim().matches("^[0-9A-Fa-f]{4}$")) {
+            Vendor ven = DB.findVendor(manufacturer.toLowerCase());
+            if (ven != null && !Strings.isNullOrEmpty(ven.getName())) {
+                manufacturer = ven.getName();
+            }
+        }
+        return manufacturer;
+    }
+
+    /**
+     * Look up the device name from the PCI IDs list, if the input strings contain IDs.
+     * The Device lookup requires the Vendor ID AND the Device ID to be valid values.
+     * If any part of this fails, return the original model value.
+     * @param refManufacturer ASN1UTF8String, likely from a ComponentIdentifier
+     * @param refModel ASN1UTF8String, likely from a ComponentIdentifier
+     * @return ASN1UTF8String with the discovered device name, or the original model value.
+     */
+    public static ASN1UTF8String translateDevice(final ASN1UTF8String refManufacturer,
+                                                 final ASN1UTF8String refModel) {
+        ASN1UTF8String manufacturer = refManufacturer;
+        ASN1UTF8String model = refModel;
+        if (manufacturer != null
+                && model != null
+                && manufacturer.getString().trim().matches("^[0-9A-Fa-f]{4}$")
+                && model.getString().trim().matches("^[0-9A-Fa-f]{4}$")) {
+            Device dev = DB.findDevice(manufacturer.getString().toLowerCase(),
+                    model.getString().toLowerCase());
+            if (dev != null && !Strings.isNullOrEmpty(dev.getName())) {
+                model = new DERUTF8String(dev.getName());
+            }
+        }
+        return model;
+    }
+
+    /**
+     * Look up the device name from the PCI IDs list, if the input strings contain IDs.
+     * The Device lookup requires the Vendor ID AND the Device ID to be valid values.
+     * If any part of this fails, return the original model value.
+     * @param refManufacturer String, likely from a ComponentResult
+     * @param refModel String, likely from a ComponentResult
+     * @return String with the discovered device name, or the original model value.
+     */
+    public static String translateDevice(final String refManufacturer,
+                                         final String refModel) {
+        String model = refModel;
+        if (refManufacturer != null
+                && model != null
+                && refManufacturer.trim().matches("^[0-9A-Fa-f]{4}$")
+                && model.trim().matches("^[0-9A-Fa-f]{4}$")) {
+            Device dev = DB.findDevice(refManufacturer.toLowerCase(),
+                    model.toLowerCase());
+            if (dev != null && !Strings.isNullOrEmpty(dev.getName())) {
+                model = dev.getName();
+            }
+        }
+        return model;
+    }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
@@ -180,8 +180,8 @@ public final class PciIds {
         String classCode = refClassCode;
         if (classCode != null && classCode.trim().matches("^[0-9A-Fa-f]{6}$")) {
             String deviceClass = classCode.substring(0,2).toLowerCase();
-            String deviceSubclass = classCode.substring(2,2).toLowerCase();
-            String programInterface = classCode.substring(4,2).toLowerCase();
+            String deviceSubclass = classCode.substring(2,4).toLowerCase();
+            String programInterface = classCode.substring(4,6).toLowerCase();
             translatedClassCode.add(deviceClass);
             translatedClassCode.add(deviceSubclass);
             translatedClassCode.add(programInterface);

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataPciContext.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataPciContext.java
@@ -3,6 +3,9 @@ package hirs.utils.tpm.eventlog.events;
 import hirs.utils.HexUtils;
 import lombok.Getter;
 
+import static hirs.utils.PciIds.translateDevice;
+import static hirs.utils.PciIds.translateVendor;
+
 /**
  * Class to process the DEVICE_SECURITY_EVENT_DATA_PCI_CONTEXT event per PFP.
  * <p>
@@ -108,11 +111,11 @@ public class DeviceSecurityEventDataPciContext extends DeviceSecurityEventDataDe
 
         dSEDpciContextInfo += super.toString();
         dSEDpciContextInfo += "\n      Device Type = PCI";
-        dSEDpciContextInfo += "\n      VendorID = 0x" + vendorId;
-        dSEDpciContextInfo += "\n      DeviceID = 0x" + deviceId;
+        dSEDpciContextInfo += "\n      Vendor = " + translateVendor(vendorId);
+        dSEDpciContextInfo += "\n      Device = " + translateDevice(vendorId, deviceId);
         dSEDpciContextInfo += "\n      RevisionID = 0x" + revisionId;
         dSEDpciContextInfo += "\n      ClassCode = 0x" + classCode;
-        dSEDpciContextInfo += "\n      SubsystemVendorID = 0x" + subsystemVendorId;
+        dSEDpciContextInfo += "\n      SubsystemVendor = " + translateVendor(subsystemVendorId);
         dSEDpciContextInfo += "\n      SubsystemID = 0x" + subsystemId;
 
         return dSEDpciContextInfo;

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataPciContext.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataPciContext.java
@@ -120,10 +120,14 @@ public class DeviceSecurityEventDataPciContext extends DeviceSecurityEventDataDe
         dSEDpciContextInfo += "\n      RevisionID = " + revisionId;
 
         List<String> classCodeList = translateDeviceClass(classCode);
-        dSEDpciContextInfo += "\n      Device Class:";
-        dSEDpciContextInfo += "\n        Class = " + classCodeList.get(0);
-        dSEDpciContextInfo += "\n        Subclass = " + classCodeList.get(1);
-        dSEDpciContextInfo += "\n        Programming Interface = " + classCodeList.get(2);
+        dSEDpciContextInfo += "\n      Device Class: ";
+        if(classCodeList.size() == 3) {
+            dSEDpciContextInfo += "\n        Class = " + classCodeList.get(0);
+            dSEDpciContextInfo += "\n        Subclass = " + classCodeList.get(1);
+            dSEDpciContextInfo += "\n        Programming Interface = " + classCodeList.get(2);
+        } else {
+            dSEDpciContextInfo += " ** Class code could not be determined **";
+        }
         dSEDpciContextInfo += "\n      SubsystemVendor = " + translateVendor(subsystemVendorId);
         dSEDpciContextInfo += "\n      Subsystem = " + translateDevice(subsystemVendorId, subsystemId);
 

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataPciContext.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataPciContext.java
@@ -102,9 +102,9 @@ public class DeviceSecurityEventDataPciContext extends DeviceSecurityEventDataDe
     }
 
     /**
-     * Returns a human readable description of the data within this structure.
+     * Returns a human-readable description of the data within this structure.
      *
-     * @return a description of this structure..
+     * @return a description of this structure.
      */
     public String toString() {
         String dSEDpciContextInfo = "";

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataPciContext.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataPciContext.java
@@ -3,6 +3,9 @@ package hirs.utils.tpm.eventlog.events;
 import hirs.utils.HexUtils;
 import lombok.Getter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static hirs.utils.PciIds.translateDevice;
 import static hirs.utils.PciIds.translateDeviceClass;
 import static hirs.utils.PciIds.translateVendor;
@@ -115,7 +118,12 @@ public class DeviceSecurityEventDataPciContext extends DeviceSecurityEventDataDe
         dSEDpciContextInfo += "\n      Vendor = " + translateVendor(vendorId);
         dSEDpciContextInfo += "\n      Device = " + translateDevice(vendorId, deviceId);
         dSEDpciContextInfo += "\n      RevisionID = " + revisionId;
-        dSEDpciContextInfo += "\n      Device Class = " + translateDeviceClass(classCode);
+
+        List<String> classCodeList = translateDeviceClass(classCode);
+        dSEDpciContextInfo += "\n      Device Class:";
+        dSEDpciContextInfo += "\n        Class = " + classCodeList.get(0);
+        dSEDpciContextInfo += "\n        Subclass = " + classCodeList.get(1);
+        dSEDpciContextInfo += "\n        Programming Interface = " + classCodeList.get(2);
         dSEDpciContextInfo += "\n      SubsystemVendor = " + translateVendor(subsystemVendorId);
         dSEDpciContextInfo += "\n      Subsystem = " + translateDevice(subsystemVendorId, subsystemId);
 

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataPciContext.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataPciContext.java
@@ -4,6 +4,7 @@ import hirs.utils.HexUtils;
 import lombok.Getter;
 
 import static hirs.utils.PciIds.translateDevice;
+import static hirs.utils.PciIds.translateDeviceClass;
 import static hirs.utils.PciIds.translateVendor;
 
 /**
@@ -113,10 +114,10 @@ public class DeviceSecurityEventDataPciContext extends DeviceSecurityEventDataDe
         dSEDpciContextInfo += "\n      Device Type = PCI";
         dSEDpciContextInfo += "\n      Vendor = " + translateVendor(vendorId);
         dSEDpciContextInfo += "\n      Device = " + translateDevice(vendorId, deviceId);
-        dSEDpciContextInfo += "\n      RevisionID = 0x" + revisionId;
-        dSEDpciContextInfo += "\n      ClassCode = 0x" + classCode;
+        dSEDpciContextInfo += "\n      RevisionID = " + revisionId;
+        dSEDpciContextInfo += "\n      Device Class = " + translateDeviceClass(classCode);
         dSEDpciContextInfo += "\n      SubsystemVendor = " + translateVendor(subsystemVendorId);
-        dSEDpciContextInfo += "\n      SubsystemID = 0x" + subsystemId;
+        dSEDpciContextInfo += "\n      Subsystem = " + translateDevice(subsystemVendorId, subsystemId);
 
         return dSEDpciContextInfo;
     }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventHeader.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventHeader.java
@@ -208,7 +208,7 @@ public abstract class DeviceSecurityEventHeader {
 
         dsedHeaderCommonInfo += "\n   SPDM Device Type = " + deviceTypeToString(deviceType);
         if (devicePathValid) {
-            dsedHeaderCommonInfo += "\n   SPDM Device Path =\n";
+            dsedHeaderCommonInfo += "\n   SPDM Device Path:\n";
             dsedHeaderCommonInfo += devicePath;
         }
         else {

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiDevicePath.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiDevicePath.java
@@ -116,7 +116,7 @@ public class UefiDevicePath {
      */
     private String processDev(final byte[] path, final int offset)
             throws UnsupportedEncodingException {
-        String devInfo = "    ";
+        String devInfo = "      ";
         int devPath = path[offset];
         byte unknownSubType = path[offset + UefiConstants.OFFSET_1];
         switch (path[0 + offset]) {

--- a/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
+++ b/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
@@ -136,16 +136,13 @@ final class Main {
                                 + evLog.getEventList().size() + " events:\n\n");
                     }
                     if (evLog.getVendorTableFileStatus() == FILESTATUS_NOT_ACCESSIBLE) {
-                        writeOut("*** WARNING: The file vendor-table.json file was not accessible so data "
-                                + "in some Secure Boot PCR 7 events cannot be processed.\n\n");
+                        writeOut("*** WARNING: The file vendor-table.json was not accessible from the "
+                                + "filesystem or the code, so some event data shown in the output of this "
+                                + "tool may be outdated or omitted.\n\n");
                     } else if (evLog.getVendorTableFileStatus() == FILESTATUS_FROM_CODE) {
                         writeOut("*** NOTE: "
                                 + "The file vendor-table.json file was not accessible from the filesystem,\n"
-                                + "          so the vendor-table.json from code was "
-                                + "used. If updates were made in the\n"
-                                + "          filesystem file, they will not be reflected. "
-                                + "This affects parsing in some\n"
-                                + "          Secure Boot PCR 7 events.\n\n");
+                                + "          so the vendor-table.json from code was used.\n\n");
                     }
                 }
                 int eventCount = 0;

--- a/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
+++ b/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
@@ -27,7 +27,12 @@ final class Main {
     private static Commander commander = null;
     private static FileOutputStream outputStream = null;
     private static byte[] eventLog = null;
-    private static boolean bContentFlag, bEventFlag, bHexEvent, bHexFlag, bPcrFlag = false;
+    private static boolean bContentFlag = false;
+    private static boolean bEventFlag = false;
+    private static boolean bHexEvent = false;
+    private static boolean bHexFlag = false;
+    private static boolean bPcrFlag = false;
+
 
     /**
      * Main Constructor.
@@ -131,17 +136,16 @@ final class Main {
                                 + evLog.getEventList().size() + " events:\n\n");
                     }
                     if (evLog.getVendorTableFileStatus() == FILESTATUS_NOT_ACCESSIBLE) {
-                        writeOut("*** WARNING: The file vendor-table.json file was not accessible so data " +
-                                "in some Secure Boot PCR 7 events cannot be processed.\n\n");
-                    }
-                    else if (evLog.getVendorTableFileStatus() == FILESTATUS_FROM_CODE) {
-                        writeOut("*** NOTE: " +
-                                "The file vendor-table.json file was not accessible from the filesystem,\n" +
-                                "          so the vendor-table.json from code was " +
-                                "used. If updates were made in the\n" +
-                                "          filesystem file, they will not be reflected. " +
-                                "This affects parsing in some\n" +
-                                "          Secure Boot PCR 7 events.\n\n");
+                        writeOut("*** WARNING: The file vendor-table.json file was not accessible so data "
+                                + "in some Secure Boot PCR 7 events cannot be processed.\n\n");
+                    } else if (evLog.getVendorTableFileStatus() == FILESTATUS_FROM_CODE) {
+                        writeOut("*** NOTE: "
+                                + "The file vendor-table.json file was not accessible from the filesystem,\n"
+                                + "          so the vendor-table.json from code was "
+                                + "used. If updates were made in the\n"
+                                + "          filesystem file, they will not be reflected. "
+                                + "This affects parsing in some\n"
+                                + "          Secure Boot PCR 7 events.\n\n");
                     }
                 }
                 int eventCount = 0;
@@ -189,7 +193,8 @@ final class Main {
      * @return a byte array holding the entire log
      */
     public static byte[] openLog(final String fileName) {
-        String os = System.getProperty("os.name").toLowerCase(), fName = fileName;
+        String os = System.getProperty("os.name").toLowerCase();
+        String fName = fileName;
         byte[] rawLog = null;
         boolean bDefault = false;
         bHexFlag = commander.getHexFlag();
@@ -248,7 +253,8 @@ final class Main {
      * @return A sting containing human readable results.
      */
     public static String compareLogs(final String logFileName1, final String logFileName2) {
-        TCGEventLog eventLog1 = null, eventLog2 = null;
+        TCGEventLog eventLog1 = null;
+        TCGEventLog eventLog2 = null;
         byte[] evLog = openLog(logFileName1);
         byte[] evLog2 = openLog(logFileName2);
         StringBuilder sb = new StringBuilder();
@@ -337,7 +343,7 @@ final class Main {
      *
      * @param eventLog The Reference Event log.
      * @param event    single event to match.
-     * @return
+     * @return indicator whether match was found.
      */
     private static boolean digestMatch(final Collection<TpmPcrEvent> eventLog,
                                        final TpmPcrEvent event) {


### PR DESCRIPTION
Closes #757 

The class PciIds is in AttestationCA. However, a few functions in PciIds are needed to process SPDM event log structures defined in the PFP (specifically DEVICE_SECURITY_EVENT_DATA_PCI_CONTEXT), and the event log classes are in Utils. PciIds class cannot be accessed from Utils without creating a circular dependency. 
1) renamed AttestationCA pciids to AcaPciIds
2) created a Utils PciIds and moved the DB object, the vendor id and device id translate functions in AcaPciIds into Utils PciIds
3) updated DeviceSecurityEventDataPciContext to use PciIds to report Vendor and Device IDs
4) update Utils PciIds to also translate classcode, and update DeviceSecurityEventDataPciContext to use this feature