### PR TITLE
[#807] Display PCR comparison table for mismatches

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/SupplyChainValidation.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/SupplyChainValidation.java
@@ -105,7 +105,7 @@ public class SupplyChainValidation extends ArchivableEntity {
         this.certificatesUsed = new ArrayList<>();
         this.rimId = "";
         for (ArchivableEntity ae : certificatesUsed) {
-            if (ae instanceof BaseReferenceManifest rm) {
+            if (ae instanceof ReferenceManifest rm) {
                 this.rimId = rm.getId().toString();
                 break;
             } else if (ae instanceof Certificate) {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationService.java
@@ -190,16 +190,22 @@ public class ValidationService {
         final SupplyChainValidation.ValidationType validationType
                 = SupplyChainValidation.ValidationType.FIRMWARE;
 
-        List<ReferenceManifest> rims = rimRepo.findByDeviceName(device.getName());
-        ReferenceManifest baseRim = null;
-        for (ReferenceManifest rim : rims) {
-            if (rim.getRimType().equals(ReferenceManifest.BASE_RIM)) {
-                baseRim = rim;
-            }
-        }
         AppraisalStatus result = FirmwareScvValidator.validateFirmware(device, policySettings,
                 rimRepo, rdvRepo, caRepo);
         Level logLevel;
+        List<ReferenceManifest> rims = rimRepo.findByDeviceName(device.getName());
+        ReferenceManifest referenceManifest = null;
+        String rimType = "";
+        if (result.getAdditionalInfo().equals(ReferenceManifest.MEASUREMENT_RIM)) {
+            rimType = ReferenceManifest.MEASUREMENT_RIM;
+        } else {
+            rimType = ReferenceManifest.BASE_RIM;
+        }
+        for (ReferenceManifest rim : rims) {
+            if (rim.getRimType().equals(rimType)) {
+                referenceManifest = rim;
+            }
+        }
 
         switch (result.getAppStatus()) {
             case PASS:
@@ -213,7 +219,7 @@ public class ValidationService {
                 logLevel = Level.ERROR;
         }
         return buildValidationRecord(validationType, result.getAppStatus(),
-                result.getMessage(), baseRim, logLevel);
+                result.getMessage(), referenceManifest, logLevel);
     }
 
     /**

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
@@ -270,7 +270,8 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
                                 fwStatus = new AppraisalStatus(FAIL, String.format("%s%n%s",
                                         fwStatus.getMessage(), sb.toString()));
                             } else {
-                                fwStatus = new AppraisalStatus(FAIL, sb.toString());
+                                fwStatus = new AppraisalStatus(FAIL,
+                                        sb.toString(), ReferenceManifest.MEASUREMENT_RIM);
                             }
                         }
                     }


### PR DESCRIPTION
These changes accomplish the following toward properly displaying PCR mismatches in the ACA:
- flag firmware failures due to eventlog measurements
- pull EventMeasurement rim data in response to the above failures

Closes #807 