### PR TITLE
[#797] Remove SupportReferenceManifest.processed

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/SupportReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/SupportReferenceManifest.java
@@ -32,8 +32,6 @@ public class SupportReferenceManifest extends ReferenceManifest {
     private int pcrHash = 0;
     @Column
     private boolean updated = false;
-    @Column
-    private boolean processed = false;
 
     /**
      * Main constructor for the RIM object. This takes in a byte array of a
@@ -127,11 +125,11 @@ public class SupportReferenceManifest extends ReferenceManifest {
         if (o == null || getClass() != o.getClass()) return false;
         if (!super.equals(o)) return false;
         SupportReferenceManifest that = (SupportReferenceManifest) o;
-        return pcrHash == that.pcrHash && updated == that.updated && processed == that.processed;
+        return pcrHash == that.pcrHash && updated == that.updated;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), pcrHash, updated, processed);
+        return Objects.hash(super.hashCode(), pcrHash, updated);
     }
 }


### PR DESCRIPTION
This change resolves the error
`ERROR : Null value was assigned to a property [class hirs.attestationca.persist.entity.userdefined.rim.SupportReferenceManifest.processed] of primitive type : hirs.attestationca.persist.entity.userdefined.rim.SupportReferenceManifest.processed (setter)`
This change also removes the column processed from the ReferenceManifest backend table.

Closes #797 