### PR TITLE
Add processing for EV_EFI_NOACTION NvIndexDynamic structure

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/utils/HexUtils.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/HexUtils.java
@@ -1,16 +1,16 @@
 package hirs.utils;
 
-//import lombok.AccessLevel;
-//import lombok.NoArgsConstructor;
-
 import java.math.BigInteger;
 
 /**
  * Utilities for working with hex strings and byte arrays.
  */
-//@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class HexUtils {
 
+    /**
+     * Default private constructor so checkstyles doesn't complain
+     */
+    private HexUtils() { }
     /**
      * The mathematical base for the hexadecimal representation.
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/HexUtils.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/HexUtils.java
@@ -1,14 +1,14 @@
 package hirs.utils;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+//import lombok.AccessLevel;
+//import lombok.NoArgsConstructor;
 
 import java.math.BigInteger;
 
 /**
  * Utilities for working with hex strings and byte arrays.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+//@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class HexUtils {
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/JsonUtils.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/JsonUtils.java
@@ -2,8 +2,8 @@ package hirs.utils;
 
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+//import lombok.AccessLevel;
+//import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
 import java.io.FileInputStream;
@@ -20,7 +20,7 @@ import java.nio.file.Path;
  * library.
  */
 @Log4j2
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+//@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JsonUtils {
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/JsonUtils.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/JsonUtils.java
@@ -2,8 +2,6 @@ package hirs.utils;
 
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
-//import lombok.AccessLevel;
-//import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
 import java.io.FileInputStream;
@@ -20,8 +18,12 @@ import java.nio.file.Path;
  * library.
  */
 @Log4j2
-//@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JsonUtils {
+
+    /**
+     * Default private constructor so checkstyles doesn't complain
+     */
+    private JsonUtils() { }
 
     /**
      * Getter for the JSON Object that is associated with the elementName value

--- a/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
@@ -26,6 +26,11 @@ import java.util.List;
 public final class PciIds {
 
     /**
+     * Default private constructor so checkstyles doesn't complain
+     */
+    private PciIds() { }
+
+    /**
      * This pci ids file can be in different places on different distributions.
      */
     public static final List<String> PCI_IDS_PATH =

--- a/HIRS_Utils/src/main/java/hirs/utils/enums/DeviceInfoEnums.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/enums/DeviceInfoEnums.java
@@ -1,6 +1,12 @@
 package hirs.utils.enums;
 
 public final class DeviceInfoEnums {
+
+    /**
+     * Default private constructor so checkstyles doesn't complain
+     */
+    private DeviceInfoEnums() { }
+
     /**
      * A variable used to describe unavailable hardware, firmware, or OS info.
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
@@ -3,13 +3,17 @@ package hirs.utils.swid;
 import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 
-
 /**
  * This class contains the String constants that are referenced by the gateway
  * class. It is expected that member properties of this class will expand as
  * more functionality is added to SwidTagGateway.
  */
 public class SwidTagConstants {
+
+    /**
+     * Default private constructor so checkstyles doesn't complain
+     */
+    private SwidTagConstants() { }
 
     public static final String DEFAULT_KEYSTORE_FILE = "keystore.jks";//"/opt/hirs/rimtool/keystore.jks";
     public static final String DEFAULT_KEYSTORE_PASSWORD = "password";

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvConstants.java
@@ -1,14 +1,15 @@
 package hirs.utils.tpm.eventlog.events;
 
-//import lombok.AccessLevel;
-//import lombok.NoArgsConstructor;
-
 /**
  * Class for defining constants referenced in the PC Client
  * Platform Firmware Profile specification.
  */
-//@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class EvConstants {
+
+    /**
+     * Default private constructor so checkstyles doesn't complain
+     */
+    private EvConstants() { }
 
     /**
      * Type length = 4 bytes.

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvConstants.java
@@ -1,13 +1,13 @@
 package hirs.utils.tpm.eventlog.events;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+//import lombok.AccessLevel;
+//import lombok.NoArgsConstructor;
 
 /**
  * Class for defining constants referenced in the PC Client
  * Platform Firmware Profile specification.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+//@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class EvConstants {
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvNoAction.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvNoAction.java
@@ -10,13 +10,17 @@ import java.nio.charset.StandardCharsets;
 /**
  * Class to process the EV_NO_ACTION event.
  * The first 16 bytes of the event data MUST be a String based identifier (Signature).
- * The only currently defined Signatures are
- * 1) "Spec ID Event03"
+ * Currently defined Signatures are
+ *    "Spec ID Event03"
  *      - implies the data is a TCG_EfiSpecIDEvent
  *      - TCG_EfiSpecIDEvent is the first event in a TPM Event Log and is used to determine
  *        if the format of the Log (SHA1 vs Crypto Agile).
- * 2) "NvIndexInstance"
+ *    "StartupLocality"
+ *      - implies the data represents locality info (use lookup to interpret)
+ *    "NvIndexInstance"
  *      - implies the data is a NV_INDEX_INSTANCE_EVENT_LOG_DATA
+ *    "NvIndexDynamic"
+ *      - implies the data is a NV_INDEX_DYNAMIC_EVENT_LOG_DATA
  * <p>
  * Notes:
  * 1. First 16 bytes of the structure is an ASCII with a fixed Length of 16
@@ -74,10 +78,13 @@ public class EvNoAction {
         } else if (signature.contains("NvIndexInstance")) {
             NvIndexInstanceEventLogData nvIndexInstanceEvent = new NvIndexInstanceEventLogData(eventData);
             noActionInfo += nvIndexInstanceEvent.toString();
+        } else if (signature.contains("NvIndexDynamic")) {
+            NvIndexDynamicEventLogData nvIndexDynamicEvent = new NvIndexDynamicEventLogData(eventData);
+            noActionInfo += nvIndexDynamicEvent.toString();
         } else {
-                noActionInfo = "EV_NO_ACTION event named " + signature
-                        + " encountered but support for processing it has not been"
-                        + " added to this application.\n";
+            noActionInfo = "   EV_NO_ACTION event named \"" + signature
+                    + "\" encountered but support for processing it has not been"
+                    + " added to this application.\n";
         }
     }
 

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/NvIndexDynamicEventLogData.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/NvIndexDynamicEventLogData.java
@@ -1,0 +1,97 @@
+package hirs.utils.tpm.eventlog.events;
+
+import hirs.utils.HexUtils;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Class to process the NV_INDEX_DYNAMIC_EVENT_LOG_DATA per PFP.
+ * Per PFP, the first 16 bytes of the structure are a String based identifier (Signature),
+ * which are a NULL-terminated ASCII string "NvIndexInstance".
+ *
+ * HEADERS defined by PFP v1.06 Rev 52.
+ * Certain fields are common to both ..HEADER and ..HEADER2, and are noted below the structures.
+ * <p>
+ * typedef struct tdNV_INDEX_DYNAMIC_EVENT_LOG_DATA {
+ *      BYTE                            Signature[16];
+ *      UINT16                          Version;
+ *      UINT8[6]                        Reserved;
+ *      UINT64                          UID;
+ *      UINT16                          DescriptionSize;
+ *      UINT8                           Description[DescriptionSize];
+ *      UINT16                          DataSize;
+ *      DEVICE_SECURITY_EVENT_DATA2     Data[DataSize];
+ * } NV_INDEX_DYNAMIC_EVENT_LOG_DATA;
+ * <p>
+ */
+public class NvIndexDynamicEventLogData {
+
+    /**
+     * Signature (text) data.
+     */
+    private String signature = "";
+
+    /**
+     * Human-readable description of the data within this DEVICE_SECURITY_EVENT_DATA/..DATA2 event.
+     */
+    String nvIndexDynamicInfo = "";
+
+    /**
+     * NvIndexInstanceEventLogData constructor.
+     *
+     * @param eventData byte array holding the event to process.
+     */
+    public NvIndexDynamicEventLogData(final byte[] eventData) {
+
+        byte[] signatureBytes = new byte[16];
+        System.arraycopy(eventData, 0, signatureBytes, 0, 16);
+        signature = new String(signatureBytes, StandardCharsets.UTF_8);
+        signature = signature.replaceAll("[^\\P{C}\t\r\n]", ""); // remove null characters
+
+        byte[] versionBytes = new byte[2];
+        System.arraycopy(eventData, 16, versionBytes, 0, 2);
+        String nvIndexVersion = HexUtils.byteArrayToHexString(versionBytes);
+        if (nvIndexVersion.isEmpty()) {
+            nvIndexVersion = "version not readable";
+        }
+        nvIndexDynamicInfo = "   Nv Index Dynamic Signature = " + signature + "\n";
+        nvIndexDynamicInfo += "   Nv Index Dynamic Version = " + nvIndexVersion + "\n";
+
+        // 6 bytes of Reserved data
+
+        byte[] uidBytes = new byte[8];
+        System.arraycopy(eventData, 24, uidBytes, 0, 8);
+        String uid = HexUtils.byteArrayToHexString(uidBytes);
+        nvIndexDynamicInfo += "   UID = " + uid + "\n";
+
+        byte[] descriptionSizeBytes = new byte[2];
+        System.arraycopy(eventData, 32, descriptionSizeBytes, 0, 2);
+        int descriptionSize = HexUtils.leReverseInt(descriptionSizeBytes);
+
+        byte[] descriptionBytes = new byte[descriptionSize];
+        System.arraycopy(eventData, 34, descriptionBytes, 0, descriptionSize);
+        String description = new String(descriptionBytes, StandardCharsets.UTF_8);
+        description = description.replaceAll("[^\\P{C}\t\r\n]", ""); // remove null characters
+        nvIndexDynamicInfo += "   Description = " + description + "\n";
+
+        int dataSizeStartByte = 34 + descriptionSize;
+        byte[] dataSizeBytes = new byte[2];
+        System.arraycopy(eventData, dataSizeStartByte, dataSizeBytes, 0, 2);
+        int dataSize = HexUtils.leReverseInt(dataSizeBytes);
+
+        int dataStartByte = dataSizeStartByte + 2;
+        byte[] dataBytes = new byte[dataSize];
+        System.arraycopy(eventData, dataStartByte, dataBytes, 0, dataSize);
+        String data = HexUtils.byteArrayToHexString(dataBytes);
+        nvIndexDynamicInfo += "   Data = " + data + "\n";
+    }
+
+    /**
+     * Returns a description of this event.
+     *
+     * @return Human-readable description of this event.
+     */
+    public String toString() {
+        return nvIndexDynamicInfo;
+    }
+}

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/NvIndexDynamicEventLogData.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/NvIndexDynamicEventLogData.java
@@ -34,7 +34,7 @@ public class NvIndexDynamicEventLogData {
     /**
      * Human-readable description of the data within this DEVICE_SECURITY_EVENT_DATA/..DATA2 event.
      */
-    String nvIndexDynamicInfo = "";
+    private String nvIndexDynamicInfo = "";
 
     /**
      * NvIndexInstanceEventLogData constructor.

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/NvIndexDynamicEventLogData.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/NvIndexDynamicEventLogData.java
@@ -7,7 +7,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * Class to process the NV_INDEX_DYNAMIC_EVENT_LOG_DATA per PFP.
  * Per PFP, the first 16 bytes of the structure are a String based identifier (Signature),
- * which are a NULL-terminated ASCII string "NvIndexInstance".
+ * which are a NULL-terminated ASCII string "NvIndexDynamic".
  *
  * HEADERS defined by PFP v1.06 Rev 52.
  * Certain fields are common to both ..HEADER and ..HEADER2, and are noted below the structures.

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/package-info.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Non-persistant classes related to TGC Event Logs.
+ * Non-persistent classes related to TGC Event Logs.
  */
 
 package hirs.utils.tpm.eventlog.events;

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/spdm/SpdmHa.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/spdm/SpdmHa.java
@@ -7,6 +7,11 @@ package hirs.utils.tpm.eventlog.spdm;
 public class SpdmHa {
 
     /**
+     * Default private constructor so checkstyles doesn't complain
+     */
+    private SpdmHa() { }
+
+    /**
      * Spdm Hash Alg = Raw bit stream.
      */
     public static final int TPM_ALG_RAW = 1;

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/spdm/SpdmHa.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/spdm/SpdmHa.java
@@ -1,13 +1,9 @@
 package hirs.utils.tpm.eventlog.spdm;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
 /**
  * Class for defining hash algorithms referenced in the DMTF SPDM specification.
  * SPDM 1.3.0, Table 21, MeasurementHashAlgo.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class SpdmHa {
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/spdm/package-info.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/spdm/package-info.java
@@ -2,5 +2,4 @@
  * Non-persistent classes related to TGC Event Logs.
  */
 
-package hirs.utils.tpm.eventlog;
-
+package hirs.utils.tpm.eventlog.spdm;

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiConstants.java
@@ -1,15 +1,16 @@
 package hirs.utils.tpm.eventlog.uefi;
 
-//import lombok.AccessLevel;
-//import lombok.NoArgsConstructor;
-
 /**
  * This class contains the String constants that are referenced by UEFI.
  * It is expected that member properties of this class will expand as
  * more functionality is added.
  */
-//@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class UefiConstants {
+
+    /**
+     * Default private constructor so checkstyles doesn't complain
+     */
+    private UefiConstants() { }
 
     /**
      * 2 byte size.

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiConstants.java
@@ -1,14 +1,14 @@
 package hirs.utils.tpm.eventlog.uefi;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+//import lombok.AccessLevel;
+//import lombok.NoArgsConstructor;
 
 /**
  * This class contains the String constants that are referenced by UEFI.
  * It is expected that member properties of this class will expand as
  * more functionality is added.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+//@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class UefiConstants {
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/package-info.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Non-persistant classes related to TGC Event Logs.
+ * Non-persistent classes related to TGC Event Logs.
  */
 
 package hirs.utils.tpm.eventlog.uefi;

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/package-info.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Non-persistant classes related to TPM.
+ * Non-persistent classes related to TPM.
  */
 
 package hirs.utils.tpm;


### PR DESCRIPTION
Closes #820 

EV_EFI_NOACTION has a structure of NvIndexDynamic which was implemented here. This is used for various SPDM calls.

Also added empty private constructors to several utility classes to appease checkstyles.