### PR TITLE
dotnet_provisioner_unit_tests workflow will use newer actions

### DIFF
--- a/.github/workflows/dotnet_provisioner_unit_tests.yml
+++ b/.github/workflows/dotnet_provisioner_unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
           git config --global core.eol lf
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/.github/workflows/dotnet_provisioner_unit_tests.yml
+++ b/.github/workflows/dotnet_provisioner_unit_tests.yml
@@ -82,14 +82,14 @@ jobs:
           more $logName
 
       - name: Upload Logs Ubuntu
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: contains(matrix.os, 'ubuntu') && always()
         with:
           name: "${{matrix.os}}-unit-tests-${{steps.ubuntu_result.outputs.result}}.log"
           path: HIRS_Provisioner.NET/*.log
 
       - name: Upload Logs Windows
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: contains(matrix.os, 'windows') && always()
         with:
           name: "${{matrix.os}}-unit-tests-${{steps.window_result.outputs.result}}.log"


### PR DESCRIPTION
actions/upload-artifact@v2 was removed. Now using v4.
actions/checkout@v3 was giving a warning. Now using v4.
Still get a warning on set-output. Can fix that another time.