### PR TITLE
CI update to show failed tests

### DIFF
--- a/.ci/system-tests/sys_test_common.sh
+++ b/.ci/system-tests/sys_test_common.sh
@@ -89,21 +89,25 @@ provisionTpm2() {
     echo "==========="
     echo "$provisionOutput";
     echo "===========";
-  if [[ $provisionOutput == *"failed"* ]]; then
+  if [[ $provisionOutput == *"failed"* ]]; then  # provisioning failed
      if [[ $expected_result == "pass" ]]; then
         ((failedTests++))
-        echo "!!! Provisioning failed, but was expected to pass"
+        echo "!!! Provisioning failed, but was expected to pass."
      else
         echo "Provisioning failed as expected."
      fi
-  else   # provisioning succeeded
+  elif [[ $provisionOutput == *"Provisioning successful"* ]]; then # provisioning succeeded
      if [[ $expected_result == "fail" ]]; then
        ((failedTests++))
-       echo "!!! Provisioning passed, but was expected to fail"
+       echo "!!! Provisioning passed, but was expected to fail."
      else
-        echo "Provisioning passed as expected."
+        echo "Provisioning passed as expected."     
      fi
+  else 
+       ((failedTests++))
+       echo "Provisioning failed. Provisioner provided an unexpected output."
   fi
+ 
 }
 
 # Places platform cert(s) held in the test folder(s) in the provisioners tcg folder

--- a/.ci/system-tests/tests/rim_system_tests.sh
+++ b/.ci/system-tests/tests/rim_system_tests.sh
@@ -54,6 +54,8 @@ if [[ $failedTests != 0 ]]; then
     #export TEST_STATUS=1;
     echo "TEST_STATUS=1" >> $GITHUB_ENV
     echo "****  $failedTests out of $totalTests ACA RIM Tests Failed! ****"
+    exit 1;
   else
     echo "****  $totalTests ACA RIM Tests Passed! ****"
+    exit 0
 fi

--- a/.ci/system-tests/tests/rim_system_tests.sh
+++ b/.ci/system-tests/tests/rim_system_tests.sh
@@ -3,7 +3,7 @@
 #    HIRS Reference Integrity Manifest System Tests
 #
 #########################################################################################
-source ./.ci/system-tests/sys_test_common.sh
+
 testResult=false
 totalTests=0;
 failedTests=0;
@@ -13,6 +13,8 @@ case $1 in
     2) test="2" ;;
     3) test="3" ;;
 esac
+
+source ./.ci/system-tests/sys_test_common.sh
 
 # Start ACA Reference Integrity Manifest Tests
 # provisionTpm2 takes 1 parameter (the expected result): "pass" or "fail"
@@ -47,6 +49,7 @@ if [ "$test" = "3" ] || [ "$test" = "all" ]; then
 fi
 
 #  Process Test Results, any single failure will send back a failed result.
+echo "failed tests is $failedTests"
 if [[ $failedTests != 0 ]]; then
     #export TEST_STATUS=1;
     echo "TEST_STATUS=1" >> $GITHUB_ENV

--- a/.ci/system-tests/tests/rim_system_tests.sh
+++ b/.ci/system-tests/tests/rim_system_tests.sh
@@ -49,7 +49,6 @@ if [ "$test" = "3" ] || [ "$test" = "all" ]; then
 fi
 
 #  Process Test Results, any single failure will send back a failed result.
-echo "failed tests is $failedTests"
 if [[ $failedTests != 0 ]]; then
     #export TEST_STATUS=1;
     echo "TEST_STATUS=1" >> $GITHUB_ENV

--- a/.ci/system-tests/tests/rim_system_tests.sh
+++ b/.ci/system-tests/tests/rim_system_tests.sh
@@ -48,7 +48,8 @@ fi
 
 #  Process Test Results, any single failure will send back a failed result.
 if [[ $failedTests != 0 ]]; then
-    export TEST_STATUS=1;
+    #export TEST_STATUS=1;
+    echo "TEST_STATUS=1" >> $GITHUB_ENV
     echo "****  $failedTests out of $totalTests ACA RIM Tests Failed! ****"
   else
     echo "****  $totalTests ACA RIM Tests Passed! ****"

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -103,8 +103,8 @@ jobs:
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
-          echo "Value = ${TEST_STATUS}"
-          if [ ${env.TEST_STATUS} != "0" ]; then
+          echo "Value = ${{env.TEST_STATUS}}"
+          if [ ${{env.TEST_STATUS}} != "0" ]; then
                 echo "ACA RIM Test 1 Failed"
                 $FAILED_TEST_COUNT=$(FAILED_TEST_COUNT + 1)
                 $FAILED_TEST_LIST=${FAILED_TEST_LIST}"ACA RIM TEST 1 "

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -102,12 +102,18 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          .ci/system-tests/tests/rim_system_tests.sh 1
+          if [ .ci/system-tests/tests/rim_system_tests.sh 1 ]
+              echo "ACA RIM Test 1 passed"
+            else
+              echo "ACA RIM Test 1 Failed"
+              FAILED_TEST_LIST=$FAILED_TEST_LIST"ACA RIM TEST 1 "
+              FAILED_TEST_COUNT++
+          fi
           echo "Value = ${{env.TEST_STATUS}}"
           if [ ${{env.TEST_STATUS}} != "0" ]; then
                 echo "ACA RIM Test 1 Failed"
-                $FAILED_TEST_COUNT=$(FAILED_TEST_COUNT + 1)
-                $FAILED_TEST_LIST=${FAILED_TEST_LIST}"ACA RIM TEST 1 "
+                #FAILED_TEST_COUNT=$(FAILED_TEST_COUNT + 1)
+                FAILED_TEST_LIST=${FAILED_TEST_LIST++}"ACA RIM TEST 1 "
             else echo "RIM Test 1 passed???"
               echo ""
           fi

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -12,7 +12,7 @@ env:
   TEST_STATUS: 0
   FAILED_TEST_COUNT: 0
   TEST_COUNT: 14
-  FAILED_TEST_LIST: "none"
+  FAILED_TEST_LIST: ""
 jobs:
   DockerTests:
     runs-on: ubuntu-latest
@@ -106,8 +106,8 @@ jobs:
               echo "ACA RIM Test 1 passed"
             else
               echo "ACA RIM Test 1 Failed"
-              FAILED_TEST_LIST=$FAILED_TEST_LIST"ACA RIM TEST 1 "
-              FAILED_TEST_COUNT++
+              FAILED_TEST_LIST="${FAILED_TEST_LIST}ACA RIM TEST 1 "
+              FAILED_TEST_COUNT=$((FAILED_TEST_COUNT++))
           fi
           echo "Value = ${{env.TEST_STATUS}}"
           echo "${FAILED_TEST_LIST} failed, moving on..."

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -153,5 +153,5 @@ jobs:
       - name: Check System Test results
         if: success() || failure()
         run: |
-         echo "TEST_RIM_1 is ${env.TEST_RIM_1}"
-         echo "TEST_RIM_2 is ${env.TEST_RIM_2}"
+         echo "TEST_RIM_1 is ${TEST_RIM_1}"
+         echo "TEST_RIM_2 is ${TEST_RIM_2}"

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -12,7 +12,7 @@ env:
   TEST_STATUS: 0
   FAILED_TEST_COUNT: 0
   TEST_COUNT: 14
-  FAILED_TEST_LIST: ""
+  FAILED_TEST_LIST: "none"
 jobs:
   DockerTests:
     runs-on: ubuntu-latest
@@ -104,9 +104,10 @@ jobs:
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
           if [ ${TEST_STATUS} == "1" ]; then
-                ${FAILED_TEST_COUNT}++
-                ${FAILED_TEST_LIST} = ${FAILED_TEST_LIST} + "ACA RIM TEST 1 "
+                ${FAILED_TEST_COUNT}=${FAILED_TEST_COUNT} + 1
+                ${FAILED_TEST_LIST}=${FAILED_TEST_LIST} + "ACA RIM TEST 1 "
           fi
+          echo "${FAILED_TEST_LIST} failed, moving on..."
           
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR
         continue-on-error: true
@@ -136,15 +137,15 @@ jobs:
         run: |
           echo "*** Exiting and removing Docker containers and network ..."
           docker compose -f .ci/docker/docker-compose-system-test.yml down -v
-          if [[ ${TEST_STATUS} == "0" ]]; then
-            echo "******** SUCCESS: System Tests for TPM 2.0 passed ********"
-            echo "TEST_STATUS=0" >> $GITHUB_ENV
-            exit 0;
-          else
-            echo "******** FAILURE: System Tests for TPM 2.0 failed ********"
-            echo "TEST_STATUS=1" >> $GITHUB_ENV
-            exit 1
-          fi
+         # if [[ ${TEST_STATUS} == "0" ]]; then
+         #   echo "******** SUCCESS: System Tests for TPM 2.0 passed ********"
+         #   echo "TEST_STATUS=0" >> $GITHUB_ENV
+         #   exit 0;
+         # else
+          #  echo "******** FAILURE: System Tests for TPM 2.0 failed ********"
+          #  echo "TEST_STATUS=1" >> $GITHUB_ENV
+          #  exit 1
+         # fi
       - name: Archive System Test Log files
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -105,13 +105,13 @@ jobs:
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
-          TEST_RIM_1="pass"
+          env.TEST_RIM_1="pass"
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR
         continue-on-error: true
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 2
-          TEST_RIM_2="pass"
+          env.TEST_RIM_2="pass"
       - name: ACA RIM TEST 3 - Test a RIM from an OEM and a Supplemental RIM from a VAR with a bad reference measurement
         continue-on-error: true
         shell: bash

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -101,7 +101,8 @@ jobs:
       #   run: |
       #     .ci/system-tests/tests/platform_cert_tests.sh
       - name: ACA RIM TEST 1 - Test a RIM from an OEM and a Supplemental RIM from a VAR
-        continue-on-error: false
+        if: always()
+        #continue-on-error: true
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
@@ -155,3 +156,5 @@ jobs:
         run: |
          echo "TEST_RIM_1 status is ${TEST_RIM_1}"
          echo "TEST_RIM_2 status is ${TEST_RIM_2}"
+         if [[ ${TEST_RIM_1} == 'failed']]; then exit 1; fi;
+          

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -154,16 +154,16 @@ jobs:
           name: System_Test_Log_Files
           path: logs/
           if-no-files-found: ignore
-      - name: Check System Test results
-        if: success() || failure()
-        run: |
-         echo "TEST_RIM_1 status is ${TEST_RIM_1}"
-         echo "TEST_RIM_2 status is ${TEST_RIM_2}"
-         echo "TEST_RIM_3 status is ${TEST_RIM_3}"
-         if [[ ${TEST_RIM_1} == 'failed']]; then 
-           exit 1;
-           else
-             exit 0; 
-         fi;
+    #  - name: Check System Test results
+     #   if: success() || failure()
+       # run: |
+       #  echo "TEST_RIM_1 status is ${TEST_RIM_1}"
+       #  echo "TEST_RIM_2 status is ${TEST_RIM_2}"
+       #  echo "TEST_RIM_3 status is ${TEST_RIM_3}"
+       #  if [[ ${TEST_RIM_1} == 'failed' ]]; then 
+       #    exit 1;
+       #    else
+       #      exit 0; 
+       #  fi;
          
-          
+         

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -105,13 +105,13 @@ jobs:
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
-           TEST_RIM_1="pass"
+           echo "TEST_RIM_1=passed" >> $GITHUB_ENV
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR
         continue-on-error: true
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 2
-           TEST_RIM_2="pass"
+           echo "TEST_RIM_2=passed" >> $GITHUB_ENV
       - name: ACA RIM TEST 3 - Test a RIM from an OEM and a Supplemental RIM from a VAR with a bad reference measurement
         continue-on-error: true
         shell: bash
@@ -153,5 +153,5 @@ jobs:
       - name: Check System Test results
         if: success() || failure()
         run: |
-         echo "TEST_RIM_1 is ${TEST_RIM_1}"
-         echo "TEST_RIM_2 is ${TEST_RIM_2}"
+         echo "TEST_RIM_1 status is ${TEST_RIM_1}"
+         echo "TEST_RIM_2 status is ${TEST_RIM_2}"

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -115,7 +115,7 @@ jobs:
         shell: bash
         run: |
           echo "*** Exiting and removing Docker containers and network ..."
-          doFailedocker compose -f .ci/docker/docker-compose-system-test.yml down -v
+          doFaileddocker compose -f .ci/docker/docker-compose-system-test.yml down -v
       - name: Archive System Test Log files
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -101,7 +101,7 @@ jobs:
       #   run: |
       #     .ci/system-tests/tests/platform_cert_tests.sh
       - name: ACA RIM TEST 1 - Test a RIM from an OEM and a Supplemental RIM from a VAR
-        continue-on-error: true
+        continue-on-error: false
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
@@ -134,7 +134,7 @@ jobs:
         shell: bash
         run: |
           echo "*** Exiting and removing Docker containers and network ..."
-          doFailedcker compose -f .ci/docker/docker-compose-system-test.yml down -v
+          doFailedocker compose -f .ci/docker/docker-compose-system-test.yml down -v
          # if [[ ${TEST_STATUS} == "0" ]]; then
          #   echo "******** SUCCESS: System Tests for TPM 2.0 passed ********"
          #   echo "TEST_STATUS=0" ${FAILED_TEST_LIST}>> $GITHUB_ENV

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -102,9 +102,9 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-            .ci/system-tests/tests/rim_system_tests.sh 1
-            if [ $? -ne 0 ]; then
-              echo "ACA RIM Test 1 Failed"
+          .ci/system-tests/tests/rim_system_tests.sh 1
+          if [ $? -ne 0 ]; then
+            echo "ACA RIM Test 1 Failed"
               FAILED_TEST_LIST="${FAILED_TEST_LIST}ACA RIM TEST 1 "
               FAILED_TEST_COUNT=$((FAILED_TEST_COUNT++))
             else
@@ -124,7 +124,7 @@ jobs:
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 3
       # - name: All RIM System Tests 1-3
-      #   continue-on-error: true
+      #   cFailedontinue-on-error: true
       #   shell: bash
       #   run: |
       #     .ci/system-tests/tests/rim_system_tests.sh
@@ -140,7 +140,7 @@ jobs:
         shell: bash
         run: |
           echo "*** Exiting and removing Docker containers and network ..."
-          docker compose -f .ci/docker/docker-compose-system-test.yml down -v
+          doFailedcker compose -f .ci/docker/docker-compose-system-test.yml down -v
          # if [[ ${TEST_STATUS} == "0" ]]; then
          #   echo "******** SUCCESS: System Tests for TPM 2.0 passed ********"
          #   echo "TEST_STATUS=0" ${FAILED_TEST_LIST}>> $GITHUB_ENV

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -104,10 +104,11 @@ jobs:
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
           if [ ${TEST_STATUS} == "1" ]; then
-                ${FAILED_TEST_COUNT}=${FAILED_TEST_COUNT} + 1
-                ${FAILED_TEST_LIST}=${FAILED_TEST_LIST} + "ACA RIM TEST 1 "
+                echo "RIM Test 1 Failed"
+                $FAILED_TEST_COUNT=$(($FAILED_TEST_COUNT + 1))
+                $FAILED_TEST_LIST=${}FAILED_TEST_LIST}"ACA RIM TEST 1 "
           fi
-          echo "${FAILED_TEST_LIST} failed, moving on..."
+          echo "${FAILED_TEST_LIS${FAILED_TEST_LIST}T} failed, moving on..."
           
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR
         continue-on-error: true
@@ -139,7 +140,7 @@ jobs:
           docker compose -f .ci/docker/docker-compose-system-test.yml down -v
          # if [[ ${TEST_STATUS} == "0" ]]; then
          #   echo "******** SUCCESS: System Tests for TPM 2.0 passed ********"
-         #   echo "TEST_STATUS=0" >> $GITHUB_ENV
+         #   echo "TEST_STATUS=0" ${FAILED_TEST_LIST}>> $GITHUB_ENV
          #   exit 0;
          # else
           #  echo "******** FAILURE: System Tests for TPM 2.0 failed ********"

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -103,9 +103,9 @@ jobs:
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
-          echo "TEST_STATUS = ${TEST_STATUS}"
-          if [ ${TEST_STATUS} != "0" ]; then
-                echo "RIM Test 1 Failed"
+          echo "Value = ${TEST_STATUS}"
+          if [ ${env.TEST_STATUS} != "0" ]; then
+                echo "ACA RIM Test 1 Failed"
                 $FAILED_TEST_COUNT=$(FAILED_TEST_COUNT + 1)
                 $FAILED_TEST_LIST=${FAILED_TEST_LIST}"ACA RIM TEST 1 "
             else echo "RIM Test 1 passed???"

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -10,11 +10,6 @@ on:
   workflow_dispatch:
 env:
   TEST_STATUS: 0
-  FAILED_TEST_COUNT: 0
-  TEST_COUNT: 14
-  FAILED_TEST_LIST: ""
-  TEST_RIM_1: "failed"
-  TEST_RIM_2: "failed"
 jobs:
   DockerTests:
     runs-on: ubuntu-latest
@@ -36,96 +31,78 @@ jobs:
           echo "${{ secrets.PKG_PWD }}" | docker login ghcr.io -u $ --password-stdin
           .ci/system-tests/setup_system_tests.sh ${GITHUB_REF#refs/heads/}
       - name: ACA POLICY TEST 1 - Test ACA default policy
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           .ci/system-tests/tests/aca_policy_tests.sh 1
       - name: ACA POLICY TEST 2 - Test EK cert Only Validation Policy without a EK Issuer Cert in the trust store
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           .ci/system-tests/tests/aca_policy_tests.sh 2
       - name: ACA POLICY TEST 3 - Test EK Only Validation Policy
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           .ci/system-tests/tests/aca_policy_tests.sh 3
       - name: ACA POLICY TEST 4 - Test PC Validation Policy with no PC
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           .ci/system-tests/tests/aca_policy_tests.sh 4
       - name: ACA POLICY TEST 5 - Test FW and PC Validation Policy with no PC
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           .ci/system-tests/tests/aca_policy_tests.sh 5
       - name: ACA POLICY TEST 6 - Test PC Validation Policy with valid PC with no Attribute Check
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           .ci/system-tests/tests/aca_policy_tests.sh 6
       - name: ACA POLICY TEST 7 - Test PC Validation Policy with valid PC with Attribute Check
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           .ci/system-tests/tests/aca_policy_tests.sh 7
       - name: ACA POLICY TEST 8 - Test PC with RIM Validation Policy with valid PC and RIM
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           .ci/system-tests/tests/aca_policy_tests.sh 8
-      # - name: All ACA Policy Tests 1-8
-      #   continue-on-error: true
-      #   shell: bash
-      #   run: |
-      #     .ci/system-tests/tests/aca_policy_tests.sh
       - name: ACA PLATFORM CERTIFICATE TEST 1 - Test a delta Platform Certificate that adds a new memory component
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           .ci/system-tests/tests/platform_cert_tests.sh 1
       - name: ACA PLATFORM CERTIFICATE TEST 2 - Test a Platform Certificate that is missing a memory component
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           .ci/system-tests/tests/platform_cert_tests.sh 2
       - name: ACA PLATFORM CERTIFICATE TEST 3 - Test a Delta Platform Certificate that has a wrong a memory component
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           .ci/system-tests/tests/platform_cert_tests.sh 3
-      # - name: All Platform Cert Tests 1-3
-      #   continue-on-error: true
-      #   shell: bash
-      #   run: |
-      #     .ci/system-tests/tests/platform_cert_tests.sh
       - name: ACA RIM TEST 1 - Test a RIM from an OEM and a Supplemental RIM from a VAR
         if: always()
-        #continue-on-error: true
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
            echo "TEST_RIM_1=passed" >> $GITHUB_ENV
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR
         if: always()
-        #continue-on-error: true
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 2
            echo "TEST_RIM_2=passed" >> $GITHUB_ENV
       - name: ACA RIM TEST 3 - Test a RIM from an OEM and a Supplemental RIM from a VAR with a bad reference measurement
         if: always()
-        #continue-on-error: true
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 3
           echo "TEST_RIM_3=passed" >> $GITHUB_ENV
-      # - name: All RIM System Tests 1-3
-      #   cFailedontinue-on-error: true
-      #   shell: bash
-      #   run: |
-      #     .ci/system-tests/tests/rim_system_tests.sh
       - name: Copy System Test Log files
         continue-on-error: true
         shell: bash
@@ -139,31 +116,10 @@ jobs:
         run: |
           echo "*** Exiting and removing Docker containers and network ..."
           doFailedocker compose -f .ci/docker/docker-compose-system-test.yml down -v
-         # if [[ ${TEST_STATUS} == "0" ]]; then
-         #   echo "******** SUCCESS: System Tests for TPM 2.0 passed ********"
-         #   echo "TEST_STATUS=0" ${FAILED_TEST_LIST}>> $GITHUB_ENV
-         #   exit 0;
-         # else
-          #  echo "******** FAILURE: System Tests for TPM 2.0 failed ********"
-          #  echo "TEST_STATUS=1" >> $GITHUB_ENV
-          #  exit 1
-         # fi
       - name: Archive System Test Log files
         uses: actions/upload-artifact@v4
         with:
           name: System_Test_Log_Files
           path: logs/
           if-no-files-found: ignore
-    #  - name: Check System Test results
-     #   if: success() || failure()
-       # run: |
-       #  echo "TEST_RIM_1 status is ${TEST_RIM_1}"
-       #  echo "TEST_RIM_2 status is ${TEST_RIM_2}"
-       #  echo "TEST_RIM_3 status is ${TEST_RIM_3}"
-       #  if [[ ${TEST_RIM_1} == 'failed' ]]; then 
-       #    exit 1;
-       #    else
-       #      exit 0; 
-       #  fi;
-         
-         
+ 

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -13,6 +13,8 @@ env:
   FAILED_TEST_COUNT: 0
   TEST_COUNT: 14
   FAILED_TEST_LIST: ""
+  TEST_RIM_1: ""
+  TEST_RIM_2: ""
 jobs:
   DockerTests:
     runs-on: ubuntu-latest
@@ -151,8 +153,8 @@ jobs:
       - name: Check System Test results
         if: success() || failure()
         run: |
-         echo "TEST_RIM_1 iss $TEST_RIM_1"
-         echo "TEST_RIM_2 iss $TEST_RIM_2"
+         echo "TEST_RIM_1 is $TEST_RIM_1"
+         echo "TEST_RIM_2 is $TEST_RIM_2"
          if [ ${FAILED_TEST_COUNT} == "0" ]; then
             echo "All ${TEST_COUNT} Sytem Test(s) passed!"
             exit 0

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -105,13 +105,13 @@ jobs:
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
-          env.TEST_RIM_1="pass"
+           TEST_RIM_1="pass"
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR
         continue-on-error: true
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 2
-          env.TEST_RIM_2="pass"
+           TEST_RIM_2="pass"
       - name: ACA RIM TEST 3 - Test a RIM from an OEM and a Supplemental RIM from a VAR with a bad reference measurement
         continue-on-error: true
         shell: bash

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -103,13 +103,13 @@ jobs:
         shell: bash
         run: |
             .ci/system-tests/tests/rim_system_tests.sh 1
-            if [ $? -eq 0 ]; then
-              echo "ACA RIM Test 1 passed"
-            else
+            if [ $? -ne 0 ]; then
               echo "ACA RIM Test 1 Failed"
               FAILED_TEST_LIST="${FAILED_TEST_LIST}ACA RIM TEST 1 "
               FAILED_TEST_COUNT=$((FAILED_TEST_COUNT++))
-          fi
+            else
+              echo "ACA RIM Test 1 passed"
+            fi
           echo "Value = ${{env.TEST_STATUS}}"
           echo "${FAILED_TEST_LIST} failed, moving on..."
           

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -102,7 +102,8 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          if ( $(.ci/system-tests/tests/rim_system_tests.sh 1) == 0 ); then
+            .ci/system-tests/tests/rim_system_tests.sh 1
+            if [ $? -eq 0 ]; then
               echo "ACA RIM Test 1 passed"
             else
               echo "ACA RIM Test 1 Failed"

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -103,10 +103,13 @@ jobs:
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
-          if [ ${TEST_STATUS} == "1" ]; then
+          echo "TEST_STATUS = ${TEST_STATUS}"
+          if [ ${TEST_STATUS} != "0" ]; then
                 echo "RIM Test 1 Failed"
-                $FAILED_TEST_COUNT=$((FAILED_TEST_COUNT + 1))
+                $FAILED_TEST_COUNT=$(FAILED_TEST_COUNT + 1)
                 $FAILED_TEST_LIST=${FAILED_TEST_LIST}"ACA RIM TEST 1 "
+            else echo "RIM Test 1 passed???"
+              echo ""
           fi
           echo "${FAILED_TEST_LIST} failed, moving on..."
           

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -115,7 +115,7 @@ jobs:
         shell: bash
         run: |
           echo "*** Exiting and removing Docker containers and network ..."
-          doFaileddocker compose -f .ci/docker/docker-compose-system-test.yml down -v
+          docker compose -f .ci/docker/docker-compose-system-test.yml down -v
       - name: Archive System Test Log files
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -103,21 +103,13 @@ jobs:
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
-          if [ $? -ne 0 ]; then
-            echo "ACA RIM Test 1 Failed"
-              FAILED_TEST_LIST="${FAILED_TEST_LIST}ACA RIM TEST 1 "
-              FAILED_TEST_COUNT=$((FAILED_TEST_COUNT++))
-            else
-              echo "ACA RIM Test 1 passed"
-            fi
-          echo "Value = ${{env.TEST_STATUS}}"
-          echo "${FAILED_TEST_LIST} failed, moving on..."
-          
+          TEST_RIM_1="pass"
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR
         continue-on-error: true
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 2
+          TEST_RIM_2="pass"
       - name: ACA RIM TEST 3 - Test a RIM from an OEM and a Supplemental RIM from a VAR with a bad reference measurement
         continue-on-error: true
         shell: bash
@@ -159,6 +151,8 @@ jobs:
       - name: Check System Test results
         if: success() || failure()
         run: |
+         echo "TEST_RIM_1 iss $TEST_RIM_1"
+         echo "TEST_RIM_2 iss $TEST_RIM_2"
          if [ ${FAILED_TEST_COUNT} == "0" ]; then
             echo "All ${TEST_COUNT} Sytem Test(s) passed!"
             exit 0

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -105,10 +105,10 @@ jobs:
           .ci/system-tests/tests/rim_system_tests.sh 1
           if [ ${TEST_STATUS} == "1" ]; then
                 echo "RIM Test 1 Failed"
-                $FAILED_TEST_COUNT=$(($FAILED_TEST_COUNT + 1))
-                $FAILED_TEST_LIST=${}FAILED_TEST_LIST}"ACA RIM TEST 1 "
+                $FAILED_TEST_COUNT=$((FAILED_TEST_COUNT + 1))
+                $FAILED_TEST_LIST=${FAILED_TEST_LIST}"ACA RIM TEST 1 "
           fi
-          echo "${FAILED_TEST_LIS${FAILED_TEST_LIST}T} failed, moving on..."
+          echo "${FAILED_TEST_LIST} failed, moving on..."
           
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR
         continue-on-error: true

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -108,16 +108,19 @@ jobs:
           .ci/system-tests/tests/rim_system_tests.sh 1
            echo "TEST_RIM_1=passed" >> $GITHUB_ENV
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR
-        continue-on-error: true
+        if: always()
+        #continue-on-error: true
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 2
            echo "TEST_RIM_2=passed" >> $GITHUB_ENV
       - name: ACA RIM TEST 3 - Test a RIM from an OEM and a Supplemental RIM from a VAR with a bad reference measurement
-        continue-on-error: true
+        if: always()
+        #continue-on-error: true
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 3
+          echo "TEST_RIM_3=passed" >> $GITHUB_ENV
       # - name: All RIM System Tests 1-3
       #   cFailedontinue-on-error: true
       #   shell: bash
@@ -156,5 +159,11 @@ jobs:
         run: |
          echo "TEST_RIM_1 status is ${TEST_RIM_1}"
          echo "TEST_RIM_2 status is ${TEST_RIM_2}"
-         if [[ ${TEST_RIM_1} == 'failed']]; then exit 1; fi;
+         echo "TEST_RIM_3 status is ${TEST_RIM_3}"
+         if [[ ${TEST_RIM_1} == 'failed']]; then 
+           exit 1;
+           else
+             exit 0; 
+         fi;
+         
           

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -102,7 +102,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          if [ .ci/system-tests/tests/rim_system_tests.sh 1 ]
+          if ( $(.ci/system-tests/tests/rim_system_tests.sh 1) == 0 ); then
               echo "ACA RIM Test 1 passed"
             else
               echo "ACA RIM Test 1 Failed"
@@ -110,13 +110,6 @@ jobs:
               FAILED_TEST_COUNT++
           fi
           echo "Value = ${{env.TEST_STATUS}}"
-          if [ ${{env.TEST_STATUS}} != "0" ]; then
-                echo "ACA RIM Test 1 Failed"
-                #FAILED_TEST_COUNT=$(FAILED_TEST_COUNT + 1)
-                FAILED_TEST_LIST=${FAILED_TEST_LIST++}"ACA RIM TEST 1 "
-            else echo "RIM Test 1 passed???"
-              echo ""
-          fi
           echo "${FAILED_TEST_LIST} failed, moving on..."
           
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -105,7 +105,7 @@ jobs:
           .ci/system-tests/tests/rim_system_tests.sh 1
           if [ ${TEST_STATUS} == "1" ]; then
                 ${FAILED_TEST_COUNT}++
-                ${FAILED_TEST_LIST} += "ACA RIM TEST 1 "
+                ${FAILED_TEST_LIST} = ${FAILED_TEST_LIST} + "ACA RIM TEST 1 "
           fi
           
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR
@@ -154,11 +154,11 @@ jobs:
       - name: Check System Test results
         if: success() || failure()
         run: |
-         if [ ${TEST_STATUS} == "0" ]; then
-            echo "All ${TEST_COUNT} test(s) passed!"
+         if [ ${FAILED_TEST_COUNT} == "0" ]; then
+            echo "All ${TEST_COUNT} Sytem Test(s) passed!"
             exit 0
          else
              echo "${FAILED_TEST_COUNT} out of ${TEST_COUNT} failed."
-             echo "Faled tests include: ${FAILED_TEST_LIST}"
+             echo "Failed tests include: ${FAILED_TEST_LIST}"
              exit 1
          fi

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -10,6 +10,9 @@ on:
   workflow_dispatch:
 env:
   TEST_STATUS: 0
+  FAILED_TEST_COUNT: 0
+  TEST_COUNT: 14
+  FAILED_TEST_LIST: ""
 jobs:
   DockerTests:
     runs-on: ubuntu-latest
@@ -100,6 +103,11 @@ jobs:
         shell: bash
         run: |
           .ci/system-tests/tests/rim_system_tests.sh 1
+          if [ ${TEST_STATUS} == "1" ]; then
+                ${FAILED_TEST_COUNT}++
+                ${FAILED_TEST_LIST} += "ACA RIM TEST 1 "
+          fi
+          
       - name: ACA RIM TEST 2 - Test a RIM from an OEM with a bad reference measurement and a Supplemental RIM from a VAR
         continue-on-error: true
         shell: bash
@@ -146,8 +154,11 @@ jobs:
       - name: Check System Test results
         if: success() || failure()
         run: |
-          if [ ${TEST_STATUS} == "0" ]; then
-            exit 0;
-          else
-            exit 1;
-          fi
+         if [ ${TEST_STATUS} == "0" ]; then
+            echo "All ${TEST_COUNT} test(s) passed!"
+            exit 0
+         else
+             echo "${FAILED_TEST_COUNT} out of ${TEST_COUNT} failed."
+             echo "Faled tests include: ${FAILED_TEST_LIST}"
+             exit 1
+         fi

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -13,8 +13,8 @@ env:
   FAILED_TEST_COUNT: 0
   TEST_COUNT: 14
   FAILED_TEST_LIST: ""
-  TEST_RIM_1: ""
-  TEST_RIM_2: ""
+  TEST_RIM_1: "failed"
+  TEST_RIM_2: "failed"
 jobs:
   DockerTests:
     runs-on: ubuntu-latest
@@ -153,13 +153,5 @@ jobs:
       - name: Check System Test results
         if: success() || failure()
         run: |
-         echo "TEST_RIM_1 is $TEST_RIM_1"
-         echo "TEST_RIM_2 is $TEST_RIM_2"
-         if [ ${FAILED_TEST_COUNT} == "0" ]; then
-            echo "All ${TEST_COUNT} Sytem Test(s) passed!"
-            exit 0
-         else
-             echo "${FAILED_TEST_COUNT} out of ${TEST_COUNT} failed."
-             echo "Failed tests include: ${FAILED_TEST_LIST}"
-             exit 1
-         fi
+         echo "TEST_RIM_1 is ${env.TEST_RIM_1}"
+         echo "TEST_RIM_2 is ${env.TEST_RIM_2}"

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -104,19 +104,20 @@ jobs:
           .ci/system-tests/tests/rim_system_tests.sh 3
           echo "TEST_RIM_3=passed" >> $GITHUB_ENV
       - name: Copy System Test Log files
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           echo "*** Extracting ACA and Provisioner.Net logs ..."
           docker exec hirs-aca1 bash -c "mkdir -p /HIRS/logs/aca/ && cp -arp /var/log/hirs/* /HIRS/logs/aca/"
           docker exec hirs-provisioner1-tpm2 bash -c "mkdir -p /HIRS/logs/provisioner/ && cp -ap hirs*.log /HIRS/logs/provisioner/ && chmod -R 777 /HIRS/logs"
       - name: Docker Compose Down
-        continue-on-error: true
+        if: always()
         shell: bash
         run: |
           echo "*** Exiting and removing Docker containers and network ..."
           doFailedocker compose -f .ci/docker/docker-compose-system-test.yml down -v
       - name: Archive System Test Log files
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: System_Test_Log_Files

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -27,7 +27,8 @@ jobs:
         run: |
           # If on a forked repo, ensure that it has a new secret for the PAT
           # and replace secrets.GITHUB_TOKEN with the secret in the fork
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          #echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.PKG_PWD }}" | docker login ghcr.io -u $ --password-stdin
           .ci/system-tests/setup_system_tests.sh ${GITHUB_REF#refs/heads/}
       - name: ACA POLICY TEST 1 - Test ACA default policy
         continue-on-error: true


### PR DESCRIPTION
Fixes the non reporting of failed system tests. Removes the use of Action based variables to collect status from individual system tests and provides exit status to indicate pass/fail for each the system tests. 
Also checks for status that do no include "pass: or "fail" in the provisioner output and fails if neither is found.

Closes #794