### PR TITLE
[#808] Retrieve unarchived RIM bundle for provision

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
@@ -239,9 +239,7 @@ public class ReferenceManifestPageController extends PageController<NoPageParams
                 messages.addError(notFoundMessage);
                 log.warn(notFoundMessage);
             } else {
-                // if support rim, update associated events
-                referenceManifest.archive();
-                referenceManifestRepository.save(referenceManifest);
+                referenceManifestRepository.delete(referenceManifest);
                 String deleteCompletedMessage = "RIM successfully deleted";
                 messages.addInfo(deleteCompletedMessage);
                 log.info(deleteCompletedMessage);


### PR DESCRIPTION
The two main changes included here are:

1. delete the RIM from the backend table when /delete is called instead of archiving
2. if an archived RIM is returned for FW validation then attempt to return an unarchived RIM with matching identifiers.

This PR also attempted to address the use cases where a good or bad RIM bundle is sent with an initial provision and then replaced by the other.  This grew beyond the scope of this PR and will be handled in a future issue.

Closes #808 