### PR TITLE
Provisioner will use .NET 8

### DIFF
--- a/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
+++ b/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="paccor.HardwareManifestPlugin" Version="1.0.0" />
     <PackageReference Include="paccor.HardwareManifestPluginManager" Version="1.0.0" />
     <PackageReference Include="paccor.paccor_scripts" Version="1.0.1" />
-    <PackageReference Include="Packaging.Targets" Version="0.1.220">
+    <PackageReference Include="Packaging.Targets" Version="0.1.226">
       <PrivateAssets>all</PrivateAssets> <!-- These assets will be consumed but won't flow to the parent project -->
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
+++ b/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
     <StartupObject>hirs.Program</StartupObject>
     <PublishSingleFile>true</PublishSingleFile>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageVersion>3.0.0</PackageVersion>
+    <PackageVersion>3.0.1</PackageVersion>
     <Release></Release> 
 </PropertyGroup>
 

--- a/HIRS_Provisioner.NET/hirsTest/hirsTest.csproj
+++ b/HIRS_Provisioner.NET/hirsTest/hirsTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Closes #791 #837 

### To build:

1. Install the .NET 8 SDK as [described by Microsoft](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) for your platform.
2.  Check out the repository 
     2.a.  Ex: ```git clone https://github.com/nsacyber/HIRS.git```
3. cd HIRS_Provisioner.NET
     3.a. Set up build ```dotnet restore```
     3.b. Build & Test ```dotnet test```
4. cd HIRS_Provisioner.NET/hirs
5. If interested in building an RPM or DEB file for linux, install dotnet 
     5.a. ```dotnet tool install --global dotnet-deb```
     5.b. ```dotnet tool install --global dotnet-rpm```
6. Create desired installation package <b>MSI building only works on Windows</b>
     6.a. <b>MSI</b> ```dotnet msbuild hirs.csproj /t:Msi /P:TargetFramework=net8.0 /p:RuntimeIdentifier=win-x64 /p:Configuration=Release```
     6.b. <b>Linux RPM</b> ```dotnet rpm -r linux-x64 -c Release```
     6.c.  <b>Linux DEB</b> ```dotnet deb -r linux-x64 -c Release```