### PR TITLE
compose-acceptance-test-linux: docker macvlan requires privileged mode

### DIFF
--- a/.ci/docker/compose-acceptance-test-linux.yml
+++ b/.ci/docker/compose-acceptance-test-linux.yml
@@ -12,6 +12,7 @@ services:
   hat:
     image: ghcr.io/nsacyber/hirs/hat
     container_name: hat
+    privileged: true
     ports:
        - 53:53/tcp
        - 53:53/udp


### PR DESCRIPTION
The macvlan network plugin for docker on linux requires privileged mode to work properly.