### PR TITLE
[#864] Undid Constant Name Rule In Checkstyles XML and Applied Formatting/Changes to HIRS_UTILS

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
@@ -103,7 +103,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
      * @param rimBytes byte array representation of the RIM
      * @throws IOException if unable to unmarshal the string
      */
-    @SuppressWarnings("checkstyle:AvoidInlineConditionals")
     public BaseReferenceManifest(final String fileName, final byte[] rimBytes)
             throws UnmarshalException {
         super(rimBytes);
@@ -127,9 +126,11 @@ public class BaseReferenceManifest extends ReferenceManifest {
                     SwidTagConstants.SWIDTAG_NAMESPACE, SwidTagConstants.META).item(0);
             setTagId(softwareIdentity.getAttribute(SwidTagConstants.TAGID));
             this.swidName = softwareIdentity.getAttribute(SwidTagConstants.NAME);
-            this.swidCorpus = Boolean.parseBoolean(softwareIdentity.getAttribute(SwidTagConstants.CORPUS)) ? 1 : 0;
+            this.swidCorpus =
+                    Boolean.parseBoolean(softwareIdentity.getAttribute(SwidTagConstants.CORPUS)) ? 1 : 0;
             this.setSwidPatch(Boolean.parseBoolean(softwareIdentity.getAttribute(SwidTagConstants.PATCH)));
-            this.setSwidSupplemental(Boolean.parseBoolean(softwareIdentity.getAttribute(SwidTagConstants.SUPPLEMENTAL)));
+            this.setSwidSupplemental(
+                    Boolean.parseBoolean(softwareIdentity.getAttribute(SwidTagConstants.SUPPLEMENTAL)));
             this.setSwidVersion(softwareIdentity.getAttribute(SwidTagConstants.VERSION));
             this.setSwidTagVersion(softwareIdentity.getAttribute(SwidTagConstants.TAGVERSION));
 
@@ -147,20 +148,22 @@ public class BaseReferenceManifest extends ReferenceManifest {
      */
     private void parseSoftwareMeta(final Element softwareMeta) {
         if (softwareMeta != null) {
-            this.colloquialVersion = softwareMeta.getAttribute(SwidTagConstants._COLLOQUIAL_VERSION_STR);
-            this.product = softwareMeta.getAttribute(SwidTagConstants._PRODUCT_STR);
-            this.revision = softwareMeta.getAttribute(SwidTagConstants._REVISION_STR);
-            this.edition = softwareMeta.getAttribute(SwidTagConstants._EDITION_STR);
-            this.rimLinkHash = softwareMeta.getAttribute(SwidTagConstants._RIM_LINK_HASH_STR);
-            this.bindingSpec = softwareMeta.getAttribute(SwidTagConstants._BINDING_SPEC_STR);
-            this.bindingSpecVersion = softwareMeta.getAttribute(SwidTagConstants._BINDING_SPEC_VERSION_STR);
-            this.setPlatformManufacturerId(softwareMeta.getAttribute(SwidTagConstants._PLATFORM_MANUFACTURER_ID_STR));
-            this.setPlatformManufacturer(softwareMeta.getAttribute(SwidTagConstants._PLATFORM_MANUFACTURER_STR));
-            this.setPlatformModel(softwareMeta.getAttribute(SwidTagConstants._PLATFORM_MODEL_STR));
-            this.platformVersion = softwareMeta.getAttribute(SwidTagConstants._PLATFORM_VERSION_STR);
-            this.payloadType = softwareMeta.getAttribute(SwidTagConstants._PAYLOAD_TYPE_STR);
-            this.pcURIGlobal = softwareMeta.getAttribute(SwidTagConstants._PC_URI_GLOBAL_STR);
-            this.pcURILocal = softwareMeta.getAttribute(SwidTagConstants._PC_URI_LOCAL_STR);
+            this.colloquialVersion = softwareMeta.getAttribute(SwidTagConstants.COLLOQUIAL_VERSION_STR);
+            this.product = softwareMeta.getAttribute(SwidTagConstants.PRODUCT_STR);
+            this.revision = softwareMeta.getAttribute(SwidTagConstants.REVISION_STR);
+            this.edition = softwareMeta.getAttribute(SwidTagConstants.EDITION_STR);
+            this.rimLinkHash = softwareMeta.getAttribute(SwidTagConstants.RIM_LINK_HASH_STR);
+            this.bindingSpec = softwareMeta.getAttribute(SwidTagConstants.BINDING_SPEC_STR);
+            this.bindingSpecVersion = softwareMeta.getAttribute(SwidTagConstants.BINDING_SPEC_VERSION_STR);
+            this.setPlatformManufacturerId(
+                    softwareMeta.getAttribute(SwidTagConstants.PLATFORM_MANUFACTURER_ID_STR));
+            this.setPlatformManufacturer(
+                    softwareMeta.getAttribute(SwidTagConstants.PLATFORM_MANUFACTURER_FULL_STR));
+            this.setPlatformModel(softwareMeta.getAttribute(SwidTagConstants.PLATFORM_MODEL_STR));
+            this.platformVersion = softwareMeta.getAttribute(SwidTagConstants.PLATFORM_VERSION_STR);
+            this.payloadType = softwareMeta.getAttribute(SwidTagConstants.PAYLOAD_TYPE_STR);
+            this.pcURIGlobal = softwareMeta.getAttribute(SwidTagConstants.PC_URI_GLOBAL_STR);
+            this.pcURILocal = softwareMeta.getAttribute(SwidTagConstants.PC_URI_LOCAL_STR);
         } else {
             log.warn("SoftwareMeta Tag not found.");
         }
@@ -202,7 +205,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
      * This method validates the .swidtag file at the given filepath against the
      * schema. A successful validation results in the output of the tag's name
      * and tagId attributes, otherwise a generic error message is printed.
-     *
      */
     private Element getDirectoryTag(final byte[] rimBytes) {
         if (rimBytes == null || rimBytes.length == 0) {
@@ -254,7 +256,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
      * This method iterates over the list of File elements under the directory.
      *
      * @param rimBytes the bytes to find the files
-     *
      */
     public List<SwidResource> getFileResources(final byte[] rimBytes) {
         Element directoryTag = getDirectoryTag(rimBytes);
@@ -267,8 +268,8 @@ public class BaseReferenceManifest extends ReferenceManifest {
             swidResource = new SwidResource();
             swidResource.setName(file.getAttribute(SwidTagConstants.NAME));
             swidResource.setSize(file.getAttribute(SwidTagConstants.SIZE));
-            swidResource.setHashValue(file.getAttribute(SwidTagConstants._SHA256_HASH.getPrefix() + ":"
-                    + SwidTagConstants._SHA256_HASH.getLocalPart()));
+            swidResource.setHashValue(file.getAttribute(SwidTagConstants.SHA_256_HASH.getPrefix() + ":"
+                    + SwidTagConstants.SHA_256_HASH.getLocalPart()));
             validHashes.add(swidResource);
         }
 
@@ -353,9 +354,15 @@ public class BaseReferenceManifest extends ReferenceManifest {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
         BaseReferenceManifest that = (BaseReferenceManifest) o;
         return swidCorpus == that.swidCorpus && Objects.equals(swidName, that.swidName)
                 && Objects.equals(colloquialVersion, that.colloquialVersion)

--- a/HIRS_Utils/build.gradle
+++ b/HIRS_Utils/build.gradle
@@ -3,8 +3,8 @@ plugins {
     id 'checkstyle'
 }
 // Get version from main project gradle
-def packVersion = properties.get("packageVersion");
-def jarVersion = properties.get("jarVersion");
+def packVersion = properties.get("packageVersion")
+def jarVersion = properties.get("jarVersion")
 //println "packageVersion is ${projVersion}"
 
 
@@ -66,10 +66,10 @@ configurations.checkstyle {
     }
 }
 checkstyleMain {
-    source ='src/main/java'
+    source = 'src/main/java'
 }
 checkstyleTest {
-    source ='src/test/java'
+    source = 'src/test/java'
 }
 tasks.withType(Checkstyle) {
     reports {

--- a/HIRS_Utils/config/spotbugs/spotbugs-exclude.xml
+++ b/HIRS_Utils/config/spotbugs/spotbugs-exclude.xml
@@ -2,14 +2,14 @@
 <!-- Docs at http://findbugs.sourceforge.net/manual/filter.html -->
 <FindBugsFilter>
     <Match>
-	    <Package name="~hirs\.utils.xjc.*" />
+        <Package name="~hirs\.utils.xjc.*"/>
     </Match>
     <Match>
-        <Package name="~hirs\.utils.rim.*" />
+        <Package name="~hirs\.utils.rim.*"/>
     </Match>
     <Match>
         <!-- https://github.com/spotbugs/spotbugs/pull/2748 -->
-        <Bug pattern="CT_CONSTRUCTOR_THROW" />
+        <Bug pattern="CT_CONSTRUCTOR_THROW"/>
     </Match>
 
     <!--    <Match>-->

--- a/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
@@ -28,39 +28,37 @@ import java.util.List;
 public final class PciIds {
 
     /**
-     * Track status of pciids file.
-     */
-    @Getter
-    private static String pciidsFileStatus = UefiConstants.FILESTATUS_NOT_ACCESSIBLE;
-
-    /**
-     * Name of pciids file in code.
-     */
-    private static final String PCIIDS_FILENAME = "/pci.ids";
-
-    /**
      * This pci ids file can be in different places on different distributions.
-     *    Fedora/RHEL/Rocky/CentOS: /usr/share/hwdata/pci.ids
-     *    Debian/Ubuntu: /usr/share/misc/pci.ids
+     * Fedora/RHEL/Rocky/CentOS: /usr/share/hwdata/pci.ids
+     * Debian/Ubuntu: /usr/share/misc/pci.ids
      * If the file is not found on the system (such as with Windows systems),
      * the file will have to be accessed from code.
      */
     public static final List<String> PCI_IDS_PATH =
             Collections.unmodifiableList(new ArrayList<>() {
                 private static final long serialVersionUID = 1L;
+
                 {
                     add("/usr/share/hwdata/pci.ids");
                     add("/usr/share/misc/pci.ids");
                     add("/tmp/pci.ids");
                 }
             });
-
     /**
      * The PCI IDs Database object.
      * This only needs to be loaded one time.
      * The pci ids library protects the data inside the object by making it immutable.
      */
     public static final PciIdsDatabase DB = new PciIdsDatabase();
+    /**
+     * Name of pciids file in code.
+     */
+    private static final String PCIIDS_FILENAME = "/pci.ids";
+    /**
+     * Track status of pciids file.
+     */
+    @Getter
+    private static String pciidsFileStatus = UefiConstants.FILESTATUS_NOT_ACCESSIBLE;
 
     //Configure the PCI IDs Database object.
     static {
@@ -124,7 +122,8 @@ public final class PciIds {
     /**
      * Default private constructor so checkstyles doesn't complain.
      */
-    private PciIds() { }
+    private PciIds() {
+    }
 
     /**
      * Look up the vendor name from the PCI IDs list, if the input string contains an ID.
@@ -172,7 +171,7 @@ public final class PciIds {
      * If any part of this fails, return the original model value.
      *
      * @param refManufacturer ASN1UTF8String, likely from a ComponentIdentifier
-     * @param refModel ASN1UTF8String, likely from a ComponentIdentifier
+     * @param refModel        ASN1UTF8String, likely from a ComponentIdentifier
      * @return ASN1UTF8String with the discovered device name, or the original model value.
      */
     public static ASN1UTF8String translateDevice(final ASN1UTF8String refManufacturer,
@@ -199,7 +198,7 @@ public final class PciIds {
      * If any part of this fails, return the original model value.
      *
      * @param refManufacturer String, likely from a ComponentResult
-     * @param refModel String, likely from a ComponentResult
+     * @param refModel        String, likely from a ComponentResult
      * @return String with the discovered device name, or the original model value.
      */
     public static String translateDevice(final String refManufacturer,
@@ -224,10 +223,10 @@ public final class PciIds {
      * If any part of this fails, return the original manufacturer value.
      *
      * @param refClassCode String, formatted as 2 characters (1 byte) for each of the 3 categories
-     * .   Example "010802":
-     * .      Class: "01"
-     * .      Subclass: "08"
-     * .      Programming Interface: "02"
+     *                     .   Example "010802":
+     *                     .      Class: "01"
+     *                     .      Subclass: "08"
+     *                     .      Programming Interface: "02"
      * @return List<String> 3-element list with the class code
      * .      1st element: human-readable description of Class
      * .      2nd element: human-readable description of Subclass

--- a/HIRS_Utils/src/main/java/hirs/utils/StringValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/StringValidator.java
@@ -17,10 +17,20 @@ public final class StringValidator {
     private final String fieldName;
     private final Logger logger;
 
+    private StringValidator(final String value, final String fieldName, final Logger logger) {
+        this.value = value;
+        this.fieldName = fieldName;
+        if (logger == null) {
+            this.logger = log;
+        } else {
+            this.logger = logger;
+        }
+    }
+
     /**
      * Begins a validation operation.
      *
-     * @param value the value to check
+     * @param value     the value to check
      * @param fieldName the name of the field (to be used in error reporting)
      * @return a Validation object, upon which validation methods can be called
      */
@@ -31,24 +41,14 @@ public final class StringValidator {
     /**
      * Begins a validation operation.
      *
-     * @param value the value to check
+     * @param value     the value to check
      * @param fieldName the name of the field (to be used in error reporting)
-     * @param logger a logger to use in lieu of Validation's logger
+     * @param logger    a logger to use in lieu of Validation's logger
      * @return a Validation object, upon which validation methods can be called
      */
     public static StringValidator check(final String value, final String fieldName,
                                         final Logger logger) {
         return new StringValidator(value, fieldName, logger);
-    }
-
-    private StringValidator(final String value, final String fieldName, final Logger logger) {
-        this.value = value;
-        this.fieldName = fieldName;
-        if (logger == null) {
-            this.logger = log;
-        } else {
-            this.logger = logger;
-        }
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/digest/Digest.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/digest/Digest.java
@@ -34,14 +34,13 @@ public final class Digest extends AbstractDigest {
             DigestAlgorithm.SHA1,
             new byte[SHA1_DIGEST_LENGTH]
     );
-
-    private static final String SHA1_EMPTY_HEX =
-            "da39a3ee5e6b4b0d3255bfef95601890afd80709";
-
     /**
      * A SHA1 digest whose content is the hash of an empty buffer.
      */
     public static final Digest SHA1_OF_NO_DATA;
+
+    private static final String SHA1_EMPTY_HEX =
+            "da39a3ee5e6b4b0d3255bfef95601890afd80709";
 
     static {
         try {
@@ -69,7 +68,7 @@ public final class Digest extends AbstractDigest {
      * Creates a new <code>Digest</code>.
      *
      * @param algorithm algorithm used to generate the digest
-     * @param digest digest value
+     * @param digest    digest value
      * @throws IllegalArgumentException if digest length does not match that of the algorithm
      */
     public Digest(final DigestAlgorithm algorithm, final byte[] digest)
@@ -81,6 +80,7 @@ public final class Digest extends AbstractDigest {
 
     /**
      * Creates a new <code>Digest</code> when an algorithm isn't specified.
+     *
      * @param digest byte array value
      */
     public Digest(final byte[] digest) {
@@ -90,9 +90,20 @@ public final class Digest extends AbstractDigest {
     /**
      * Default constructor necessary for Hibernate.
      */
-    protected Digest() {
+    private Digest() {
         this.algorithm = null;
         this.digest = null;
+    }
+
+    /**
+     * Helper method to reverse the toString method. Returns a Digest given a String
+     * that was created using an AbstractDigest's toString method.
+     *
+     * @param digest String representation of an AbstractDigest
+     * @return Digest object recreated from the String passed in
+     */
+    public static Digest fromString(final String digest) {
+        return new Digest(algorithmFromString(digest), digestFromString(digest));
     }
 
     /**
@@ -112,16 +123,5 @@ public final class Digest extends AbstractDigest {
      */
     public OptionalDigest asOptionalDigest() {
         return new OptionalDigest(algorithm, digest);
-    }
-
-    /**
-     * Helper method to reverse the toString method. Returns a Digest given a String
-     * that was created using an AbstractDigest's toString method.
-     *
-     * @param digest String representation of an AbstractDigest
-     * @return Digest object recreated from the String passed in
-     */
-    public static Digest fromString(final String digest) {
-        return new Digest(algorithmFromString(digest), digestFromString(digest));
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/digest/Digest.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/digest/Digest.java
@@ -58,10 +58,10 @@ public final class Digest extends AbstractDigest {
             columnDefinition = "varbinary(64)")
     private final byte[] digest;
 
+    @Getter
     @XmlElement
     @Column(nullable = false)
     @Enumerated(EnumType.ORDINAL)
-    @Getter
     private final DigestAlgorithm algorithm;
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/digest/DigestComparisonResultType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/digest/DigestComparisonResultType.java
@@ -3,7 +3,6 @@ package hirs.utils.digest;
 /**
  * Enumeration identifying the different outcomes of a comparison between
  * two {@link Digest} objects.
- *
  */
 public enum DigestComparisonResultType {
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/digest/OptionalDigest.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/digest/OptionalDigest.java
@@ -23,12 +23,12 @@ import java.util.Arrays;
 @Access(AccessType.FIELD)
 public final class OptionalDigest extends AbstractDigest {
     @XmlElement
-    @Column(nullable = true, name = "digest", length = SHA512_DIGEST_LENGTH,
+    @Column(name = "digest", length = SHA512_DIGEST_LENGTH,
             columnDefinition = "varbinary(64)")
     private final byte[] digest;
 
     @XmlElement
-    @Column(nullable = true)
+    @Column
     @Enumerated(EnumType.ORDINAL)
     @Getter
     private final DigestAlgorithm algorithm;
@@ -37,7 +37,7 @@ public final class OptionalDigest extends AbstractDigest {
      * Creates a new <code>OptionalDigest</code>.
      *
      * @param digestAlgorithm algorithm used to generate the digest
-     * @param optionalDigest digest value
+     * @param optionalDigest  digest value
      * @throws IllegalArgumentException if digest length does not match that of the algorithm
      */
     public OptionalDigest(final DigestAlgorithm digestAlgorithm, final byte[] optionalDigest)
@@ -50,9 +50,20 @@ public final class OptionalDigest extends AbstractDigest {
     /**
      * Default constructor necessary for Hibernate.
      */
-    protected OptionalDigest() {
+    private OptionalDigest() {
         this.algorithm = null;
         this.digest = null;
+    }
+
+    /**
+     * Helper method to reverse the toString method. Returns an OptionalDigest given a String
+     * that was created using an AbstractDigest's toString method.
+     *
+     * @param digest String representation of an AbstractDigest
+     * @return OptionalDigest object recreated from the String passed in
+     */
+    public static OptionalDigest fromString(final String digest) {
+        return new OptionalDigest(algorithmFromString(digest), digestFromString(digest));
     }
 
     /**
@@ -72,16 +83,5 @@ public final class OptionalDigest extends AbstractDigest {
      */
     public Digest asDigest() {
         return new Digest(algorithm, digest);
-    }
-
-    /**
-     * Helper method to reverse the toString method. Returns an OptionalDigest given a String
-     * that was created using an AbstractDigest's toString method.
-     *
-     * @param digest String representation of an AbstractDigest
-     * @return OptionalDigest object recreated from the String passed in
-     */
-    public static OptionalDigest fromString(final String digest) {
-        return new OptionalDigest(algorithmFromString(digest), digestFromString(digest));
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/enums/DeviceInfoEnums.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/enums/DeviceInfoEnums.java
@@ -18,6 +18,7 @@ public final class DeviceInfoEnums {
      * Constant variable representing the various Long sized strings.
      */
     public static final int LONG_STRING_LENGTH = 255;
+
     /**
      * Default private constructor so checkstyles doesn't complain.
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/exception/PolicyManagerException.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/exception/PolicyManagerException.java
@@ -12,8 +12,7 @@ public class PolicyManagerException extends RuntimeException {
      * Creates a new <code>PolicyManagerException</code> that has the message
      * <code>msg</code>.
      *
-     * @param msg
-     *            exception message
+     * @param msg exception message
      */
     public PolicyManagerException(final String msg) {
         super(msg);
@@ -23,8 +22,7 @@ public class PolicyManagerException extends RuntimeException {
      * Creates a new <code>PolicyManagerException</code> that wraps the given
      * <code>Throwable</code>.
      *
-     * @param t
-     *            root cause
+     * @param t root cause
      */
     public PolicyManagerException(final Throwable t) {
         super(t);
@@ -34,10 +32,8 @@ public class PolicyManagerException extends RuntimeException {
      * Creates a new <code>PolicyManagerException</code> that has the message
      * <code>msg</code> and wraps the root cause.
      *
-     * @param msg
-     *            exception message
-     * @param t
-     *            root cause
+     * @param msg exception message
+     * @param t   root cause
      */
     public PolicyManagerException(final String msg, final Throwable t) {
         super(msg, t);

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -277,8 +277,8 @@ public class ReferenceManifestValidator {
             filepath = file.getAttribute(SwidTagConstants.NAME);
         }
         if (getHashValue(filepath, "SHA256").equals(
-                file.getAttribute(SwidTagConstants._SHA256_HASH.getPrefix() + ":"
-                        + SwidTagConstants._SHA256_HASH.getLocalPart()))) {
+                file.getAttribute(SwidTagConstants.SHA_256_HASH.getPrefix() + ":"
+                        + SwidTagConstants.SHA_256_HASH.getLocalPart()))) {
             log.info("Support RIM hash verified for {}", filepath);
             return true;
         } else {
@@ -377,7 +377,7 @@ public class ReferenceManifestValidator {
      *
      * @param signature the signature that failed to validate
      * @param context   the context used for validation
-     * @throws XMLSignatureException
+     * @throws XMLSignatureException if there is an issue validating the provided signature
      */
     private void whySignatureInvalid(final XMLSignature signature, final DOMValidateContext context)
             throws XMLSignatureException {
@@ -415,7 +415,7 @@ public class ReferenceManifestValidator {
             throws Exception {
         if (cert == null || trustStore == null) {
             throw new Exception("Null certificate or truststore received");
-        } else if (trustStore.size() == 0) {
+        } else if (trustStore.isEmpty()) {
             throw new Exception("Truststore is empty");
         }
 
@@ -542,9 +542,8 @@ public class ReferenceManifestValidator {
      *
      * @param pemString the input string
      * @return an X509Certificate created from the string, or null
-     * @throws Exception if certificate cannot be successfully parsed
      */
-    private X509Certificate parseCertFromPEMString(final String pemString) throws Exception {
+    private X509Certificate parseCertFromPEMString(final String pemString) {
         String certificateHeader = "-----BEGIN CERTIFICATE-----";
         String certificateFooter = "-----END CERTIFICATE-----";
         try {
@@ -614,7 +613,7 @@ public class ReferenceManifestValidator {
      *
      * @param certificate the cert to pull the subjectKeyIdentifier from
      * @return the String representation of the subjectKeyIdentifier
-     * @throws IOException
+     * @throws IOException if there are issues retrieving the certificate subject key identifier
      */
     private String getCertificateSubjectKeyIdentifier(final X509Certificate certificate)
             throws IOException {
@@ -631,7 +630,7 @@ public class ReferenceManifestValidator {
     /**
      * This method parses the subject key identifier from the KeyName element of a signature.
      *
-     * @param doc
+     * @param doc document
      * @return SKID if found, or an empty string.
      */
     private String getKeyName(final Document doc) {

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
@@ -78,83 +78,83 @@ public final class SwidTagConstants {
     public static final String FX_SEPARATOR = ":";
     public static final String RFC3852_PFX = "rcf3852";
     public static final String RFC3339_PFX = "rcf3339";
-    public static final String _COLLOQUIAL_VERSION_STR = N8060_PFX + FX_SEPARATOR
+    public static final String COLLOQUIAL_VERSION_STR = N8060_PFX + FX_SEPARATOR
             + COLLOQUIAL_VERSION;
-    public static final String _PRODUCT_STR = N8060_PFX + FX_SEPARATOR
+    public static final String PRODUCT_STR = N8060_PFX + FX_SEPARATOR
             + PRODUCT;
-    public static final String _REVISION_STR = N8060_PFX + FX_SEPARATOR
+    public static final String REVISION_STR = N8060_PFX + FX_SEPARATOR
             + REVISION;
-    public static final String _EDITION_STR = N8060_PFX + FX_SEPARATOR
+    public static final String EDITION_STR = N8060_PFX + FX_SEPARATOR
             + EDITION;
-    public static final String _RIM_LINK_HASH_STR = RIM_PFX + FX_SEPARATOR
+    public static final String RIM_LINK_HASH_STR = RIM_PFX + FX_SEPARATOR
             + RIM_LINK_HASH;
-    public static final String _BINDING_SPEC_STR = RIM_PFX + FX_SEPARATOR
+    public static final String BINDING_SPEC_STR = RIM_PFX + FX_SEPARATOR
             + BINDING_SPEC;
-    public static final String _BINDING_SPEC_VERSION_STR = RIM_PFX + FX_SEPARATOR
+    public static final String BINDING_SPEC_VERSION_STR = RIM_PFX + FX_SEPARATOR
             + BINDING_SPEC_VERSION;
-    public static final String _PLATFORM_MANUFACTURER_STR = RIM_PFX + FX_SEPARATOR
+    public static final String PLATFORM_MANUFACTURER_FULL_STR = RIM_PFX + FX_SEPARATOR
             + PLATFORM_MANUFACTURER_STR;
-    public static final String _PLATFORM_MANUFACTURER_ID_STR = RIM_PFX + FX_SEPARATOR
+    public static final String PLATFORM_MANUFACTURER_ID_STR = RIM_PFX + FX_SEPARATOR
             + PLATFORM_MANUFACTURER_ID;
-    public static final String _PLATFORM_MODEL_STR = RIM_PFX + FX_SEPARATOR
+    public static final String PLATFORM_MODEL_STR = RIM_PFX + FX_SEPARATOR
             + PLATFORM_MODEL;
-    public static final String _PLATFORM_VERSION_STR = RIM_PFX + FX_SEPARATOR
+    public static final String PLATFORM_VERSION_STR = RIM_PFX + FX_SEPARATOR
             + PLATFORM_VERSION;
-    public static final String _PAYLOAD_TYPE_STR = RIM_PFX + FX_SEPARATOR
+    public static final String PAYLOAD_TYPE_STR = RIM_PFX + FX_SEPARATOR
             + PAYLOAD_TYPE;
-    public static final String _PC_URI_LOCAL_STR = RIM_PFX + FX_SEPARATOR
+    public static final String PC_URI_LOCAL_STR = RIM_PFX + FX_SEPARATOR
             + PC_URI_LOCAL;
-    public static final String _PC_URI_GLOBAL_STR = RIM_PFX + FX_SEPARATOR
+    public static final String PC_URI_GLOBAL_STR = RIM_PFX + FX_SEPARATOR
             + PC_URI_GLOBAL;
-    public static final QName _SHA256_HASH = new QName(
+    public static final QName SHA_256_HASH = new QName(
             "http://www.w3.org/2001/04/xmlenc#sha256", HASH, "SHA256");
-    public static final QName _COLLOQUIAL_VERSION = new QName(
+    public static final QName QNAME_COLLOQUIAL_VERSION = new QName(
             NIST_NS, COLLOQUIAL_VERSION, N8060_PFX);
-    public static final QName _EDITION = new QName(
+    public static final QName QNAME_EDITION = new QName(
             NIST_NS, EDITION, N8060_PFX);
-    public static final QName _PRODUCT = new QName(
+    public static final QName QNAME_PRODUCT = new QName(
             NIST_NS, PRODUCT, N8060_PFX);
-    public static final QName _REVISION = new QName(
+    public static final QName QNAME_REVISION = new QName(
             NIST_NS, REVISION, N8060_PFX);
-    public static final QName _PAYLOAD_TYPE = new QName(
+    public static final QName QNAME_PAYLOAD_TYPE = new QName(
             TCG_NS, PAYLOAD_TYPE, RIM_PFX);
-    public static final QName _PLATFORM_MANUFACTURER = new QName(
+    public static final QName QNAME_PLATFORM_MANUFACTURER = new QName(
             TCG_NS, PLATFORM_MANUFACTURER_STR, RIM_PFX);
-    public static final QName _PLATFORM_MANUFACTURER_ID = new QName(
+    public static final QName QNAME_PLATFORM_MANUFACTURER_ID = new QName(
             TCG_NS, PLATFORM_MANUFACTURER_ID, RIM_PFX);
-    public static final QName _PLATFORM_MODEL = new QName(
+    public static final QName QNAME_PLATFORM_MODEL = new QName(
             TCG_NS, PLATFORM_MODEL, RIM_PFX);
-    public static final QName _PLATFORM_VERSION = new QName(
+    public static final QName QNAME_PLATFORM_VERSION = new QName(
             TCG_NS, PLATFORM_VERSION, RIM_PFX);
-    public static final QName _FIRMWARE_MANUFACTURER_STR = new QName(
+    public static final QName QNAME_FIRMWARE_MANUFACTURER_STR = new QName(
             TCG_NS, FIRMWARE_MANUFACTURER_STR, RIM_PFX);
-    public static final QName _FIRMWARE_MANUFACTURER_ID = new QName(
+    public static final QName QNAME_FIRMWARE_MANUFACTURER_ID = new QName(
             TCG_NS, FIRMWARE_MANUFACTURER_ID, RIM_PFX);
-    public static final QName _FIRMWARE_MODEL = new QName(
+    public static final QName QNAME_FIRMWARE_MODEL = new QName(
             TCG_NS, FIRMWARE_MODEL, RIM_PFX);
-    public static final QName _FIRMWARE_VERSION = new QName(
+    public static final QName QNAME_FIRMWARE_VERSION = new QName(
             TCG_NS, FIRMWARE_VERSION, RIM_PFX);
-    public static final QName _BINDING_SPEC = new QName(
+    public static final QName QNAME_BINDING_SPEC = new QName(
             TCG_NS, BINDING_SPEC, RIM_PFX);
-    public static final QName _BINDING_SPEC_VERSION = new QName(
+    public static final QName QNAME_BINDING_SPEC_VERSION = new QName(
             TCG_NS, BINDING_SPEC_VERSION, RIM_PFX);
-    public static final QName _PC_URI_LOCAL = new QName(
+    public static final QName QNAME_PC_URI_LOCAL = new QName(
             TCG_NS, PC_URI_LOCAL, RIM_PFX);
-    public static final QName _PC_URI_GLOBAL = new QName(
+    public static final QName QNAME_PC_URI_GLOBAL = new QName(
             TCG_NS, PC_URI_GLOBAL, RIM_PFX);
-    public static final QName _RIM_LINK_HASH = new QName(
+    public static final QName QNAME_RIM_LINK_HASH = new QName(
             TCG_NS, RIM_LINK_HASH, RIM_PFX);
-    public static final QName _SUPPORT_RIM_TYPE = new QName(
+    public static final QName QNAME_SUPPORT_RIM_TYPE = new QName(
             TCG_NS, SUPPORT_RIM_TYPE, RIM_PFX);
-    public static final QName _SUPPORT_RIM_FORMAT = new QName(
+    public static final QName QNAME_SUPPORT_RIM_FORMAT = new QName(
             TCG_NS, SUPPORT_RIM_FORMAT, RIM_PFX);
-    public static final QName _SUPPORT_RIM_URI_GLOBAL = new QName(
+    public static final QName QNAME_SUPPORT_RIM_URI_GLOBAL = new QName(
             TCG_NS, SUPPORT_RIM_URI_GLOBAL, RIM_PFX);
-    public static final QName _N8060_ENVVARPREFIX = new QName(
+    public static final QName N8060_ENVVARPREFIX = new QName(
             NIST_NS, "envVarPrefix", N8060_PFX);
-    public static final QName _N8060_ENVVARSUFFIX = new QName(
+    public static final QName N8060_ENVVARSUFFIX = new QName(
             NIST_NS, "envVarSuffix", N8060_PFX);
-    public static final QName _N8060_PATHSEPARATOR = new QName(
+    public static final QName N8060_PATHSEPARATOR = new QName(
             NIST_NS, "pathSeparator", N8060_PFX);
     public static final String CA_ISSUERS = "1.3.6.1.5.5.7.48.2";
 

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/TPMBaselineGeneratorException.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/TPMBaselineGeneratorException.java
@@ -12,8 +12,7 @@ public class TPMBaselineGeneratorException extends Exception {
      * Creates a new <code>CreateTPMBaselineException</code> that has the
      * message <code>msg</code>.
      *
-     * @param msg
-     *            exception message
+     * @param msg exception message
      */
     TPMBaselineGeneratorException(final String msg) {
         super(msg);
@@ -23,8 +22,7 @@ public class TPMBaselineGeneratorException extends Exception {
      * Creates a new <code>CreateTPMBaselineException</code> that wraps the
      * given <code>Throwable</code>.
      *
-     * @param t
-     *            root cause
+     * @param t root cause
      */
     TPMBaselineGeneratorException(final Throwable t) {
         super(t);
@@ -34,10 +32,8 @@ public class TPMBaselineGeneratorException extends Exception {
      * Creates a new <code>CreateTPMBaselineException</code> that has the
      * message <code>msg</code> and wraps the root cause.
      *
-     * @param msg
-     *            exception message
-     * @param t
-     *            root cause
+     * @param msg exception message
+     * @param t   root cause
      */
     TPMBaselineGeneratorException(final String msg, final Throwable t) {
         super(msg, t);

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
@@ -25,56 +25,104 @@ import java.util.LinkedHashMap;
  */
 public final class TCGEventLog {
 
-    /** Logger. */
-    private static final Logger LOGGER = LogManager.getLogger(TCGEventLog.class);
-    /** Name of the hash algorithm used to process the Event Log, default is SHA256.  */
-    @Getter
-    private String eventLogHashAlgorithm = "TPM_ALG_SHA256";
-    /** Parsed event log array. */
-    private static final int SIG_OFFSET = 32;
-    /**  TEV_NO_ACTION signature size. */
-    private static final int SIG_SIZE = 16;
-    /** Initial value for SHA 256 values.*/
+    /**
+     * Initial value for SHA 256 values.
+     */
     public static final String INIT_SHA256_LIST = "00000000000000000000000000"
             + "00000000000000000000000000000000000000";
-    /** Initial value for SHA 256 values.*/
+    /**
+     * Initial value for SHA 256 values.
+     */
     public static final String LOCALITY4_SHA256_LIST = "ffffffffffffffffffffffffff"
             + "ffffffffffffffffffffffffffffffffffffff";
-    /** Initial value for SHA 1 values. */
+    /**
+     * Initial value for SHA 1 values.
+     */
     public static final String INIT_SHA1_LIST = "0000000000000000000000000000000000000000";
-    /** Initial value for SHA 1 values. */
+    /**
+     * Initial value for SHA 1 values.
+     */
     public static final String LOCALITY4_SHA1_LIST = "ffffffffffffffffffffffffffffffffffffffff";
-    /** PFP defined EV_NO_ACTION identifier. */
+    /**
+     * PFP defined EV_NO_ACTION identifier.
+     */
     public static final int NO_ACTION_EVENT = 0x00000003;
-    /** String value of SHA1 hash.*/
+    /**
+     * String value of SHA1 hash.
+     */
     public static final String HASH_STRING = "SHA1";
-    /** String value of SHA256 hash.  */
+    /**
+     * String value of SHA256 hash.
+     */
     public static final String HASH256_STRING = "SHA-256";
-    /** Each PCR bank holds 24 registers. */
+    /**
+     * Each PCR bank holds 24 registers.
+     */
     public static final int PCR_COUNT = 24;
-    /** Locality 4 starts at PCR 17. */
+    /**
+     * Locality 4 starts at PCR 17.
+     */
     public static final int PCR_LOCALITY4_MIN = 17;
-    /** Locality 4 Ends at PCR 23. */
+    /**
+     * Locality 4 Ends at PCR 23.
+     */
     public static final int PCR_LOCALITY4_MAX = 23;
-    /** 2 dimensional array holding the PCR values. */
-    private byte[][] pcrList;
-    /** List of parsed events within the log. */
-    private LinkedHashMap<Integer, TpmPcrEvent> eventList = new LinkedHashMap<>();
-    /** Length of PCR. Indicates which hash algorithm is used. */
-    private int pcrLength;
-    /** Name of hash algorithm. */
-    private String hashType;
-    /** Initial PCR Value to use. */
-    private String initValue;
-    /** Initial PcR Value to use for locality 4. */
-    private String initLocalityFourValue;
-    /** Content Output Flag use. */
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER = LogManager.getLogger(TCGEventLog.class);
+    /**
+     * Parsed event log array.
+     */
+    private static final int SIG_OFFSET = 32;
+    /**
+     * TEV_NO_ACTION signature size.
+     */
+    private static final int SIG_SIZE = 16;
+    /**
+     * Name of the hash algorithm used to process the Event Log, default is SHA256.
+     */
+    @Getter
+    private String eventLogHashAlgorithm = "TPM_ALG_SHA256";
+    /**
+     * 2 dimensional array holding the PCR values.
+     */
+    private final byte[][] pcrList;
+    /**
+     * List of parsed events within the log.
+     */
+    private final LinkedHashMap<Integer, TpmPcrEvent> eventList = new LinkedHashMap<>();
+    /**
+     * Length of PCR. Indicates which hash algorithm is used.
+     */
+    private final int pcrLength;
+    /**
+     * Name of hash algorithm.
+     */
+    private final String hashType;
+    /**
+     * Initial PCR Value to use.
+     */
+    private final String initValue;
+    /**
+     * Initial PcR Value to use for locality 4.
+     */
+    private final String initLocalityFourValue;
+    /**
+     * Content Output Flag use.
+     */
     private boolean bContent = false;
-    /** Event Output Flag use. */
+    /**
+     * Event Output Flag use.
+     */
     private boolean bHexEvent = false;
-    /** Event Output Flag use. */
+    /**
+     * Event Output Flag use.
+     */
     private boolean bEvent = false;
-    /** Event Output Flag use. */
+    /**
+     * Event Output Flag use.
+     */
     @Getter
     private boolean bCryptoAgile = false;
     /**
@@ -111,29 +159,31 @@ public final class TCGEventLog {
 
     /**
      * Simple constructor for Event Log.
+     *
      * @param rawlog data for the event log file.
-     * @throws java.security.NoSuchAlgorithmException if an unknown algorithm is encountered.
+     * @throws java.security.NoSuchAlgorithmException  if an unknown algorithm is encountered.
      * @throws java.security.cert.CertificateException if a certificate in the log cannot be parsed.
-     * @throws java.io.IOException IO Stream if event cannot be parsed.
+     * @throws java.io.IOException                     IO Stream if event cannot be parsed.
      */
     public TCGEventLog(final byte[] rawlog)
-                       throws CertificateException, NoSuchAlgorithmException, IOException {
+            throws CertificateException, NoSuchAlgorithmException, IOException {
         this(rawlog, false, false, false);
     }
 
     /**
      * Default constructor for just the rawlog that'll set up SHA1 Log.
-     * @param rawlog data for the event log file.
-     * @param bEventFlag if true provides human readable event descriptions.
-     * @param bContentFlag if true provides hex output for Content in the description.
+     *
+     * @param rawlog        data for the event log file.
+     * @param bEventFlag    if true provides human readable event descriptions.
+     * @param bContentFlag  if true provides hex output for Content in the description.
      * @param bHexEventFlag if true provides hex event structure in the description.
-     * @throws java.security.NoSuchAlgorithmException if an unknown algorithm is encountered.
+     * @throws java.security.NoSuchAlgorithmException  if an unknown algorithm is encountered.
      * @throws java.security.cert.CertificateException if a certificate in the log cannot be parsed.
-     * @throws java.io.IOException IO Stream if event cannot be parsed.
+     * @throws java.io.IOException                     IO Stream if event cannot be parsed.
      */
     public TCGEventLog(final byte[] rawlog, final boolean bEventFlag,
                        final boolean bContentFlag, final boolean bHexEventFlag)
-                       throws CertificateException, NoSuchAlgorithmException, IOException {
+            throws CertificateException, NoSuchAlgorithmException, IOException {
 
         bCryptoAgile = isLogCrytoAgile(rawlog);
         if (bCryptoAgile) {
@@ -194,18 +244,18 @@ public final class TCGEventLog {
      * This method puts blank values in the pcrList.
      */
     private void initPcrList() {
-            try {
-                for (int i = 0; i < PCR_COUNT; i++) {
-                    System.arraycopy(Hex.decodeHex(initValue.toCharArray()),
+        try {
+            for (int i = 0; i < PCR_COUNT; i++) {
+                System.arraycopy(Hex.decodeHex(initValue.toCharArray()),
                         0, pcrList[i], 0, pcrLength);
-                }
-                for (int i = PCR_LOCALITY4_MIN; i < PCR_LOCALITY4_MAX; i++) {
-                        System.arraycopy(Hex.decodeHex(initLocalityFourValue.toCharArray()),
-                            0, pcrList[i], 0, pcrLength);
-                    }
-            } catch (DecoderException deEx) {
-                LOGGER.error(deEx);
             }
+            for (int i = PCR_LOCALITY4_MIN; i < PCR_LOCALITY4_MAX; i++) {
+                System.arraycopy(Hex.decodeHex(initLocalityFourValue.toCharArray()),
+                        0, pcrList[i], 0, pcrLength);
+            }
+        } catch (DecoderException deEx) {
+            LOGGER.error(deEx);
+        }
     }
 
 //    /**
@@ -298,6 +348,7 @@ public final class TCGEventLog {
 
     /**
      * Returns a list of event found in the Event Log.
+     *
      * @return an arraylist of event.
      */
     public Collection<TpmPcrEvent> getEventList() {
@@ -307,6 +358,7 @@ public final class TCGEventLog {
     /**
      * Returns a specific element of the Event Log that corresponds to the requested
      * event number.
+     *
      * @param eventNumber specific event to find in the list.
      * @return TPM Event in the position of the list
      */
@@ -326,6 +378,7 @@ public final class TCGEventLog {
 
     /**
      * Human readable string representing the contents of the Event Log.
+     *
      * @return Description of the log.
      */
     public String toString() {
@@ -334,14 +387,15 @@ public final class TCGEventLog {
             sb.append(event.toString(bEvent, bHexEvent, bContent));
         }
         sb.append("Event Log processing completed.\n");
-       return sb.toString();
+        return sb.toString();
     }
 
     /**
      * Human readable string representing the contents of the Event Log.
-     * @param event flag to set
+     *
+     * @param event    flag to set
      * @param hexEvent flag to set
-     * @param content flag to set
+     * @param content  flag to set
      * @return Description of the log.
      */
     public String toString(final boolean event,
@@ -357,10 +411,11 @@ public final class TCGEventLog {
     /**
      * Returns the TCG Algorithm Registry defined ID for the Digest Algorithm
      * used in the event log.
+     *
      * @return TCG Defined Algorithm name
      */
     public int getEventLogHashAlgorithmID() {
-       return TcgTpmtHa.tcgAlgStringToId(eventLogHashAlgorithm);
+        return TcgTpmtHa.tcgAlgStringToId(eventLogHashAlgorithm);
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TcgTpmtHa.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TcgTpmtHa.java
@@ -18,26 +18,6 @@ import java.math.BigInteger;
  */
 public class TcgTpmtHa {
     /**
-     * TCG Defined Algorithm Identifiers.
-     */
-    @Getter
-    private int hashAlgId = 0;
-    /**
-     * Length of the  hash.
-     */
-    @Getter
-    private int hashLength = 0;
-    /**
-     * Human readable name of the hash algorithm.
-     */
-    @Getter
-    private String hashName = "";
-    /**
-     * Hash data.
-     */
-    @Getter(value = AccessLevel.PROTECTED)
-    private byte[] digest = null;
-    /**
      * TCG ID for SHA1.
      */
     public static final int TPM_ALG_SHA1 = 0x04;
@@ -78,6 +58,26 @@ public class TcgTpmtHa {
      */
     public static final int TPM_ALG_NULL_LENGTH = 0;
     /**
+     * TCG Defined Algorithm Identifiers.
+     */
+    @Getter
+    private int hashAlgId = 0;
+    /**
+     * Length of the  hash.
+     */
+    @Getter
+    private int hashLength = 0;
+    /**
+     * Human readable name of the hash algorithm.
+     */
+    @Getter
+    private String hashName = "";
+    /**
+     * Hash data.
+     */
+    @Getter(value = AccessLevel.PROTECTED)
+    private byte[] digest = null;
+    /**
      * buffer to hold the structure.
      */
     private byte[] buffer = null;
@@ -100,25 +100,6 @@ public class TcgTpmtHa {
         buffer = new byte[algID.length + digest.length];
         System.arraycopy(algID, 0, buffer, 0, algID.length);
         System.arraycopy(digest, 0, buffer, algID.length, digest.length);
-    }
-
-    /**
-     * Returns the contents of the TPMT_HA structure buffer.
-     *
-     * @return contents of the TPMT_HA structure.
-     */
-    public byte[] getBuffer() {
-        return java.util.Arrays.copyOf(buffer, buffer.length);
-    }
-
-    /**
-     * Readable description of the Algorithm.
-     *
-     * @return Readable Algorithm name
-     */
-    @Override
-    public String toString() {
-        return String.format("%s hash = %s", hashName, HexUtils.byteArrayToHexString(digest));
     }
 
     /**
@@ -211,5 +192,24 @@ public class TcgTpmtHa {
                 length = TPM_ALG_NULL_LENGTH;
         }
         return length;
+    }
+
+    /**
+     * Returns the contents of the TPMT_HA structure buffer.
+     *
+     * @return contents of the TPMT_HA structure.
+     */
+    public byte[] getBuffer() {
+        return java.util.Arrays.copyOf(buffer, buffer.length);
+    }
+
+    /**
+     * Readable description of the Algorithm.
+     *
+     * @return Readable Algorithm name
+     */
+    @Override
+    public String toString() {
+        return String.format("%s hash = %s", hashName, HexUtils.byteArrayToHexString(digest));
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TcgTpmtHa.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TcgTpmtHa.java
@@ -21,62 +21,76 @@ public class TcgTpmtHa {
      * TCG ID for SHA1.
      */
     public static final int TPM_ALG_SHA1 = 0x04;
+
     /**
      * TCG ID for SHA1.
      */
     public static final int TPM_ALG_SHA256 = 0x0B;
+
     /**
      * TCG ID for SHA 384.
      */
     public static final int TPM_ALG_SHA384 = 0x0C;
+
     /**
      * TCG ID for SHA512.
      */
     public static final int TPM_ALG_SHA_512 = 0x0D;
+
     /**
      * TCG ID for Null algorithm.
      */
     public static final int TPM_ALG_NULL = 0x10;
+
     /**
      * TCG ID for SHA1.
      */
     public static final int TPM_ALG_SHA1_LENGTH = 20;
+
     /**
      * TCG ID for SHA1.
      */
     public static final int TPM_ALG_SHA256_LENGTH = 32;
+
     /**
      * TCG ID for SHA 384.
      */
     public static final int TPM_ALG_SHA384_LENGTH = 48;
+
     /**
      * TCG ID for SHA512.
      */
     public static final int TPM_ALG_SHA512_LENGTH = 64;
+
     /**
      * TCG ID for Null algorithm.
      */
     public static final int TPM_ALG_NULL_LENGTH = 0;
+
     /**
      * TCG Defined Algorithm Identifiers.
      */
     @Getter
     private int hashAlgId = 0;
+
     /**
      * Length of the  hash.
      */
     @Getter
     private int hashLength = 0;
+
     /**
-     * Human readable name of the hash algorithm.
+     * Human-readable name of the hash algorithm.
      */
     @Getter
     private String hashName = "";
+
     /**
      * Hash data.
      */
     @Getter(value = AccessLevel.PROTECTED)
     private byte[] digest = null;
+
     /**
      * buffer to hold the structure.
      */
@@ -111,27 +125,14 @@ public class TcgTpmtHa {
      * @return name of the algorithm
      */
     public static String tcgAlgIdToString(final int algId) {
-        String alg;
-        switch (algId) {
-            case TPM_ALG_SHA1:
-                alg = "TPM_ALG_SHA1";
-                break;
-            case TPM_ALG_SHA256:
-                alg = "TPM_ALG_SHA256";
-                break;
-            case TPM_ALG_SHA384:
-                alg = "TPM_ALG_SHA384";
-                break;
-            case TPM_ALG_SHA_512:
-                alg = "TPM_ALG_SHA512";
-                break;
-            case TPM_ALG_NULL:
-                alg = "TPM_ALG_NULL";
-                break;
-            default:
-                alg = "Unknown or invalid Hash";
-        }
-        return alg;
+        return switch (algId) {
+            case TPM_ALG_SHA1 -> "TPM_ALG_SHA1";
+            case TPM_ALG_SHA256 -> "TPM_ALG_SHA256";
+            case TPM_ALG_SHA384 -> "TPM_ALG_SHA384";
+            case TPM_ALG_SHA_512 -> "TPM_ALG_SHA512";
+            case TPM_ALG_NULL -> "TPM_ALG_NULL";
+            default -> "Unknown or invalid Hash";
+        };
     }
 
     /**
@@ -143,25 +144,13 @@ public class TcgTpmtHa {
      * @return id of hash algorithm
      */
     public static int tcgAlgStringToId(final String algorithm) {
-        int alg;
-        switch (algorithm) {
-            case "TPM_ALG_SHA1":
-                alg = TPM_ALG_SHA1;
-                break;
-            case "TPM_ALG_SHA256":
-                alg = TPM_ALG_SHA256;
-                break;
-            case "TPM_ALG_SHA384":
-                alg = TPM_ALG_SHA384;
-                break;
-            case "TPM_ALG_SHA512":
-                alg = TPM_ALG_SHA_512;
-                break;
-            case "TPM_ALG_NULL":
-            default:
-                alg = TPM_ALG_NULL;
-        }
-        return alg;
+        return switch (algorithm) {
+            case "TPM_ALG_SHA1" -> TPM_ALG_SHA1;
+            case "TPM_ALG_SHA256" -> TPM_ALG_SHA256;
+            case "TPM_ALG_SHA384" -> TPM_ALG_SHA384;
+            case "TPM_ALG_SHA512" -> TPM_ALG_SHA_512;
+            default -> TPM_ALG_NULL;
+        };
     }
 
     /**
@@ -173,25 +162,13 @@ public class TcgTpmtHa {
      * @return length of hash data in  bytes
      */
     public static int tcgAlgLength(final int algId) {
-        int length;
-        switch (algId) {
-            case TPM_ALG_SHA1:
-                length = TPM_ALG_SHA1_LENGTH;
-                break;
-            case TPM_ALG_SHA256:
-                length = TPM_ALG_SHA256_LENGTH;
-                break;
-            case TPM_ALG_SHA384:
-                length = TPM_ALG_SHA384_LENGTH;
-                break;
-            case TPM_ALG_SHA_512:
-                length = TPM_ALG_SHA512_LENGTH;
-                break;
-            case TPM_ALG_NULL:
-            default:
-                length = TPM_ALG_NULL_LENGTH;
-        }
-        return length;
+        return switch (algId) {
+            case TPM_ALG_SHA1 -> TPM_ALG_SHA1_LENGTH;
+            case TPM_ALG_SHA256 -> TPM_ALG_SHA256_LENGTH;
+            case TPM_ALG_SHA384 -> TPM_ALG_SHA384_LENGTH;
+            case TPM_ALG_SHA_512 -> TPM_ALG_SHA512_LENGTH;
+            default -> TPM_ALG_NULL_LENGTH;
+        };
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
@@ -3,17 +3,17 @@ package hirs.utils.tpm.eventlog;
 import hirs.utils.HexUtils;
 import hirs.utils.tpm.eventlog.events.EvCompactHash;
 import hirs.utils.tpm.eventlog.events.EvConstants;
+import hirs.utils.tpm.eventlog.events.EvEfiBootServicesApp;
 import hirs.utils.tpm.eventlog.events.EvEfiGptPartition;
 import hirs.utils.tpm.eventlog.events.EvEfiHandoffTable;
 import hirs.utils.tpm.eventlog.events.EvEfiSpdmDeviceSecurityEvent;
 import hirs.utils.tpm.eventlog.events.EvEventTag;
 import hirs.utils.tpm.eventlog.events.EvIPL;
 import hirs.utils.tpm.eventlog.events.EvNoAction;
+import hirs.utils.tpm.eventlog.events.EvPostCode;
 import hirs.utils.tpm.eventlog.events.EvSCrtmContents;
 import hirs.utils.tpm.eventlog.events.EvSCrtmVersion;
 import hirs.utils.tpm.eventlog.uefi.UefiConstants;
-import hirs.utils.tpm.eventlog.events.EvEfiBootServicesApp;
-import hirs.utils.tpm.eventlog.events.EvPostCode;
 import hirs.utils.tpm.eventlog.uefi.UefiFirmware;
 import hirs.utils.tpm.eventlog.uefi.UefiVariable;
 import lombok.AccessLevel;
@@ -61,60 +61,77 @@ public class TpmPcrEvent {
      * Log format. SHA1=1, Crytpo agile=2.
      * this can be refactored out
      */
-    @Getter @Setter(value = AccessLevel.PROTECTED)
+    @Getter
+    @Setter(value = AccessLevel.PROTECTED)
     private int logFormat = -1;
+
     /**
      * PCR index.
      */
     @Getter
     private int pcrIndex = -1;
+
     /**
      * Event Type (long).
      */
     @Getter
     private long eventType = 0;
+
     /**
      * Event digest.
      */
     private byte[] digest = null;
+
     /**
      * Event data (no content).
      */
     private byte[] event;
+
     /**
      * Event content data.
      */
     private byte[] eventContent;
+
     /**
      * TCG Event Log spec version.
      */
     @Getter
     private String specVersion = "Unknown";
+
     /**
      * TCG Event Log errata version.
      */
     @Getter
     private String specErrataVersion = "Unknown";
+
     /**
      * Description for toString support.
      */
     private String description = "";
+
     /**
      * Length (in bytes) of a pcr.
      */
-    @Setter @Getter
+    @Getter
+    @Setter
     private int digestLength = 0;
+
     /**
      * Event hash for SHA1 event logs.
      */
     private byte[] eventDataSha1hash;
+
     /**
      * Event hash for Crypto Agile events.
      */
     private byte[] eventDataSha256hash;
-    @Setter @Getter
+
+    @Getter
+    @Setter
     private int eventNumber;
-    @Setter @Getter
+
+    @Getter
+    @Setter
     private boolean error = false;
 
     /**
@@ -145,403 +162,6 @@ public class TpmPcrEvent {
      */
     public TpmPcrEvent(final ByteArrayInputStream baIs) throws IOException {
 
-    }
-
-    /**
-     * Sets the digest from a  TCG_PCR_EVENT digest field.
-     * This can be SHA1 for older event structures or any algorithm for newer structure.
-     *
-     * @param data cryptographic hash
-     * @param length length of the cryptographic hash
-     */
-    protected void setEventDigest(final byte[] data, final int length) {
-        digest = new byte[length];
-        System.arraycopy(data, 0, digest, 0, length);
-    }
-
-    /**
-     * Retrieves the digest from a TCG Event.
-     * This can be SHA1 for older event structures or any algorithm for newer structure.
-     *
-     * @return the digest data for the event
-     */
-    public byte[] getEventDigest() {
-        byte[] digestCopy = new byte[digestLength];
-        System.arraycopy(digest, 0, digestCopy, 0, this.digestLength);
-        return digestCopy;
-    }
-
-    /**
-     * Returns a hex representation of the event digest.
-     * @return hex string
-     */
-    public String getEventDigestStr() {
-        return Hex.encodeHexString(this.digest);
-    }
-
-    /**
-     * Sets the event PCR index value from a TCG Event.
-     *
-     * @param eventIndex TCG Event PCR Index as defined in the PFP
-     */
-    protected void setPcrIndex(final byte[] eventIndex) {
-        pcrIndex = HexUtils.leReverseInt(eventIndex);
-    }
-
-    /**
-     * Sets the EventType.
-     *
-     * @param type byte array holding the PFP defined log event type
-     */
-    protected void setEventType(final byte[] type) {
-        eventType = new BigInteger(1, HexUtils.leReverseByte(type)).longValue();
-    }
-
-    /**
-     * Returns a formatted string of the type for the event.
-     * @return a string formatted to be human readable
-     */
-    public String getEventTypeStr() {
-        return String.format("0x%s %s", Long.toHexString(eventType), eventString((int) eventType));
-    }
-
-    /**
-     * Returns a formatted string of the type for the event minus the byte code.
-     * @return a string formatted to be human readable
-     */
-    public String getEventTypeString() {
-        return eventString((int) eventType);
-    }
-
-    /**
-     * Sets the event data after processing.
-     *
-     * @param eventData The PFP defined event content
-     */
-    protected void setEventData(final byte[] eventData) {
-        event = new byte[eventData.length];
-        System.arraycopy(eventData, 0, event, 0, eventData.length);
-    }
-
-    /**
-     * Gets the Event Data (no event content) for the event.
-     * event log format.
-     *
-     * @return byte array holding the event structure.
-     */
-    public byte[] getEvent() {
-        return Arrays.copyOf(event, event.length);
-    }
-
-    /**
-     * Sets the event content after processing.
-     *
-     * @param eventData The PFP defined event content
-     */
-    protected void setEventContent(final byte[] eventData) {
-        eventContent = new byte[eventData.length];
-        //EvPostCode evPostCode = new EvPostCode(eventContent);
-        System.arraycopy(eventData, 0, eventContent, 0, eventData.length);
-    }
-
-    /**
-     * Gets the event Content Data (not the entire event structure).
-     *
-     * @return byte array holding the events content field
-     */
-    public byte[] getEventContent() {
-        return Arrays.copyOf(eventContent, eventContent.length);
-    }
-
-    /**
-     * A getter that parses the content based on the type and returns the proper string
-     * value for the content.
-     * @return an appended string of human readable data
-     */
-    public String getEventContentStr() {
-        StringBuilder sb = new StringBuilder();
-
-        switch ((int) this.eventType) {
-            case EvConstants.EV_PREBOOT_CERT:
-                sb.append(" EV_PREBOOT_CERT");
-                break;
-            case EvConstants.EV_POST_CODE:
-                sb.append(new EvPostCode(eventContent).toString());
-                break;
-            case EvConstants.EV_UNUSED:
-                break;
-            case EvConstants.EV_NO_ACTION:
-                EvNoAction noAction = null;
-                try {
-                    noAction = new EvNoAction(eventContent);
-                    sb.append(noAction.toString());
-                    if (noAction.isSpecIDEvent()) {
-                        specVersion = noAction.getSpecVersion();
-                        specErrataVersion = noAction.getSpecErrataVersion();
-                    }
-                } catch (UnsupportedEncodingException ueEx) {
-                    log.error(ueEx);
-                    sb.append(ueEx.toString());
-                }
-                break;
-            case EvConstants.EV_SEPARATOR:
-                if (EvPostCode.isAscii(eventContent)
-                        && !this.isBlank(eventContent)) {
-                    sb.append(String.format("Separator event content = %s",
-                            new String(eventContent, StandardCharsets.UTF_8)));
-                }
-                break;
-            case EvConstants.EV_EVENT_TAG:
-                sb.append(new EvEventTag(eventContent).toString());
-                break;
-            case EvConstants.EV_S_CRTM_CONTENTS:
-                sb.append(new EvSCrtmContents(eventContent).toString());
-                break;
-            case EvConstants.EV_S_CRTM_VERSION:
-                try {
-                    sb.append(new EvSCrtmVersion(eventContent).toString());
-                } catch (UnsupportedEncodingException ueEx) {
-                    log.error(ueEx);
-                    sb.append(ueEx.toString());
-                }
-                break;
-            case EvConstants.EV_CPU_MICROCODE:
-            case EvConstants.EV_PLATFORM_CONFIG_FLAGS:
-            case EvConstants.EV_TABLE_OF_DEVICES:
-                break;
-            case EvConstants.EV_COMPACT_HASH:
-                try {
-                    sb.append(new EvCompactHash(eventContent).toString());
-                } catch (UnsupportedEncodingException ueEx) {
-                    log.error(ueEx);
-                    sb.append(ueEx.toString());
-                }
-                break;
-            case EvConstants.EV_IPL:
-                sb.append(new EvIPL(eventContent).toString());
-                break;
-            case EvConstants.EV_IPL_PARTITION_DATA:
-            case EvConstants.EV_NONHOST_CODE:
-            case EvConstants.EV_NONHOST_CONFIG:
-            case EvConstants.EV_NONHOST_INFO:
-            case EvConstants.EV_EV_OMIT_BOOT_DEVICES_EVENTS:
-            case EvConstants.EV_EFI_EVENT_BASE:
-                break;
-            case EvConstants.EV_EFI_VARIABLE_DRIVER_CONFIG:
-            case EvConstants.EV_EFI_VARIABLE_BOOT:
-            case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
-            case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
-            case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
-                try {
-                    sb.append(new UefiVariable(eventContent).toString());
-                } catch (CertificateException cEx) {
-                    log.error(cEx);
-                    sb.append(cEx.toString());
-                } catch (NoSuchAlgorithmException noSaEx) {
-                    log.error(noSaEx);
-                    sb.append(noSaEx.toString());
-                } catch (IOException ioEx) {
-                    log.error(ioEx);
-                    sb.append(ioEx.toString());
-                }
-                break;
-            case EvConstants.EV_EFI_BOOT_SERVICES_APPLICATION:
-            case EvConstants.EV_EFI_BOOT_SERVICES_DRIVER: // same as EV_EFI_BOOT_SERVICES_APP
-                try {
-                    sb.append(new EvEfiBootServicesApp(eventContent).toString());
-                } catch (UnsupportedEncodingException ueEx) {
-                    log.error(ueEx);
-                    sb.append(ueEx.toString());
-                }
-                break;
-            case EvConstants.EV_EFI_RUNTIME_SERVICES_DRIVER:
-                break;
-            case EvConstants.EV_EFI_GPT_EVENT:
-                try {
-                    sb.append(new EvEfiGptPartition(eventContent).toString());
-                } catch (UnsupportedEncodingException ueEx) {
-                    log.error(ueEx);
-                    sb.append(ueEx.toString());
-                }
-                break;
-            case EvConstants.EV_EFI_ACTION:
-            case EvConstants.EV_ACTION:
-                sb.append(new String(eventContent, StandardCharsets.UTF_8));
-                break;
-            case EvConstants.EV_EFI_PLATFORM_FIRMWARE_BLOB:
-                sb.append(new UefiFirmware(eventContent).toString());
-                break;
-            case EvConstants.EV_EFI_HANDOFF_TABLES:
-                sb.append(new EvEfiHandoffTable(eventContent).toString());
-                break;
-            case EvConstants.EV_EFI_HCRTM_EVENT:
-                break;
-            case EvConstants.EV_EFI_SPDM_FIRMWARE_BLOB:
-            case EvConstants.EV_EFI_SPDM_FIRMWARE_CONFIG:
-                sb.append(new EvEfiSpdmDeviceSecurityEvent(eventContent).toString());
-                break;
-            default:
-                sb.append("Unknown Event found\n");
-        }
-
-        return cleanTextContent(sb.toString());
-    }
-
-    /**
-     * Parses the event content and creates a human readable description of each event.
-     *
-     * @param eventData        the byte array holding the event data.
-     * @param content the byte array holding the event content.
-     * @param eventPosition  event position within the event log.
-     * @param hashName     name of the hash algorithm used by the event log
-     * @return String description of the event.
-     * @throws CertificateException     if the event contains an event that cannot be processed.
-     * @throws NoSuchAlgorithmException if an event contains an unsupported algorithm.
-     * @throws java.io.IOException      if the event cannot be parsed.
-     */
-    public String processEvent(final byte[] eventData, final byte[] content,
-                               final int eventPosition, final String hashName)
-           throws CertificateException, NoSuchAlgorithmException, IOException {
-        int eventID = (int) eventType;
-        this.eventNumber = eventPosition;
-        description += "Event# " + eventPosition + ": ";
-        description += "Index PCR[" + getPcrIndex() + "]\n";
-        description += "Event Type: 0x" + Long.toHexString(eventType) + " " + eventString(eventID);
-        description += "\n";
-        if (hashName.compareToIgnoreCase("TPM_ALG_SHA1") == 0) {   // Digest
-            description += "digest (SHA-1): " + Hex.encodeHexString(this.digest);
-        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA256") == 0) {   // Digest
-            description += "digest (SHA256): " + Hex.encodeHexString(this.digest);
-        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA384") == 0) {   // Digest
-            description += "digest (SHA384): " + Hex.encodeHexString(this.digest);
-        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA512") == 0) {   // Digest
-            description += "digest (SHA512): " + Hex.encodeHexString(this.digest);
-        } else {
-            description += "Unsupported Hash Algorithm encountered";
-        }
-        if (eventID != UefiConstants.SIZE_4) {
-            description += "\n";
-        }
-        // Calculate both the SHA1 and SHA256 on the event since this will equal the digest
-        // field of about half the log messages.
-        MessageDigest md1 = MessageDigest.getInstance("SHA-1");
-        md1.update(eventData);
-        eventDataSha1hash = md1.digest();
-        MessageDigest md2 = MessageDigest.getInstance("SHA-256");
-        md2.update(eventData);
-        eventDataSha256hash = md2.digest();
-
-        switch (eventID) {
-            case EvConstants.EV_PREBOOT_CERT:
-                description += " EV_PREBOOT_CERT" + "\n";
-                break;
-            case EvConstants.EV_POST_CODE:
-                EvPostCode postCode = new EvPostCode(content);
-                description += "Event Content:\n" + postCode.toString();
-                break;
-            case EvConstants.EV_UNUSED:
-                break;
-            case EvConstants.EV_NO_ACTION:
-                EvNoAction noAction = new EvNoAction(content);
-                description += "Event Content:\n" + noAction.toString();
-                if (noAction.isSpecIDEvent()) {
-                    specVersion = noAction.getSpecVersion();
-                    specErrataVersion = noAction.getSpecErrataVersion();
-                }
-                pciidsFileStatus = noAction.getPciidsFileStatus();
-                break;
-            case EvConstants.EV_SEPARATOR:
-                if (EvPostCode.isAscii(content)) {
-                    String separatorEventData = new String(content, StandardCharsets.UTF_8);
-                    if (!this.isBlank(content)) {
-                        description += "Separator event content = " + separatorEventData;
-                    }
-                }
-                break;
-            case EvConstants.EV_ACTION:
-                description += "Event Content:\n"
-                        + new String(content, StandardCharsets.UTF_8);
-                break;
-            case EvConstants.EV_EVENT_TAG:
-                EvEventTag eventTag = new EvEventTag(content);
-                description += eventTag.toString();
-                break;
-            case EvConstants.EV_S_CRTM_CONTENTS:
-                EvSCrtmContents sCrtmContents = new EvSCrtmContents(content);
-                description += "Event Content:\n   " + sCrtmContents.toString();
-                break;
-            case EvConstants.EV_S_CRTM_VERSION:
-                EvSCrtmVersion sCrtmVersion = new EvSCrtmVersion(content);
-                description += "Event Content:\n" + sCrtmVersion.toString();
-                break;
-            case EvConstants.EV_CPU_MICROCODE:
-                break;
-            case EvConstants.EV_PLATFORM_CONFIG_FLAGS:
-                break;
-            case EvConstants.EV_TABLE_OF_DEVICES:
-                break;
-            case EvConstants.EV_COMPACT_HASH:
-                EvCompactHash compactHash = new EvCompactHash(content);
-                description += "Event Content:\n" + compactHash.toString();
-                break;
-            case EvConstants.EV_IPL:
-                EvIPL ipl = new EvIPL(content);
-                description += "Event Content:\n" + ipl.toString();
-                break;
-            case EvConstants.EV_IPL_PARTITION_DATA:
-                break;
-            case EvConstants.EV_NONHOST_CODE:
-                break;
-            case EvConstants.EV_NONHOST_CONFIG:
-                break;
-            case EvConstants.EV_NONHOST_INFO:
-                break;
-            case EvConstants.EV_EV_OMIT_BOOT_DEVICES_EVENTS:
-                break;
-            case EvConstants.EV_EFI_EVENT_BASE:
-                break;
-            case EvConstants.EV_EFI_VARIABLE_DRIVER_CONFIG:
-            case EvConstants.EV_EFI_VARIABLE_BOOT:
-            case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
-            case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
-            case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
-                UefiVariable efiVar = new UefiVariable(content);
-                description += "Event Content:\n" + efiVar.toString();
-                vendorTableFileStatus = efiVar.getVendorTableFileStatus();
-                break;
-            case EvConstants.EV_EFI_BOOT_SERVICES_APPLICATION:
-            case EvConstants.EV_EFI_BOOT_SERVICES_DRIVER:
-                EvEfiBootServicesApp bootServices = new EvEfiBootServicesApp(content);
-                description += "Event Content:\n" + bootServices.toString();
-                break;
-            case EvConstants.EV_EFI_RUNTIME_SERVICES_DRIVER:
-                break;
-            case EvConstants.EV_EFI_GPT_EVENT:
-                description += "Event Content:\n" + new EvEfiGptPartition(content).toString();
-                break;
-            case EvConstants.EV_EFI_ACTION:
-                description += new String(content, StandardCharsets.UTF_8);
-                break;
-            case EvConstants.EV_EFI_PLATFORM_FIRMWARE_BLOB:
-                description += "Event Content:\n"
-                        + new UefiFirmware(content).toString();
-                break;
-            case EvConstants.EV_EFI_HANDOFF_TABLES:
-                EvEfiHandoffTable efiTable = new EvEfiHandoffTable(content);
-                description += "Event Content:\n" + efiTable.toString();
-                break;
-            case EvConstants.EV_EFI_HCRTM_EVENT:
-                break;
-            case EvConstants.EV_EFI_SPDM_FIRMWARE_BLOB:
-            case EvConstants.EV_EFI_SPDM_FIRMWARE_CONFIG:
-                EvEfiSpdmDeviceSecurityEvent efiSpdmDse = new EvEfiSpdmDeviceSecurityEvent(content);
-                description += "Event Content:\n" + efiSpdmDse.toString();
-                pciidsFileStatus = efiSpdmDse.getPciidsFileStatus();
-                break;
-            default:
-                description += " Unknown Event found" + "\n";
-        }
-        return description;
     }
 
     /**
@@ -629,6 +249,374 @@ public class TpmPcrEvent {
     }
 
     /**
+     * Sets the digest from a  TCG_PCR_EVENT digest field.
+     * This can be SHA1 for older event structures or any algorithm for newer structure.
+     *
+     * @param data   cryptographic hash
+     * @param length length of the cryptographic hash
+     */
+    protected void setEventDigest(final byte[] data, final int length) {
+        digest = new byte[length];
+        System.arraycopy(data, 0, digest, 0, length);
+    }
+
+    /**
+     * Retrieves the digest from a TCG Event.
+     * This can be SHA1 for older event structures or any algorithm for newer structure.
+     *
+     * @return the digest data for the event
+     */
+    public byte[] getEventDigest() {
+        byte[] digestCopy = new byte[digestLength];
+        System.arraycopy(digest, 0, digestCopy, 0, this.digestLength);
+        return digestCopy;
+    }
+
+    /**
+     * Returns a hex representation of the event digest.
+     *
+     * @return hex string
+     */
+    public String getEventDigestStr() {
+        return Hex.encodeHexString(this.digest);
+    }
+
+    /**
+     * Sets the event PCR index value from a TCG Event.
+     *
+     * @param eventIndex TCG Event PCR Index as defined in the PFP
+     */
+    protected void setPcrIndex(final byte[] eventIndex) {
+        pcrIndex = HexUtils.leReverseInt(eventIndex);
+    }
+
+    /**
+     * Sets the EventType.
+     *
+     * @param type byte array holding the PFP defined log event type
+     */
+    protected void setEventType(final byte[] type) {
+        eventType = new BigInteger(1, HexUtils.leReverseByte(type)).longValue();
+    }
+
+    /**
+     * Returns a formatted string of the type for the event.
+     *
+     * @return a string formatted to be human readable
+     */
+    public String getEventTypeStr() {
+        return String.format("0x%s %s", Long.toHexString(eventType), eventString((int) eventType));
+    }
+
+    /**
+     * Returns a formatted string of the type for the event minus the byte code.
+     *
+     * @return a string formatted to be human readable
+     */
+    public String getEventTypeString() {
+        return eventString((int) eventType);
+    }
+
+    /**
+     * Sets the event data after processing.
+     *
+     * @param eventData The PFP defined event content
+     */
+    protected void setEventData(final byte[] eventData) {
+        event = new byte[eventData.length];
+        System.arraycopy(eventData, 0, event, 0, eventData.length);
+    }
+
+    /**
+     * Gets the Event Data (no event content) for the event.
+     * event log format.
+     *
+     * @return byte array holding the event structure.
+     */
+    public byte[] getEvent() {
+        return Arrays.copyOf(event, event.length);
+    }
+
+    /**
+     * Gets the event Content Data (not the entire event structure).
+     *
+     * @return byte array holding the events content field
+     */
+    public byte[] getEventContent() {
+        return Arrays.copyOf(eventContent, eventContent.length);
+    }
+
+    /**
+     * Sets the event content after processing.
+     *
+     * @param eventData The PFP defined event content
+     */
+    protected void setEventContent(final byte[] eventData) {
+        eventContent = new byte[eventData.length];
+        //EvPostCode evPostCode = new EvPostCode(eventContent);
+        System.arraycopy(eventData, 0, eventContent, 0, eventData.length);
+    }
+
+    /**
+     * A getter that parses the content based on the type and returns the proper string
+     * value for the content.
+     *
+     * @return an appended string of human readable data
+     */
+    public String getEventContentStr() {
+        StringBuilder sb = new StringBuilder();
+
+        switch ((int) this.eventType) {
+            case EvConstants.EV_PREBOOT_CERT:
+                sb.append(" EV_PREBOOT_CERT");
+                break;
+            case EvConstants.EV_POST_CODE:
+                sb.append(new EvPostCode(eventContent));
+                break;
+            case EvConstants.EV_UNUSED, EvConstants.EV_IPL_PARTITION_DATA, EvConstants.EV_NONHOST_CODE,
+                 EvConstants.EV_NONHOST_CONFIG, EvConstants.EV_NONHOST_INFO,
+                 EvConstants.EV_EV_OMIT_BOOT_DEVICES_EVENTS, EvConstants.EV_EFI_EVENT_BASE,
+                 EvConstants.EV_EFI_RUNTIME_SERVICES_DRIVER, EvConstants.EV_CPU_MICROCODE,
+                 EvConstants.EV_PLATFORM_CONFIG_FLAGS, EvConstants.EV_TABLE_OF_DEVICES,
+                 EvConstants.EV_EFI_HCRTM_EVENT:
+                break;
+            case EvConstants.EV_NO_ACTION:
+                EvNoAction noAction = null;
+                try {
+                    noAction = new EvNoAction(eventContent);
+                    sb.append(noAction);
+                    if (noAction.isSpecIDEvent()) {
+                        specVersion = noAction.getSpecVersion();
+                        specErrataVersion = noAction.getSpecErrataVersion();
+                    }
+                } catch (UnsupportedEncodingException ueEx) {
+                    log.error(ueEx);
+                    sb.append(ueEx);
+                }
+                break;
+            case EvConstants.EV_SEPARATOR:
+                if (EvPostCode.isAscii(eventContent)
+                        && !this.isBlank(eventContent)) {
+                    sb.append(String.format("Separator event content = %s",
+                            new String(eventContent, StandardCharsets.UTF_8)));
+                }
+                break;
+            case EvConstants.EV_EVENT_TAG:
+                sb.append(new EvEventTag(eventContent));
+                break;
+            case EvConstants.EV_S_CRTM_CONTENTS:
+                sb.append(new EvSCrtmContents(eventContent));
+                break;
+            case EvConstants.EV_S_CRTM_VERSION:
+                try {
+                    sb.append(new EvSCrtmVersion(eventContent));
+                } catch (UnsupportedEncodingException ueEx) {
+                    log.error(ueEx);
+                    sb.append(ueEx);
+                }
+                break;
+            case EvConstants.EV_COMPACT_HASH:
+                try {
+                    sb.append(new EvCompactHash(eventContent));
+                } catch (UnsupportedEncodingException ueEx) {
+                    log.error(ueEx);
+                    sb.append(ueEx);
+                }
+                break;
+            case EvConstants.EV_IPL:
+                sb.append(new EvIPL(eventContent));
+                break;
+            case EvConstants.EV_EFI_VARIABLE_DRIVER_CONFIG:
+            case EvConstants.EV_EFI_VARIABLE_BOOT:
+            case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
+            case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
+            case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
+                try {
+                    sb.append(new UefiVariable(eventContent));
+                } catch (CertificateException | NoSuchAlgorithmException | IOException exception) {
+                    log.error(exception);
+                    sb.append(exception);
+                }
+                break;
+            case EvConstants.EV_EFI_BOOT_SERVICES_APPLICATION:
+            case EvConstants.EV_EFI_BOOT_SERVICES_DRIVER: // same as EV_EFI_BOOT_SERVICES_APP
+                try {
+                    sb.append(new EvEfiBootServicesApp(eventContent));
+                } catch (UnsupportedEncodingException ueEx) {
+                    log.error(ueEx);
+                    sb.append(ueEx);
+                }
+                break;
+            case EvConstants.EV_EFI_GPT_EVENT:
+                try {
+                    sb.append(new EvEfiGptPartition(eventContent));
+                } catch (UnsupportedEncodingException ueEx) {
+                    log.error(ueEx);
+                    sb.append(ueEx);
+                }
+                break;
+            case EvConstants.EV_EFI_ACTION:
+            case EvConstants.EV_ACTION:
+                sb.append(new String(eventContent, StandardCharsets.UTF_8));
+                break;
+            case EvConstants.EV_EFI_PLATFORM_FIRMWARE_BLOB:
+                sb.append(new UefiFirmware(eventContent));
+                break;
+            case EvConstants.EV_EFI_HANDOFF_TABLES:
+                sb.append(new EvEfiHandoffTable(eventContent));
+                break;
+            case EvConstants.EV_EFI_SPDM_FIRMWARE_BLOB:
+            case EvConstants.EV_EFI_SPDM_FIRMWARE_CONFIG:
+                sb.append(new EvEfiSpdmDeviceSecurityEvent(eventContent));
+                break;
+            default:
+                sb.append("Unknown Event found\n");
+        }
+
+        return cleanTextContent(sb.toString());
+    }
+
+    /**
+     * Parses the event content and creates a human readable description of each event.
+     *
+     * @param eventData     the byte array holding the event data.
+     * @param content       the byte array holding the event content.
+     * @param eventPosition event position within the event log.
+     * @param hashName      name of the hash algorithm used by the event log
+     * @return String description of the event.
+     * @throws CertificateException     if the event contains an event that cannot be processed.
+     * @throws NoSuchAlgorithmException if an event contains an unsupported algorithm.
+     * @throws java.io.IOException      if the event cannot be parsed.
+     */
+    public String processEvent(final byte[] eventData, final byte[] content,
+                               final int eventPosition, final String hashName)
+            throws CertificateException, NoSuchAlgorithmException, IOException {
+        int eventID = (int) eventType;
+        this.eventNumber = eventPosition;
+        description += "Event# " + eventPosition + ": ";
+        description += "Index PCR[" + getPcrIndex() + "]\n";
+        description += "Event Type: 0x" + Long.toHexString(eventType) + " " + eventString(eventID);
+        description += "\n";
+        if (hashName.compareToIgnoreCase("TPM_ALG_SHA1") == 0) {   // Digest
+            description += "digest (SHA-1): " + Hex.encodeHexString(this.digest);
+        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA256") == 0) {   // Digest
+            description += "digest (SHA256): " + Hex.encodeHexString(this.digest);
+        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA384") == 0) {   // Digest
+            description += "digest (SHA384): " + Hex.encodeHexString(this.digest);
+        } else if (hashName.compareToIgnoreCase("TPM_ALG_SHA512") == 0) {   // Digest
+            description += "digest (SHA512): " + Hex.encodeHexString(this.digest);
+        } else {
+            description += "Unsupported Hash Algorithm encountered";
+        }
+        if (eventID != UefiConstants.SIZE_4) {
+            description += "\n";
+        }
+        // Calculate both the SHA1 and SHA256 on the event since this will equal the digest
+        // field of about half the log messages.
+        MessageDigest md1 = MessageDigest.getInstance("SHA-1");
+        md1.update(eventData);
+        eventDataSha1hash = md1.digest();
+        MessageDigest md2 = MessageDigest.getInstance("SHA-256");
+        md2.update(eventData);
+        eventDataSha256hash = md2.digest();
+
+        switch (eventID) {
+            case EvConstants.EV_PREBOOT_CERT:
+                description += " EV_PREBOOT_CERT" + "\n";
+                break;
+            case EvConstants.EV_POST_CODE:
+                EvPostCode postCode = new EvPostCode(content);
+                description += "Event Content:\n" + postCode;
+                break;
+            case EvConstants.EV_UNUSED, EvConstants.EV_EFI_RUNTIME_SERVICES_DRIVER,
+                 EvConstants.EV_EFI_HCRTM_EVENT, EvConstants.EV_EFI_EVENT_BASE,
+                 EvConstants.EV_EV_OMIT_BOOT_DEVICES_EVENTS, EvConstants.EV_NONHOST_INFO,
+                 EvConstants.EV_NONHOST_CONFIG, EvConstants.EV_NONHOST_CODE,
+                 EvConstants.EV_IPL_PARTITION_DATA, EvConstants.EV_PLATFORM_CONFIG_FLAGS,
+                 EvConstants.EV_CPU_MICROCODE, EvConstants.EV_TABLE_OF_DEVICES:
+                break;
+            case EvConstants.EV_NO_ACTION:
+                EvNoAction noAction = new EvNoAction(content);
+                description += "Event Content:\n" + noAction;
+                if (noAction.isSpecIDEvent()) {
+                    specVersion = noAction.getSpecVersion();
+                    specErrataVersion = noAction.getSpecErrataVersion();
+                }
+                pciidsFileStatus = noAction.getPciidsFileStatus();
+                break;
+            case EvConstants.EV_SEPARATOR:
+                if (EvPostCode.isAscii(content)) {
+                    String separatorEventData = new String(content, StandardCharsets.UTF_8);
+                    if (!this.isBlank(content)) {
+                        description += "Separator event content = " + separatorEventData;
+                    }
+                }
+                break;
+            case EvConstants.EV_ACTION:
+                description += "Event Content:\n"
+                        + new String(content, StandardCharsets.UTF_8);
+                break;
+            case EvConstants.EV_EVENT_TAG:
+                EvEventTag eventTag = new EvEventTag(content);
+                description += eventTag.toString();
+                break;
+            case EvConstants.EV_S_CRTM_CONTENTS:
+                EvSCrtmContents sCrtmContents = new EvSCrtmContents(content);
+                description += "Event Content:\n   " + sCrtmContents;
+                break;
+            case EvConstants.EV_S_CRTM_VERSION:
+                EvSCrtmVersion sCrtmVersion = new EvSCrtmVersion(content);
+                description += "Event Content:\n" + sCrtmVersion;
+                break;
+            case EvConstants.EV_COMPACT_HASH:
+                EvCompactHash compactHash = new EvCompactHash(content);
+                description += "Event Content:\n" + compactHash;
+                break;
+            case EvConstants.EV_IPL:
+                EvIPL ipl = new EvIPL(content);
+                description += "Event Content:\n" + ipl;
+                break;
+            case EvConstants.EV_EFI_VARIABLE_DRIVER_CONFIG:
+            case EvConstants.EV_EFI_VARIABLE_BOOT:
+            case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
+            case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
+            case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
+                UefiVariable efiVar = new UefiVariable(content);
+                description += "Event Content:\n" + efiVar;
+                vendorTableFileStatus = efiVar.getVendorTableFileStatus();
+                break;
+            case EvConstants.EV_EFI_BOOT_SERVICES_APPLICATION:
+            case EvConstants.EV_EFI_BOOT_SERVICES_DRIVER:
+                EvEfiBootServicesApp bootServices = new EvEfiBootServicesApp(content);
+                description += "Event Content:\n" + bootServices;
+                break;
+            case EvConstants.EV_EFI_GPT_EVENT:
+                description += "Event Content:\n" + new EvEfiGptPartition(content);
+                break;
+            case EvConstants.EV_EFI_ACTION:
+                description += new String(content, StandardCharsets.UTF_8);
+                break;
+            case EvConstants.EV_EFI_PLATFORM_FIRMWARE_BLOB:
+                description += "Event Content:\n"
+                        + new UefiFirmware(content);
+                break;
+            case EvConstants.EV_EFI_HANDOFF_TABLES:
+                EvEfiHandoffTable efiTable = new EvEfiHandoffTable(content);
+                description += "Event Content:\n" + efiTable;
+                break;
+            case EvConstants.EV_EFI_SPDM_FIRMWARE_BLOB:
+            case EvConstants.EV_EFI_SPDM_FIRMWARE_CONFIG:
+                EvEfiSpdmDeviceSecurityEvent efiSpdmDse = new EvEfiSpdmDeviceSecurityEvent(content);
+                description += "Event Content:\n" + efiSpdmDse;
+                pciidsFileStatus = efiSpdmDse.getPciidsFileStatus();
+                break;
+            default:
+                description += " Unknown Event found" + "\n";
+        }
+        return description;
+    }
+
+    /**
      * Human readable output of a check of input against the current event hash.
      *
      * @return human readable string.
@@ -656,6 +644,7 @@ public class TpmPcrEvent {
 
     /**
      * This method takes in an event and compares the hashes to verify that they match.
+     *
      * @param tpmPcrEvent an event to match.
      * @return true if the event # matches and the hash is correct.
      */
@@ -720,11 +709,12 @@ public class TpmPcrEvent {
             sb.append("Event content (Hex) (" + evContent.length + " bytes): "
                     + Hex.encodeHexString(evContent));
         }
-        return sb.toString() + "\n";
+        return sb + "\n";
     }
 
     /**
      * Remove bad visual value text.
+     *
      * @param text content to operate over.
      * @return cleared string
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
@@ -33,8 +33,8 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
      *
      * @param is          ByteArrayInputStream holding the TCG Log event.
      * @param eventNumber event position within the event log.
-     * @throws java.io.IOException              if an error occurs in parsing the event.
-     * @throws java.security.NoSuchAlgorithmException if an undefined algorithm is encountered.
+     * @throws java.io.IOException                     if an error occurs in parsing the event.
+     * @throws java.security.NoSuchAlgorithmException  if an undefined algorithm is encountered.
      * @throws java.security.cert.CertificateException If a certificate within an event can't be processed.
      */
     public TpmPcrEvent1(final ByteArrayInputStream is, final int eventNumber)

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
@@ -61,15 +61,15 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
     /**
      * list of digests.
      */
-    private ArrayList<TcgTpmtHa> hashList = new ArrayList<>();
+    private final ArrayList<TcgTpmtHa> hashList = new ArrayList<>();
 
     /**
      * Constructor.
      *
      * @param is          ByteArrayInputStream holding the TCG Log event
      * @param eventNumber event position within the event log.
-     * @throws java.io.IOException              if an error occurs in parsing the event
-     * @throws java.security.NoSuchAlgorithmException if an undefined algorithm is encountered.
+     * @throws java.io.IOException                     if an error occurs in parsing the event
+     * @throws java.security.NoSuchAlgorithmException  if an undefined algorithm is encountered.
      * @throws java.security.cert.CertificateException If a certificate within an event can't be processed.
      */
     public TpmPcrEvent2(final ByteArrayInputStream is, final int eventNumber)

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEvent.java
@@ -17,7 +17,7 @@ import lombok.Setter;
  * .   which implies the data is a DEVICE_SECURITY_EVENT_DATA or ..DATA2, respectively.
  * Field 2:
  * .   The Version field also indicates whether the Device Security Event is ..DATA or ..DATA2.
- *
+ * <p>
  * DEVICE SECURITY EVENT structures defined by PFP v1.06 Rev 52:
  * <p>
  * typedef struct tdDEVICE_SECURITY_EVENT_DATA {
@@ -39,18 +39,17 @@ import lombok.Setter;
  * }
  * <p>
  */
+@Getter
 public abstract class DeviceSecurityEvent {
 
     /**
      * DeviceSecurityEventDataContext Object.
      */
-    @Getter
     private DeviceSecurityEventDataPciContext dsedPciContext = null;
 
     /**
      * Device type.
      */
-    @Getter
     @Setter
     private int deviceType = -1;
 
@@ -58,7 +57,6 @@ public abstract class DeviceSecurityEvent {
      * Human-readable description of the data within the
      * DEVICE_SECURITY_EVENT_DATA_DEVICE_CONTEXT. DEVICE can be either PCI or USB.
      */
-    @Getter
     private String deviceContextInfo = "";
 
     /**
@@ -70,12 +68,10 @@ public abstract class DeviceSecurityEvent {
      * Status will only change IF this is an event that uses this file,
      * and if that event causes a different status.
      */
-    @Getter
     private String pciidsFileStatus = UefiConstants.FILESTATUS_FROM_FILESYSTEM;
 
     /**
      * DeviceSecurityEventData Default Constructor.
-     *
      */
     public DeviceSecurityEvent() {
 
@@ -85,7 +81,6 @@ public abstract class DeviceSecurityEvent {
      * Parse the Device Context structure, can be PCI or USB based on device type field.
      *
      * @param dsedDeviceContextBytes byte array holding the DeviceSecurityEventData.
-     *
      */
     public void instantiateDeviceContext(final byte[] dsedDeviceContextBytes) {
 

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataDeviceContext.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataDeviceContext.java
@@ -15,18 +15,8 @@ import lombok.Getter;
  * } DEVICE_SECURITY_EVENT_DATA_DEVICE_CONTEXT;
  * <p>
  */
+@Getter
 public abstract class DeviceSecurityEventDataDeviceContext {
-
-    /**
-     * PCI Version.
-     */
-    @Getter
-    private int version = 0;
-    /**
-     * PCI Length.
-     */
-    @Getter
-    private int length = 0;
 
     /**
      * Device Security Event Data Device Type = no device type.
@@ -40,6 +30,14 @@ public abstract class DeviceSecurityEventDataDeviceContext {
      * Device Security Event Data Device Type = DEVICE_TYPE_USB.
      */
     public static final int DEVICE_TYPE_USB = 2;
+    /**
+     * PCI Version.
+     */
+    private int version = 0;
+    /**
+     * PCI Length.
+     */
+    private int length = 0;
 
     /**
      * DeviceSecurityEventDataDeviceContext Constructor.

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataSubHeader.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/DeviceSecurityEventDataSubHeader.java
@@ -24,7 +24,6 @@ public abstract class DeviceSecurityEventDataSubHeader {
 
     /**
      * DeviceSecurityEventDataSubHeader Default Constructor.
-     *
      */
     public DeviceSecurityEventDataSubHeader() {
     }
@@ -37,13 +36,10 @@ public abstract class DeviceSecurityEventDataSubHeader {
      * @return name of the device type
      */
     public static String subheaderTypeToString(final int subheaderTypeInt) {
-        switch (subheaderTypeInt) {
-            case SUBHEADERTYPE_MEAS_BLOCK:
-                return "SPDM Measurement Block";
-            case SUBHEADERTYPE_CERT_CHAIN:
-                return "SPDM Cert Chain";
-            default:
-                return "Unknown or invalid Subheader Type of value " + subheaderTypeInt;
-        }
+        return switch (subheaderTypeInt) {
+            case SUBHEADERTYPE_MEAS_BLOCK -> "SPDM Measurement Block";
+            case SUBHEADERTYPE_CERT_CHAIN -> "SPDM Cert Chain";
+            default -> "Unknown or invalid Subheader Type of value " + subheaderTypeInt;
+        };
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvConstants.java
@@ -175,6 +175,7 @@ public final class EvConstants {
      * EFI SPDM Device Authority Event ID.
      */
     public static final int EV_EFI_SPDM_DEVICE_AUTHORITY = 0x800000E4;
+
     /**
      * Default private constructor so checkstyles doesn't complain.
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvEfiGptPartition.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvEfiGptPartition.java
@@ -50,25 +50,25 @@ import java.util.List;
  */
 public class EvEfiGptPartition {
     /**
-     * Header Size.
+     * Partition Length.
      */
-    private int headerSize = 0;
+    private static final int PARTITION_ENTRY_LENGTH = UefiConstants.SIZE_128;
     /**
      * Header bytes.
      */
-    private byte[] header = new byte[UefiConstants.SIZE_8];
+    private final byte[] header = new byte[UefiConstants.SIZE_8];
     /**
      * Number of partitions in this event.
      */
-    private int numberOfPartitions;
-    /**
-     * Partition Length.
-     */
-    private int partitonEntryLength = UefiConstants.SIZE_128;
+    private final int numberOfPartitions;
     /**
      * List of Partitions.
      */
-    private List<UefiPartition> partitionList;
+    private final List<UefiPartition> partitionList;
+    /**
+     * Header Size.
+     */
+    private int headerSize = 0;
 
     /**
      * GPT Partition Event Type constructor.
@@ -89,7 +89,7 @@ public class EvEfiGptPartition {
         byte[] partitions = new byte[UefiConstants.SIZE_8];
         System.arraycopy(eventDataBytes, headerSize, partitions, 0, UefiConstants.SIZE_8);
         numberOfPartitions = getIntFromBytes(partitions);
-        int partitionLength = numberOfPartitions * partitonEntryLength;
+        int partitionLength = numberOfPartitions * PARTITION_ENTRY_LENGTH;
         byte[] partitionEntries = new byte[partitionLength];
         System.arraycopy(eventDataBytes, headerSize + UefiConstants.SIZE_8, partitionEntries,
                 0, partitionLength);
@@ -100,7 +100,7 @@ public class EvEfiGptPartition {
     /**
      * Processes an individual GPT partition entry.
      *
-     * @param partitions           byte array holding partition data.
+     * @param partitions      byte array holding partition data.
      * @param numOfPartitions number of partitions included in the data.
      * @throws java.io.UnsupportedEncodingException if partition data fails to parse.
      */
@@ -108,16 +108,16 @@ public class EvEfiGptPartition {
             throws UnsupportedEncodingException {
         byte[] partitionData = new byte[UefiConstants.SIZE_128];
         for (int i = 0; i < numOfPartitions; i++) {
-            System.arraycopy(partitions, i * partitonEntryLength, partitionData, 0,
-                    partitonEntryLength);
+            System.arraycopy(partitions, i * PARTITION_ENTRY_LENGTH, partitionData, 0,
+                    PARTITION_ENTRY_LENGTH);
             partitionList.add(new UefiPartition(partitionData));
         }
     }
 
     /**
-     * Provides a human readable string describing the GPT Partition information.
+     * Provides a human-readable string describing the GPT Partition information.
      *
-     * @return a human readable string holding the partition information.
+     * @return a human-readable string holding the partition information.
      */
     public String toString() {
         String headerStr = HexUtils.byteArrayToHexString(header);

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvEfiHandoffTable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvEfiHandoffTable.java
@@ -32,19 +32,18 @@ import java.util.ArrayList;
  */
 public class EvEfiHandoffTable {
     /**
+     * List of Vendor GUIDs.
+     */
+    private final ArrayList<UefiGuid> vendorGuids = new ArrayList<>();
+    /**
+     * List of Vendors.
+     */
+    private final ArrayList<byte[]> vendorTables = new ArrayList<>();
+    /**
      * Number of Tables.
      */
     @Getter
     private int numberOfTables = 0;
-    /**
-     * List of Vendor GUIDs.
-     */
-    private ArrayList<UefiGuid> vendorGuids = new ArrayList<>();
-    /**
-     * List of Vendors.
-     */
-    private ArrayList<byte[]> vendorTables = new ArrayList<>();
-
     private Path vendorPathString;
 
     /**
@@ -71,7 +70,7 @@ public class EvEfiHandoffTable {
     /**
      * EvEFIHandoffTable constructor.
      *
-     * @param tpmEventData byte array holding the Handoff table data.
+     * @param tpmEventData     byte array holding the Handoff table data.
      * @param vendorPathString the string for the vendor file
      */
     public EvEfiHandoffTable(final byte[] tpmEventData, final Path vendorPathString) {
@@ -122,7 +121,7 @@ public class EvEfiHandoffTable {
     }
 
     /**
-     * Returns a human readable description of the hand off tables.
+     * Returns a human-readable description of the hand off tables.
      *
      * @return a human readable description.
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvIPL.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvIPL.java
@@ -4,7 +4,7 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * Processes event type EV_IPL which is deprecated in the current spec,
- *  but defined in older version of the specification(1.0.0) as contain
+ * but defined in older version of the specification(1.0.0) as contain
  * "informative information about the IPL code" (ascii strings).
  */
 public class EvIPL {
@@ -12,32 +12,35 @@ public class EvIPL {
     private String description = "";
 
     /**
-     *IPL Event Constructor.
+     * IPL Event Constructor.
+     *
      * @param event byte array holding the IPL Event data.
      */
     public EvIPL(final byte[] event) {
         event(event);
     }
 
-   /**
-    * Processes IPL event.
-    * @param event byte array holding the IPL Event data.
-    * @return a description of the IPl event.
-    */
+    /**
+     * Processes IPL event.
+     *
+     * @param event byte array holding the IPL Event data.
+     * @return a description of the IPl event.
+     */
     public String event(final byte[] event) {
         if (event == null) {
             description = "Invalid IPL event data";
-            } else {
-                description = "  \"" + new String(event, StandardCharsets.UTF_8) + "\"";
+        } else {
+            description = "  \"" + new String(event, StandardCharsets.UTF_8) + "\"";
         }
         return description;
-        }
+    }
 
     /**
-     * Returns a human readable description of the IPL Event.
+     * Returns a human-readable description of the IPL Event.
+     *
      * @return human readable description.
      */
     public String toString() {
-      return description;
+        return description;
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvPostCode.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvPostCode.java
@@ -7,30 +7,37 @@ import java.nio.charset.StandardCharsets;
 
 /**
  * Class for processing EV_POST_CODE event types
- *
+ * <p>
  * typedef struct tdUEFI_PLATFORM_FIRMWARE_BLOB {
- *         UEFI_PHYSICAL_ADDRESS   BlobBase;    // Same as UINT64 for most systems
- *         UINT64                  BlobLength;
- *        } UEFI_PLATFORM_FIRMWARE_BLOB;
- *
+ * UEFI_PHYSICAL_ADDRESS   BlobBase;    // Same as UINT64 for most systems
+ * UINT64                  BlobLength;
+ * } UEFI_PLATFORM_FIRMWARE_BLOB;
+ * <p>
  * However Table 9 of the PC Client Platform firmware profile states that even content is a string
- *   For POST code, the event data SHOULD be POST CODE.
- *   For embedded SMM code, the event data SHOULD be SMM CODE.
- *   For ACPI flash data, the event data SHOULD be ACPI DATA.
- *   For BIS code, the event data SHOULD be BIS CODE.
- *   For embedded option ROMs, the event data SHOULD be Embedded UEFI Driver.
+ * For POST code, the event data SHOULD be POST CODE.
+ * For embedded SMM code, the event data SHOULD be SMM CODE.
+ * For ACPI flash data, the event data SHOULD be ACPI DATA.
+ * For BIS code, the event data SHOULD be BIS CODE.
+ * For embedded option ROMs, the event data SHOULD be Embedded UEFI Driver.
  */
 public class EvPostCode {
-    /** Event Description. */
+    /**
+     * Event Description.
+     */
     private String codeInfo = "";
-    /** String type flag. */
+    /**
+     * String type flag.
+     */
     private boolean bisString = false;
-    /** Firmware object. */
+    /**
+     * Firmware object.
+     */
     @Getter
     private UefiFirmware firmwareBlob = null;
 
     /**
      * EcPostCode constructor.
+     *
      * @param postCode byte array holding the post code content.
      */
     public EvPostCode(final byte[] postCode) {
@@ -44,26 +51,8 @@ public class EvPostCode {
     }
 
     /**
-     * Flag set to true if Post Code is a string.
-     * @return true if Post Code is a string.
-     */
-    public boolean isString() {
-        return bisString;
-    }
-
-    /**
-     * Returns a human readable string of the Post Code information.
-     * @return  human readable string.
-     */
-    public String toString() {
-        if (bisString) {
-            return codeInfo;
-        }
-       return firmwareBlob.toString();
-     }
-
-    /**
      * Determines if the byte array is a string.
+     *
      * @param postCode byte array input.
      * @return true if byte array is a string.
      */
@@ -73,6 +62,27 @@ public class EvPostCode {
                 return false;
             }
         }
-       return true;
+        return true;
+    }
+
+    /**
+     * Flag set to true if Post Code is a string.
+     *
+     * @return true if Post Code is a string.
+     */
+    public boolean isString() {
+        return bisString;
+    }
+
+    /**
+     * Returns a human-readable string of the Post Code information.
+     *
+     * @return human readable string.
+     */
+    public String toString() {
+        if (bisString) {
+            return codeInfo;
+        }
+        return firmwareBlob.toString();
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvPostCode.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvPostCode.java
@@ -25,10 +25,12 @@ public class EvPostCode {
      * Event Description.
      */
     private String codeInfo = "";
+
     /**
      * String type flag.
      */
     private boolean bisString = false;
+
     /**
      * Firmware object.
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvSCrtmContents.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/EvSCrtmContents.java
@@ -9,32 +9,33 @@ public class EvSCrtmContents {
 
     private String description = "";
 
-   /**
+    /**
      * Constructor that takes in the event data and waits to be called.
+     *
      * @param event byte array holding the event content data.
      */
     public EvSCrtmContents(final byte[] event) {
         scrtmContents(event);
     }
 
-   /**
-    * Checks if event data is null and if not it converts to a String.
-    * @param event byte array holding the event data.
-    * @return String contents contained within the event.
-    */
-    public String scrtmContents(final byte[] event) {
+    /**
+     * Checks if event data is null and if not it converts to a String.
+     *
+     * @param event byte array holding the event data.
+     */
+    public void scrtmContents(final byte[] event) {
         if (event == null) {
-            description = "invalid content event data";
-            } else {
-                description = new String(event, StandardCharsets.UTF_8);
-            }
-        return description;
-     }
+            this.description = "invalid content event data";
+        } else {
+            this.description = new String(event, StandardCharsets.UTF_8);
+        }
+    }
 
-   /**
-    * Human readable string contained within the CRTM Contents event.
-    * @return Human readable string.
-    */
+    /**
+     * Human-readable string contained within the CRTM Contents event.
+     *
+     * @return Human readable string.
+     */
     public String toString() {
         return description;
     }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/NvIndexDynamicEventLogData.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/events/NvIndexDynamicEventLogData.java
@@ -8,7 +8,7 @@ import java.nio.charset.StandardCharsets;
  * Class to process the NV_INDEX_DYNAMIC_EVENT_LOG_DATA per PFP.
  * Per PFP, the first 16 bytes of the structure are a String based identifier (Signature),
  * which are a NULL-terminated ASCII string "NvIndexDynamic".
- *
+ * <p>
  * HEADERS defined by PFP v1.06 Rev 52.
  * Certain fields are common to both ..HEADER and ..HEADER2, and are noted below the structures.
  * <p>

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/spdm/SpdmMeasurementBlock.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/spdm/SpdmMeasurementBlock.java
@@ -11,17 +11,17 @@ import java.io.IOException;
  * <p>
  * Measurement block format, defined by SPDM v1.03, Sect 10.11.1, Table 53:
  * Measurement block format {
- *      Index                           1 byte;
- *      MeasurementSpec                 1 byte;
- *      MeasurementSize                 2 bytes;
- *      Measurement                     <MeasurementSize> bytes;
+ * Index                           1 byte;
+ * MeasurementSpec                 1 byte;
+ * MeasurementSize                 2 bytes;
+ * Measurement                     <MeasurementSize> bytes;
  * }
  * <p>
  * Index: index of the measurement block, as there can be more than one
  * MeasurementSpec: bit mask; the measurement specification that the requested Measurement follows
- *     See "MeasurementSpecificationSel" in Table 21. See Tables 29, 53, 54
- *     Bit 0: DMTFmeasSpec, per Table 54
- *     Bit 1-7: Reserved
+ * See "MeasurementSpecificationSel" in Table 21. See Tables 29, 53, 54
+ * Bit 0: DMTFmeasSpec, per Table 54
+ * Bit 1-7: Reserved
  * Measurement: the digest
  */
 public class SpdmMeasurementBlock {
@@ -39,7 +39,7 @@ public class SpdmMeasurementBlock {
     /**
      * SPDM Measurement.
      */
-    private SpdmMeasurement spdmMeasurement;
+    private final SpdmMeasurement spdmMeasurement;
 
     /**
      * SpdmMeasurementBlock Constructor.
@@ -76,7 +76,7 @@ public class SpdmMeasurementBlock {
         String spdmMeasBlockInfo = "";
 
         spdmMeasBlockInfo += "      Index = " + index + "\n";
-        spdmMeasBlockInfo += "      MeasurementSpec = " +  measurementSpec  + "\n";
+        spdmMeasBlockInfo += "      MeasurementSpec = " + measurementSpec + "\n";
         spdmMeasBlockInfo += spdmMeasurement.toString();
 
         return spdmMeasBlockInfo;

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiConstants.java
@@ -282,6 +282,7 @@ public final class UefiConstants {
      * file status, where file is not accessible (either not found, or no access permission).
      */
     public static final String FILESTATUS_NOT_ACCESSIBLE = "fileNotAccessible";
+
     /**
      * Default private constructor so checkstyles doesn't complain.
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiDevicePath.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiDevicePath.java
@@ -73,6 +73,22 @@ public class UefiDevicePath {
     }
 
     /**
+     * Converts from a char array to byte array.
+     * Removes the upper byte (typically set to 0) of each char.
+     *
+     * @param data Character array.
+     * @return byte array.
+     */
+    public static byte[] convertChar16tobyteArray(final byte[] data) {
+        byte[] hexdata = new byte[data.length];
+        int j = 0;
+        for (int i = 0; i < data.length; i = i + UefiConstants.SIZE_2) {
+            hexdata[j++] = data[i];
+        }
+        return hexdata;
+    }
+
+    /**
      * Returns the UEFI device subtype.
      *
      * @return uefi subtype
@@ -118,8 +134,8 @@ public class UefiDevicePath {
      * Current types processed include Hardware Device Path, ACPI Device Path,
      * Messaging Device Path, and Media Device Path.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return human-readable string representing the UEFI device path
      * @throws java.io.UnsupportedEncodingException
      */
@@ -127,7 +143,7 @@ public class UefiDevicePath {
         String devInfo = "      ";
         int devPath = path[offset];
         byte unknownSubType = path[offset + UefiConstants.OFFSET_1];
-        switch (path[0 + offset]) {
+        switch (path[offset]) {
             case UefiConstants.DEV_HW:
                 type = "Hardware Device Path";
                 if (devPath == UefiConstants.DEVPATH_HARWARE) {
@@ -182,8 +198,8 @@ public class UefiDevicePath {
     /**
      * processes the ACPI UEFI device subtype.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return acpi device info
      */
     private String acpiSubType(final byte[] path, final int offset) {
@@ -205,8 +221,8 @@ public class UefiDevicePath {
     /**
      * Processes the ACPI short subtype.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return short acpi info.
      */
     private String acpiShortSubType(final byte[] path, final int offset) {
@@ -226,8 +242,8 @@ public class UefiDevicePath {
     /**
      * Processes the PCI subType.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return pci device info.
      */
     private String pciSubType(final byte[] path, final int offset) {
@@ -243,8 +259,8 @@ public class UefiDevicePath {
     /**
      * processes the SATA subtype.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return SATA drive info.
      */
     private String sataSubType(final byte[] path, final int offset) {
@@ -264,8 +280,8 @@ public class UefiDevicePath {
     /**
      * Processes the hard drive subtype.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return hard drive info.
      */
     private String hardDriveSubType(final byte[] path, final int offset) {
@@ -311,8 +327,8 @@ public class UefiDevicePath {
     /**
      * Process the File path subtype.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return file path info.
      */
     private String filePathSubType(final byte[] path, final int offset) {
@@ -336,8 +352,8 @@ public class UefiDevicePath {
      * Vendor-assigned GUID that defines the data that follows.
      * Vendor-defined variable size data.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return vendor device info.
      */
     private String vendorSubType(final byte[] path, final int offset) {
@@ -351,7 +367,7 @@ public class UefiDevicePath {
         System.arraycopy(path, UefiConstants.OFFSET_4 + offset, guidData,
                 0, UefiConstants.SIZE_16);
         UefiGuid guid = new UefiGuid(guidData);
-        subType += guid.toString() + " ";
+        subType += guid + " ";
         if (subTypeLength - UefiConstants.SIZE_16 > 0) {
             byte[] vendorData = new byte[subTypeLength - UefiConstants.SIZE_16];
             System.arraycopy(path, UefiConstants.OFFSET_20
@@ -368,8 +384,8 @@ public class UefiDevicePath {
      * Returns USB device info.
      * UEFI Specification, Version 2.8.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return USB device info.
      */
     private String usbSubType(final byte[] path, final int offset) {
@@ -395,8 +411,8 @@ public class UefiDevicePath {
      * See Links to UEFI Related Documents
      * (http://uefi.org/uefi under the headings NVM Express Specification.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return NVM device info.
      */
     private String nvmSubType(final byte[] path, final int offset) {
@@ -420,8 +436,8 @@ public class UefiDevicePath {
      * Only processes the Device type.
      * Status bootHandler pointer, and description String pointer are ignored.
      *
-     * @param path byte array holding the device path.
-     * @param offset
+     * @param path   byte array holding the device path.
+     * @param offset offset
      * @return String that represents the UEFI defined BIOS Device Type.
      */
     private String biosDevicePath(final byte[] path, final int offset) {
@@ -468,8 +484,8 @@ public class UefiDevicePath {
      * PIWG Firmware File Section 10.3.5.6:
      * Contents are defined in the UEFI PI Specification.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return String that represents the PIWG Firmware Volume Path
      */
     private String piwgFirmVolFile(final byte[] path, final int offset) {
@@ -489,8 +505,8 @@ public class UefiDevicePath {
      * PIWG Firmware Volume Section 10.3.5.7:
      * Contents are defined in the UEFI PI Specification.
      *
-     * @param path
-     * @param offset
+     * @param path   path
+     * @param offset offset
      * @return String that represents the PIWG Firmware Volume Path
      */
     private String piwgFirmVolPath(final byte[] path, final int offset) {
@@ -511,21 +527,5 @@ public class UefiDevicePath {
      */
     public String toString() {
         return devPathInfo;
-    }
-
-    /**
-     * Converts from a char array to byte array.
-     * Removes the upper byte (typically set to 0) of each char.
-     *
-     * @param data Character array.
-     * @return byte array.
-     */
-    public static byte[] convertChar16tobyteArray(final byte[] data) {
-        byte[] hexdata = new byte[data.length];
-        int j = 0;
-        for (int i = 0; i < data.length; i = i + UefiConstants.SIZE_2) {
-            hexdata[j++] = data[i];
-        }
-        return hexdata;
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiGuid.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiGuid.java
@@ -45,11 +45,11 @@ public class UefiGuid {
     /**
      * guid byte array.
      */
-    private byte[] guid;
+    private final byte[] guid;
     /**
      * UUID object.
      */
-    private UUID uuid;
+    private final UUID uuid;
 
     /**
      * UefiGUID constructor.
@@ -63,7 +63,7 @@ public class UefiGuid {
     /**
      * UefiGUID constructor.
      *
-     * @param guidBytes byte array holding a valid guid.
+     * @param guidBytes        byte array holding a valid guid.
      * @param vendorPathString string path for vendor
      */
     public UefiGuid(final byte[] guidBytes, final Path vendorPathString) {
@@ -88,6 +88,7 @@ public class UefiGuid {
      * Converts a GUID with a byte array to a RFC-1422 UUID object.
      * Assumes a MS format and converts to Big Endian format used by most others , including Linux
      * Matched uuids found in /sys/firmware/efi/efivars on Centos 7.
+     *
      * @param guid byte array holding the guid data.
      * @return UUID processed from the passed in guid
      */
@@ -118,6 +119,22 @@ public class UefiGuid {
      */
     public static int getGuidLength() {
         return UefiConstants.SIZE_16;
+    }
+
+    /**
+     * Returns a string of the entity that the UUID represents.
+     * Does not contain a vendor lookup on the UUID.
+     *
+     * @param guid byte array holding the guid data.
+     * @return true if the UUID has a valid structure.
+     */
+    public static boolean isValidUUID(final byte[] guid) {
+        boolean valid = false;
+        UUID tmpUuid = processGuid(guid);
+        if (tmpUuid.toString().length() != 0) {
+            valid = true;
+        }
+        return valid;
     }
 
     /**
@@ -177,22 +194,6 @@ public class UefiGuid {
      */
     public String toStringNoLookup() {
         return uuid.toString();
-    }
-
-    /**
-     * Returns a string of the entity that the UUID represents.
-     * Does not contain a vendor lookup on the UUID.
-     *
-     * @param guid byte array holding the guid data.
-     * @return true if the UUID has a valid structure.
-     */
-    public static boolean isValidUUID(final byte[] guid) {
-        boolean valid = false;
-        UUID tmpUuid = processGuid(guid);
-        if (tmpUuid.toString().length() != 0) {
-            valid = true;
-        }
-        return valid;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureData.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureData.java
@@ -11,14 +11,14 @@ import java.security.cert.CertificateException;
 
 /**
  * Class for processing either
- *   1) the contents of a Secure Boot PK, KEK, DB or DBX contents,
- *      used for EFIVariables associated with Secure Boot,
- *      as defined by Section 32.4.1 Signature Database from the UEFI 2.8 specification
- *   2) the contents of an SPDM devdb,
- *      used for SPDM Device Policy or Device Authority, whose data is an EFIVariable
- *         EFIVariable data for SPDM Device Policy: UefiSignatureList
- *         EFIVariable data for SPDM Device: UefiSignatureData only
- *      as defined by PFP v1.06 Rev52, Section 10.4
+ * 1) the contents of a Secure Boot PK, KEK, DB or DBX contents,
+ * used for EFIVariables associated with Secure Boot,
+ * as defined by Section 32.4.1 Signature Database from the UEFI 2.8 specification
+ * 2) the contents of an SPDM devdb,
+ * used for SPDM Device Policy or Device Authority, whose data is an EFIVariable
+ * EFIVariable data for SPDM Device Policy: UefiSignatureList
+ * EFIVariable data for SPDM Device: UefiSignatureData only
+ * as defined by PFP v1.06 Rev52, Section 10.4
  * <p>
  * typedef struct _EFI_SIGNATURE_DATA {
  * EFI_GUID    SignatureOwner;
@@ -33,7 +33,7 @@ public class UefiSignatureData {
     /**
      * UEFI Certificate GUID.
      */
-    private byte[] guid = new byte[UefiConstants.SIZE_16];
+    private final byte[] guid = new byte[UefiConstants.SIZE_16];
     /**
      * UEFI Signature data.
      */
@@ -61,7 +61,7 @@ public class UefiSignatureData {
     /**
      * UEFI Certificate SHA256 hash.
      */
-    private byte[] binaryHash = new byte[UefiConstants.SIZE_32];
+    private final byte[] binaryHash = new byte[UefiConstants.SIZE_32];
     /**
      * UEFI Signature data status.
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
@@ -13,17 +13,17 @@ import static hirs.utils.tpm.eventlog.uefi.UefiConstants.FILESTATUS_NOT_ACCESSIB
 
 /**
  * Class for processing either
- *   1) the contents of a Secure Boot PK, KEK, DB or DBX contents,
- *      used for EFIVariables associated with Secure Boot,
- *      as defined by Section 32.4.1 Signature Database from the UEFI 2.8 specification
- *   2) the contents of an SPDM devdb,
- *      used for SPDM Device Policy, whose data is an EFIVariable
- *      as defined by PFP v1.06 Rev52, Section 10.4
+ * 1) the contents of a Secure Boot PK, KEK, DB or DBX contents,
+ * used for EFIVariables associated with Secure Boot,
+ * as defined by Section 32.4.1 Signature Database from the UEFI 2.8 specification
+ * 2) the contents of an SPDM devdb,
+ * used for SPDM Device Policy, whose data is an EFIVariable
+ * as defined by PFP v1.06 Rev52, Section 10.4
  * <p>
  * An EFI Signature List is actually a list of Certificates used to verify a Signature.
  * This is mainly found in PCR[7] UEFI variables for either the
- *      Secure Boot PK, KEK, Db and DBx variables
- *      or the SPDM devdb variable (under EV_EFI_SPDM_DEVICE_POLICY).
+ * Secure Boot PK, KEK, Db and DBx variables
+ * or the SPDM devdb variable (under EV_EFI_SPDM_DEVICE_POLICY).
  * <p>
  * typedef struct _EFI_SIGNATURE_LIST {
  * EFI_GUID            SignatureType;
@@ -33,20 +33,20 @@ import static hirs.utils.tpm.eventlog.uefi.UefiConstants.FILESTATUS_NOT_ACCESSIB
  * // UINT8               SignatureHeader[SignatureHeaderSize];
  * // EFI_SIGNATURE_DATA  Signatures[...][SignatureSize];
  * } EFI_SIGNATURE_LIST;
- *
+ * <p>
  * SignatureListHeader (contents common to any Signature Type)
- *      - SignatureType
- *      - SignatureListSize
- *      - SignatureHeaderSize
- *      - SignatureSize
+ * - SignatureType
+ * - SignatureListSize
+ * - SignatureHeaderSize
+ * - SignatureSize
  * SignatureHeader (contents depend on the SignatureType)
- *      - The format of this header is specified by the SignatureType (SHA256, X509).
+ * - The format of this header is specified by the SignatureType (SHA256, X509).
  * Signatures[][] is an array of signatures.
- *      - Each signature is SignatureSize bytes in length.
- *      - The format of the signature is defined by SignatureType (SHA256, X509).
- *
- *                               / |-------------------------| ------- SignatureType
- *                              /  | Signature List Header   |         SignatureListSize
+ * - Each signature is SignatureSize bytes in length.
+ * - The format of the signature is defined by SignatureType (SHA256, X509).
+ * <p>
+ * / |-------------------------| ------- SignatureType
+ * /  | Signature List Header   |         SignatureListSize
  * |---------------------|     /   |-------------------------|\        SignatureHeaderSize
  * | Signature List #0   |    /    |    Signature Header     | \ _____ SignatureSize
  * |                     |   /     |-------------------------|
@@ -57,11 +57,10 @@ import static hirs.utils.tpm.eventlog.uefi.UefiConstants.FILESTATUS_NOT_ACCESSIB
  * |                     |         |      Signature #2       |      (1 cert or hash)
  * |                     |         |-------------------------|
  * |---------------------|         |           ...           |
- *                         \       |                         |
- *                           \     |-------------------------|
- *                             \   |      Signature #n       |
- *                               \ |-------------------------|
- *
+ * \       |                         |
+ * \     |-------------------------|
+ * \   |      Signature #n       |
+ * \ |-------------------------|
  */
 public class UefiSignatureList {
     /**
@@ -97,7 +96,7 @@ public class UefiSignatureList {
     /**
      * Array List of Signature found in the list.
      */
-    private ArrayList<UefiSignatureData> sigList = new ArrayList<UefiSignatureData>();
+    private final ArrayList<UefiSignatureData> sigList = new ArrayList<UefiSignatureData>();
     /**
      * Input Stream for processing.
      */

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
@@ -64,6 +64,10 @@ import static hirs.utils.tpm.eventlog.uefi.UefiConstants.FILESTATUS_NOT_ACCESSIB
  */
 public class UefiSignatureList {
     /**
+     * Array List of Signature found in the list.
+     */
+    private final ArrayList<UefiSignatureData> sigList = new ArrayList<>();
+    /**
      * Size of the signature list.
      */
     private int listSize = 0;
@@ -94,17 +98,15 @@ public class UefiSignatureList {
      */
     private String dataInvalidStatus = "Signature List data validity is undetermined yet";
     /**
-     * Array List of Signature found in the list.
-     */
-    private final ArrayList<UefiSignatureData> sigList = new ArrayList<UefiSignatureData>();
-    /**
      * Input Stream for processing.
      */
     private ByteArrayInputStream efiSigDataIS = null;
+
     /**
      * Type of signature.
      */
     private UefiGuid signatureType = null;
+
     /**
      * Track status of vendor-table.json.
      */
@@ -212,16 +214,11 @@ public class UefiSignatureList {
      * @return true if the GUID is a valid GUID for Signature List Type, false if not.
      */
     public boolean isValidSigListGUID(final UefiGuid guid) {
-        switch (guid.getVendorTableReference()) {
-            case "EFI_CERT_SHA256_GUID":
-            case "EFI_CERT_X509_SHA256":
-            case "EFI_CERT_X509_SHA384":
-            case "EFI_CERT_X509_SHA512":
-            case "EFI_CERT_X509_GUID":
-                return true;
-            default:
-                return false;
-        }
+        return switch (guid.getVendorTableReference()) {
+            case "EFI_CERT_SHA256_GUID", "EFI_CERT_X509_SHA256", "EFI_CERT_X509_SHA384",
+                 "EFI_CERT_X509_SHA512", "EFI_CERT_X509_GUID" -> true;
+            default -> false;
+        };
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -35,7 +35,7 @@ public class UefiVariable {
     /**
      * List of Signature lists.
      */
-    private List<UefiSignatureList> certSuperList;
+    private final List<UefiSignatureList> certSuperList;
     /**
      * Name of the UEFI variable.
      */
@@ -87,11 +87,11 @@ public class UefiVariable {
      *
      * @param variableData byte array holding the UEFI Variable.
      * @throws java.security.cert.CertificateException If there a problem
-     *              parsing the X509 certificate.
+     *                                                 parsing the X509 certificate.
      * @throws java.security.NoSuchAlgorithmException  if there's a problem
-     *              hashing the certificate.
+     *                                                 hashing the certificate.
      * @throws java.io.IOException                     If there's a problem
-     *              parsing the signature data.
+     *                                                 parsing the signature data.
      */
     public UefiVariable(final byte[] variableData)
             throws CertificateException, NoSuchAlgorithmException, IOException {
@@ -136,10 +136,10 @@ public class UefiVariable {
             case "devdb":
                 processSigList(uefiVariableData);
                 break;      // Update when test patterns exist
-                            // PFP v1.06 Rev 52, Sec 3.3.4.8
-                            // EV_EFI_SPDM_DEVICE_POLICY: EFI_SIGNATURE_LIST
-                            // EV_EFI_SPDM_DEVICE_AUTHORITY: EFI_SIGNATURE_DATA
-                            // for now, differentiate them by using devdc for ..DEVICE_AUTHORITY
+            // PFP v1.06 Rev 52, Sec 3.3.4.8
+            // EV_EFI_SPDM_DEVICE_POLICY: EFI_SIGNATURE_LIST
+            // EV_EFI_SPDM_DEVICE_AUTHORITY: EFI_SIGNATURE_DATA
+            // for now, differentiate them by using devdc for ..DEVICE_AUTHORITY
             case "devdc":
                 processSigDataX509(uefiVariableData);
                 break;
@@ -161,11 +161,11 @@ public class UefiVariable {
      *
      * @param data the bye array holding one or more Signature Lists.
      * @throws java.security.cert.CertificateException If there's a problem
-     *          parsing the X509 certificate.
+     *                                                 parsing the X509 certificate.
      * @throws java.security.NoSuchAlgorithmException  if there's a problem
-     *          hashing the certificate.
+     *                                                 hashing the certificate.
      * @throws java.io.IOException                     If there's a problem
-     *          parsing the signature data.
+     *                                                 parsing the signature data.
      */
     private void processSigList(final byte[] data)
             throws CertificateException, NoSuchAlgorithmException, IOException {
@@ -186,7 +186,7 @@ public class UefiVariable {
             // (ie. if the new file status is not-accessible or from-code, then want to update)
             if ((vendorTableFileStatus != FILESTATUS_NOT_ACCESSIBLE)
                     && (list.getVendorTableFileStatus() != FILESTATUS_FROM_FILESYSTEM)) {
-                        vendorTableFileStatus = list.getVendorTableFileStatus();
+                vendorTableFileStatus = list.getVendorTableFileStatus();
             }
 
 //            efiVariableSigListContents += list.toString();
@@ -275,7 +275,7 @@ public class UefiVariable {
             case "dbx":
             case "devdb":           // SPDM_DEVICE_POLICY and SPDM_DEVICE_AUTHORITY
             case "devdc":           // for now use devdb and devdc respectively
-                                    // (update when more test patterns exist)
+                // (update when more test patterns exist)
                 break;
             case "Boot00":
                 efiVariable.append(bootv.toString());
@@ -289,7 +289,7 @@ public class UefiVariable {
             default:
                 if (!tmpName.isEmpty()) {
                     efiVariable.append(String.format("      Data not provided for "
-                                    + "UEFI variable named %s   ", tmpName));
+                            + "UEFI variable named %s   ", tmpName));
                 } else {
                     efiVariable.append("      Data not provided   ");
                 }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiX509Cert.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiX509Cert.java
@@ -1,6 +1,7 @@
 package hirs.utils.tpm.eventlog.uefi;
 
 import jakarta.xml.bind.DatatypeConverter;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.security.MessageDigest;

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/BaseElement.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/BaseElement.java
@@ -14,6 +14,8 @@ import jakarta.xml.bind.annotation.XmlAnyAttribute;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlSeeAlso;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.xml.namespace.QName;
 import java.util.HashMap;
@@ -21,14 +23,13 @@ import java.util.Map;
 
 
 /**
- * 
- *         Attributes common to all Elements in this schema
- *       
- * 
+ * Attributes common to all Elements in this schema
+ *
+ *
  * <p>Java class for BaseElement complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="BaseElement">
  *   &lt;complexContent>
@@ -39,67 +40,38 @@ import java.util.Map;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Getter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "BaseElement", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 @XmlSeeAlso({
-    SoftwareIdentity.class,
-    Entity.class,
-    Link.class,
-    Meta.class,
-    ResourceCollection.class
+        SoftwareIdentity.class,
+        Entity.class,
+        Link.class,
+        Meta.class,
+        ResourceCollection.class
 })
 public class BaseElement {
 
-    @XmlAttribute(name = "lang", namespace = "http://www.w3.org/XML/1998/namespace")
-    protected String lang;
-    @XmlAnyAttribute
-    private Map<QName, String> otherAttributes = new HashMap<QName, String>();
-
     /**
-     * 
-     *           Allow xml:lang attribute on any element.
-     *         
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getLang() {
-        return lang;
-    }
-
-    /**
-     * Sets the value of the lang property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setLang(String value) {
-        this.lang = value;
-    }
-
-    /**
+     * -- GETTER --
      * Gets a map that contains attributes that aren't bound to any typed property on this class.
-     * 
      * <p>
-     * the map is keyed by the name of the attribute and 
+     * the map is keyed by the name of the attribute and
      * the value is the string value of the attribute.
-     * 
+     * <p>
      * the map returned by this method is live, and you can add new attribute
      * by updating the map directly. Because of this design, there's no setter.
-     * 
-     * 
-     * @return
-     *     always non-null
      */
-    public Map<QName, String> getOtherAttributes() {
-        return otherAttributes;
-    }
+    @XmlAnyAttribute
+    private final Map<QName, String> otherAttributes = new HashMap<>();
+
+    /**
+     * -- GETTER --
+     * Allow xml:lang attribute on any element.
+     */
+    @Setter
+    @XmlAttribute(name = "lang", namespace = "http://www.w3.org/XML/1998/namespace")
+    protected String lang;
 
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/CanonicalizationMethodType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/CanonicalizationMethodType.java
@@ -50,8 +50,8 @@ public class CanonicalizationMethodType {
     @XmlAnyElement(lax = true)
     protected List<Object> content;
 
-    @Setter
     @Getter
+    @Setter
     @XmlAttribute(name = "Algorithm", required = true)
     @XmlSchemaType(name = "anyURI")
     protected String algorithm;

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/CanonicalizationMethodType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/CanonicalizationMethodType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAnyElement;
@@ -17,13 +15,18 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlMixed;
 import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for CanonicalizationMethodType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="CanonicalizationMethodType">
  *   &lt;complexContent>
@@ -36,44 +39,43 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "CanonicalizationMethodType", propOrder = {
-    "content"
+        "content"
 })
 public class CanonicalizationMethodType {
 
     @XmlMixed
     @XmlAnyElement(lax = true)
     protected List<Object> content;
+
+    @Setter
+    @Getter
     @XmlAttribute(name = "Algorithm", required = true)
     @XmlSchemaType(name = "anyURI")
     protected String algorithm;
 
     /**
      * Gets the value of the content property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the content property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getContent().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link Object }
      * {@link String }
-     * 
-     * 
      */
     public List<Object> getContent() {
         if (content == null) {
@@ -81,29 +83,4 @@ public class CanonicalizationMethodType {
         }
         return this.content;
     }
-
-    /**
-     * Gets the value of the algorithm property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getAlgorithm() {
-        return algorithm;
-    }
-
-    /**
-     * Sets the value of the algorithm property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setAlgorithm(String value) {
-        this.algorithm = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/DSAKeyValueType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/DSAKeyValueType.java
@@ -12,13 +12,15 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
  * <p>Java class for DSAKeyValueType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="DSAKeyValueType">
  *   &lt;complexContent>
@@ -40,188 +42,38 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Setter
+@Getter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "DSAKeyValueType", propOrder = {
-    "p",
-    "q",
-    "g",
-    "y",
-    "j",
-    "seed",
-    "pgenCounter"
+        "p",
+        "q",
+        "g",
+        "y",
+        "j",
+        "seed",
+        "pgenCounter"
 })
 public class DSAKeyValueType {
-
     @XmlElement(name = "P")
     protected byte[] p;
+    
     @XmlElement(name = "Q")
     protected byte[] q;
+
     @XmlElement(name = "G")
     protected byte[] g;
+
     @XmlElement(name = "Y", required = true)
     protected byte[] y;
+
     @XmlElement(name = "J")
     protected byte[] j;
+
     @XmlElement(name = "Seed")
     protected byte[] seed;
+
     @XmlElement(name = "PgenCounter")
     protected byte[] pgenCounter;
-
-    /**
-     * Gets the value of the p property.
-     * 
-     * @return
-     *     possible object is
-     *     byte[]
-     */
-    public byte[] getP() {
-        return p;
-    }
-
-    /**
-     * Sets the value of the p property.
-     * 
-     * @param value
-     *     allowed object is
-     *     byte[]
-     */
-    public void setP(byte[] value) {
-        this.p = value;
-    }
-
-    /**
-     * Gets the value of the q property.
-     * 
-     * @return
-     *     possible object is
-     *     byte[]
-     */
-    public byte[] getQ() {
-        return q;
-    }
-
-    /**
-     * Sets the value of the q property.
-     * 
-     * @param value
-     *     allowed object is
-     *     byte[]
-     */
-    public void setQ(byte[] value) {
-        this.q = value;
-    }
-
-    /**
-     * Gets the value of the g property.
-     * 
-     * @return
-     *     possible object is
-     *     byte[]
-     */
-    public byte[] getG() {
-        return g;
-    }
-
-    /**
-     * Sets the value of the g property.
-     * 
-     * @param value
-     *     allowed object is
-     *     byte[]
-     */
-    public void setG(byte[] value) {
-        this.g = value;
-    }
-
-    /**
-     * Gets the value of the y property.
-     * 
-     * @return
-     *     possible object is
-     *     byte[]
-     */
-    public byte[] getY() {
-        return y;
-    }
-
-    /**
-     * Sets the value of the y property.
-     * 
-     * @param value
-     *     allowed object is
-     *     byte[]
-     */
-    public void setY(byte[] value) {
-        this.y = value;
-    }
-
-    /**
-     * Gets the value of the j property.
-     * 
-     * @return
-     *     possible object is
-     *     byte[]
-     */
-    public byte[] getJ() {
-        return j;
-    }
-
-    /**
-     * Sets the value of the j property.
-     * 
-     * @param value
-     *     allowed object is
-     *     byte[]
-     */
-    public void setJ(byte[] value) {
-        this.j = value;
-    }
-
-    /**
-     * Gets the value of the seed property.
-     * 
-     * @return
-     *     possible object is
-     *     byte[]
-     */
-    public byte[] getSeed() {
-        return seed;
-    }
-
-    /**
-     * Sets the value of the seed property.
-     * 
-     * @param value
-     *     allowed object is
-     *     byte[]
-     */
-    public void setSeed(byte[] value) {
-        this.seed = value;
-    }
-
-    /**
-     * Gets the value of the pgenCounter property.
-     * 
-     * @return
-     *     possible object is
-     *     byte[]
-     */
-    public byte[] getPgenCounter() {
-        return pgenCounter;
-    }
-
-    /**
-     * Sets the value of the pgenCounter property.
-     * 
-     * @param value
-     *     allowed object is
-     *     byte[]
-     */
-    public void setPgenCounter(byte[] value) {
-        this.pgenCounter = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/DSAKeyValueType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/DSAKeyValueType.java
@@ -43,8 +43,8 @@ import lombok.Setter;
  * &lt;/complexType>
  * </pre>
  */
-@Setter
 @Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "DSAKeyValueType", propOrder = {
         "p",
@@ -58,7 +58,7 @@ import lombok.Setter;
 public class DSAKeyValueType {
     @XmlElement(name = "P")
     protected byte[] p;
-    
+
     @XmlElement(name = "Q")
     protected byte[] q;
 

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/DigestMethodType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/DigestMethodType.java
@@ -51,8 +51,8 @@ public class DigestMethodType {
     @XmlAnyElement(lax = true)
     protected List<Object> content;
 
-    @Setter
     @Getter
+    @Setter
     @XmlAttribute(name = "Algorithm", required = true)
     @XmlSchemaType(name = "anyURI")
     protected String algorithm;

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/DigestMethodType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/DigestMethodType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAnyElement;
@@ -17,14 +15,19 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlMixed;
 import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
 import org.w3c.dom.Element;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for DigestMethodType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="DigestMethodType">
  *   &lt;complexContent>
@@ -37,75 +40,49 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "DigestMethodType", propOrder = {
-    "content"
+        "content"
 })
 public class DigestMethodType {
 
     @XmlMixed
     @XmlAnyElement(lax = true)
     protected List<Object> content;
+
+    @Setter
+    @Getter
     @XmlAttribute(name = "Algorithm", required = true)
     @XmlSchemaType(name = "anyURI")
     protected String algorithm;
 
     /**
      * Gets the value of the content property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the content property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getContent().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link Object }
      * {@link Element }
      * {@link String }
-     * 
-     * 
      */
     public List<Object> getContent() {
         if (content == null) {
-            content = new ArrayList<Object>();
+            content = new ArrayList<>();
         }
         return this.content;
     }
-
-    /**
-     * Gets the value of the algorithm property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getAlgorithm() {
-        return algorithm;
-    }
-
-    /**
-     * Sets the value of the algorithm property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setAlgorithm(String value) {
-        this.algorithm = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Directory.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Directory.java
@@ -8,20 +8,21 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElements;
 import jakarta.xml.bind.annotation.XmlType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * <p>Java class for Directory complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="Directory">
  *   &lt;complexContent>
@@ -35,49 +36,44 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Directory", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", propOrder = {
-    "directoryOrFile"
+        "directoryOrFile"
 })
 public class Directory
-    extends FilesystemItem
-{
+        extends FilesystemItem {
 
     @XmlElements({
-        @XmlElement(name = "Directory", type = Directory.class),
-        @XmlElement(name = "File", type = File.class)
+            @XmlElement(name = "Directory", type = Directory.class),
+            @XmlElement(name = "File", type = File.class)
     })
     protected List<FilesystemItem> directoryOrFile;
 
     /**
      * Gets the value of the directoryOrFile property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the directoryOrFile property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getDirectoryOrFile().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link Directory }
      * {@link File }
-     * 
-     * 
      */
     public List<FilesystemItem> getDirectoryOrFile() {
         if (directoryOrFile == null) {
-            directoryOrFile = new ArrayList<FilesystemItem>();
+            directoryOrFile = new ArrayList<>();
         }
         return this.directoryOrFile;
     }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Entity.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Entity.java
@@ -53,8 +53,8 @@ public class Entity
     @XmlElement(name = "Meta")
     protected List<Meta> meta;
 
-    @Setter
     @Getter
+    @Setter
     @XmlAttribute(name = "name", required = true)
     protected String name;
 

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Entity.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Entity.java
@@ -8,21 +8,24 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for Entity complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="Entity">
  *   &lt;complexContent>
@@ -39,51 +42,55 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Entity", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", propOrder = {
-    "meta"
+        "meta"
 })
 public class Entity
-    extends BaseElement
-{
+        extends BaseElement {
 
     @XmlElement(name = "Meta")
     protected List<Meta> meta;
+
+    @Setter
+    @Getter
     @XmlAttribute(name = "name", required = true)
     protected String name;
+
+    @Setter
     @XmlAttribute(name = "regid")
     @XmlSchemaType(name = "anyURI")
     protected String regid;
+
     @XmlAttribute(name = "role", required = true)
     @XmlSchemaType(name = "NMTOKENS")
     protected List<String> role;
+
+    @Getter
+    @Setter
     @XmlAttribute(name = "thumbprint")
     protected String thumbprint;
 
     /**
      * Gets the value of the meta property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the meta property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getMeta().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link Meta }
-     * 
-     * 
      */
     public List<Meta> getMeta() {
         if (meta == null) {
@@ -93,36 +100,10 @@ public class Entity
     }
 
     /**
-     * Gets the value of the name property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getName() {
-        return name;
-    }
-
-    /**
-     * Sets the value of the name property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setName(String value) {
-        this.name = value;
-    }
-
-    /**
      * Gets the value of the regid property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getRegid() {
         if (regid == null) {
@@ -133,68 +114,29 @@ public class Entity
     }
 
     /**
-     * Sets the value of the regid property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setRegid(String value) {
-        this.regid = value;
-    }
-
-    /**
      * Gets the value of the role property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the role property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getRole().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link String }
-     * 
-     * 
      */
     public List<String> getRole() {
         if (role == null) {
-            role = new ArrayList<String>();
+            role = new ArrayList<>();
         }
         return this.role;
     }
-
-    /**
-     * Gets the value of the thumbprint property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getThumbprint() {
-        return thumbprint;
-    }
-
-    /**
-     * Sets the value of the thumbprint property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setThumbprint(String value) {
-        this.thumbprint = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Evidence.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Evidence.java
@@ -13,14 +13,17 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
+
 import javax.xml.datatype.XMLGregorianCalendar;
 
 
 /**
  * <p>Java class for Evidence complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="Evidence">
  *   &lt;complexContent>
@@ -32,67 +35,18 @@ import javax.xml.datatype.XMLGregorianCalendar;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Setter
+@Getter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Evidence", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 public class Evidence
-    extends ResourceCollection
-{
+        extends ResourceCollection {
 
     @XmlAttribute(name = "date")
     @XmlSchemaType(name = "dateTime")
     protected XMLGregorianCalendar date;
+
     @XmlAttribute(name = "deviceId")
     protected String deviceId;
-
-    /**
-     * Gets the value of the date property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link XMLGregorianCalendar }
-     *     
-     */
-    public XMLGregorianCalendar getDate() {
-        return date;
-    }
-
-    /**
-     * Sets the value of the date property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link XMLGregorianCalendar }
-     *     
-     */
-    public void setDate(XMLGregorianCalendar value) {
-        this.date = value;
-    }
-
-    /**
-     * Gets the value of the deviceId property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getDeviceId() {
-        return deviceId;
-    }
-
-    /**
-     * Sets the value of the deviceId property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setDeviceId(String value) {
-        this.deviceId = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Evidence.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Evidence.java
@@ -36,8 +36,8 @@ import javax.xml.datatype.XMLGregorianCalendar;
  * &lt;/complexType>
  * </pre>
  */
-@Setter
 @Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Evidence", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 public class Evidence

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/File.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/File.java
@@ -8,18 +8,21 @@
 
 package hirs.utils.xjc;
 
-import java.math.BigInteger;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigInteger;
 
 
 /**
  * <p>Java class for File complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="File">
  *   &lt;complexContent>
@@ -31,66 +34,17 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Setter
+@Getter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "File", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 public class File
-    extends FilesystemItem
-{
+        extends FilesystemItem {
 
     @XmlAttribute(name = "size")
     protected BigInteger size;
+
     @XmlAttribute(name = "version")
     protected String version;
-
-    /**
-     * Gets the value of the size property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link BigInteger }
-     *     
-     */
-    public BigInteger getSize() {
-        return size;
-    }
-
-    /**
-     * Sets the value of the size property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link BigInteger }
-     *     
-     */
-    public void setSize(BigInteger value) {
-        this.size = value;
-    }
-
-    /**
-     * Gets the value of the version property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getVersion() {
-        return version;
-    }
-
-    /**
-     * Sets the value of the version property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setVersion(String value) {
-        this.version = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/File.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/File.java
@@ -35,8 +35,8 @@ import java.math.BigInteger;
  * &lt;/complexType>
  * </pre>
  */
-@Setter
 @Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "File", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 public class File

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/FilesystemItem.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/FilesystemItem.java
@@ -13,13 +13,15 @@ import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlSeeAlso;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
  * <p>Java class for FilesystemItem complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="FilesystemItem">
  *   &lt;complexContent>
@@ -33,122 +35,27 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "FilesystemItem", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 @XmlSeeAlso({
-    File.class,
-    Directory.class
+        File.class,
+        Directory.class
 })
 public class FilesystemItem
-    extends Meta
-{
+        extends Meta {
 
     @XmlAttribute(name = "key")
     protected Boolean key;
+
     @XmlAttribute(name = "location")
     protected String location;
+
     @XmlAttribute(name = "name", required = true)
     protected String name;
+
     @XmlAttribute(name = "root")
     protected String root;
-
-    /**
-     * Gets the value of the key property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link Boolean }
-     *     
-     */
-    public Boolean isKey() {
-        return key;
-    }
-
-    /**
-     * Sets the value of the key property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link Boolean }
-     *     
-     */
-    public void setKey(Boolean value) {
-        this.key = value;
-    }
-
-    /**
-     * Gets the value of the location property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getLocation() {
-        return location;
-    }
-
-    /**
-     * Sets the value of the location property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setLocation(String value) {
-        this.location = value;
-    }
-
-    /**
-     * Gets the value of the name property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getName() {
-        return name;
-    }
-
-    /**
-     * Sets the value of the name property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setName(String value) {
-        this.name = value;
-    }
-
-    /**
-     * Gets the value of the root property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getRoot() {
-        return root;
-    }
-
-    /**
-     * Sets the value of the root property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setRoot(String value) {
-        this.root = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/KeyInfoType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/KeyInfoType.java
@@ -73,8 +73,8 @@ public class KeyInfoType {
     @XmlAnyElement(lax = true)
     protected List<Object> content;
 
-    @Setter
     @Getter
+    @Setter
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/KeyInfoType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/KeyInfoType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -23,14 +21,19 @@ import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.Getter;
+import lombok.Setter;
 import org.w3c.dom.Element;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for KeyInfoType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="KeyInfoType">
  *   &lt;complexContent>
@@ -50,27 +53,28 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "KeyInfoType", propOrder = {
-    "content"
+        "content"
 })
 public class KeyInfoType {
 
     @XmlElementRefs({
-        @XmlElementRef(name = "KeyValue", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "X509Data", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "KeyName", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "PGPData", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "MgmtData", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "SPKIData", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "RetrievalMethod", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false)
+            @XmlElementRef(name = "KeyValue", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "X509Data", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "KeyName", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "PGPData", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "MgmtData", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "SPKIData", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "RetrievalMethod", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false)
     })
     @XmlMixed
     @XmlAnyElement(lax = true)
     protected List<Object> content;
+
+    @Setter
+    @Getter
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID
@@ -79,20 +83,20 @@ public class KeyInfoType {
 
     /**
      * Gets the value of the content property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the content property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getContent().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link JAXBElement }{@code <}{@link KeyValueType }{@code >}
@@ -105,38 +109,11 @@ public class KeyInfoType {
      * {@link Element }
      * {@link JAXBElement }{@code <}{@link SPKIDataType }{@code >}
      * {@link JAXBElement }{@code <}{@link RetrievalMethodType }{@code >}
-     * 
-     * 
      */
     public List<Object> getContent() {
         if (content == null) {
-            content = new ArrayList<Object>();
+            content = new ArrayList<>();
         }
         return this.content;
     }
-
-    /**
-     * Gets the value of the id property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Sets the value of the id property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setId(String value) {
-        this.id = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/KeyValueType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/KeyValueType.java
@@ -81,7 +81,7 @@ public class KeyValueType {
      */
     public List<Object> getContent() {
         if (content == null) {
-            content = new ArrayList<Object>();
+            content = new ArrayList<>();
         }
         return this.content;
     }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/KeyValueType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/KeyValueType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -20,12 +18,15 @@ import jakarta.xml.bind.annotation.XmlMixed;
 import jakarta.xml.bind.annotation.XmlType;
 import org.w3c.dom.Element;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * <p>Java class for KeyValueType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="KeyValueType">
  *   &lt;complexContent>
@@ -39,18 +40,16 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "KeyValueType", propOrder = {
-    "content"
+        "content"
 })
 public class KeyValueType {
 
     @XmlElementRefs({
-        @XmlElementRef(name = "RSAKeyValue", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "DSAKeyValue", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false)
+            @XmlElementRef(name = "RSAKeyValue", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "DSAKeyValue", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false)
     })
     @XmlMixed
     @XmlAnyElement(lax = true)
@@ -58,20 +57,20 @@ public class KeyValueType {
 
     /**
      * Gets the value of the content property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the content property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getContent().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link JAXBElement }{@code <}{@link RSAKeyValueType }{@code >}
@@ -79,8 +78,6 @@ public class KeyValueType {
      * {@link String }
      * {@link JAXBElement }{@code <}{@link DSAKeyValueType }{@code >}
      * {@link Object }
-     * 
-     * 
      */
     public List<Object> getContent() {
         if (content == null) {

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Link.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Link.java
@@ -15,13 +15,15 @@ import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
  * <p>Java class for Link complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="Link">
  *   &lt;complexContent>
@@ -38,199 +40,35 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Link", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 public class Link
-    extends BaseElement
-{
+        extends BaseElement {
 
     @XmlAttribute(name = "artifact")
     protected String artifact;
+
     @XmlAttribute(name = "href", required = true)
     @XmlSchemaType(name = "anyURI")
     protected String href;
+
     @XmlAttribute(name = "media")
     protected String media;
+
     @XmlAttribute(name = "ownership")
     protected Ownership ownership;
+
     @XmlAttribute(name = "rel", required = true)
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlSchemaType(name = "NMTOKEN")
     protected String rel;
+
     @XmlAttribute(name = "type")
     protected String type;
+
     @XmlAttribute(name = "use")
     protected Use use;
-
-    /**
-     * Gets the value of the artifact property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getArtifact() {
-        return artifact;
-    }
-
-    /**
-     * Sets the value of the artifact property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setArtifact(String value) {
-        this.artifact = value;
-    }
-
-    /**
-     * Gets the value of the href property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getHref() {
-        return href;
-    }
-
-    /**
-     * Sets the value of the href property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setHref(String value) {
-        this.href = value;
-    }
-
-    /**
-     * Gets the value of the media property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getMedia() {
-        return media;
-    }
-
-    /**
-     * Sets the value of the media property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setMedia(String value) {
-        this.media = value;
-    }
-
-    /**
-     * Gets the value of the ownership property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link Ownership }
-     *     
-     */
-    public Ownership getOwnership() {
-        return ownership;
-    }
-
-    /**
-     * Sets the value of the ownership property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link Ownership }
-     *     
-     */
-    public void setOwnership(Ownership value) {
-        this.ownership = value;
-    }
-
-    /**
-     * Gets the value of the rel property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getRel() {
-        return rel;
-    }
-
-    /**
-     * Sets the value of the rel property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setRel(String value) {
-        this.rel = value;
-    }
-
-    /**
-     * Gets the value of the type property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * Sets the value of the type property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setType(String value) {
-        this.type = value;
-    }
-
-    /**
-     * Gets the value of the use property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link Use }
-     *     
-     */
-    public Use getUse() {
-        return use;
-    }
-
-    /**
-     * Sets the value of the use property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link Use }
-     *     
-     */
-    public void setUse(Use value) {
-        this.use = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/ManifestType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/ManifestType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -19,13 +17,18 @@ import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for ManifestType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="ManifestType">
  *   &lt;complexContent>
@@ -38,17 +41,18 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ManifestType", propOrder = {
-    "reference"
+        "reference"
 })
 public class ManifestType {
 
     @XmlElement(name = "Reference", required = true)
     protected List<ReferenceType> reference;
+
+    @Getter
+    @Setter
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID
@@ -57,55 +61,28 @@ public class ManifestType {
 
     /**
      * Gets the value of the reference property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the reference property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getReference().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link ReferenceType }
-     * 
-     * 
      */
     public List<ReferenceType> getReference() {
         if (reference == null) {
-            reference = new ArrayList<ReferenceType>();
+            reference = new ArrayList<>();
         }
         return this.reference;
     }
-
-    /**
-     * Gets the value of the id property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Sets the value of the id property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setId(String value) {
-        this.id = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Meta.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Meta.java
@@ -16,9 +16,9 @@ import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for Meta complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="Meta">
  *   &lt;complexContent>
@@ -28,20 +28,17 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Meta", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 @XmlSeeAlso({
-    SoftwareMeta.class,
-    Resource.class,
-    Process.class,
-    FilesystemItem.class
+        SoftwareMeta.class,
+        Resource.class,
+        Process.class,
+        FilesystemItem.class
 })
 public class Meta
-    extends BaseElement
-{
+        extends BaseElement {
 
 
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/ObjectFactory.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/ObjectFactory.java
@@ -364,7 +364,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SPKIData")
     public JAXBElement<SPKIDataType> createSPKIData(SPKIDataType value) {
-        return new JAXBElement<SPKIDataType>(_SPKIData_QNAME, SPKIDataType.class, null, value);
+        return new JAXBElement<>(_SPKIData_QNAME, SPKIDataType.class, null, value);
     }
 
     /**
@@ -372,7 +372,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyInfo")
     public JAXBElement<KeyInfoType> createKeyInfo(KeyInfoType value) {
-        return new JAXBElement<KeyInfoType>(_KeyInfo_QNAME, KeyInfoType.class, null, value);
+        return new JAXBElement<>(_KeyInfo_QNAME, KeyInfoType.class, null, value);
     }
 
     /**
@@ -380,7 +380,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureValue")
     public JAXBElement<SignatureValueType> createSignatureValue(SignatureValueType value) {
-        return new JAXBElement<SignatureValueType>(_SignatureValue_QNAME, SignatureValueType.class, null,
+        return new JAXBElement<>(_SignatureValue_QNAME, SignatureValueType.class, null,
                 value);
     }
 
@@ -389,7 +389,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyValue")
     public JAXBElement<KeyValueType> createKeyValue(KeyValueType value) {
-        return new JAXBElement<KeyValueType>(_KeyValue_QNAME, KeyValueType.class, null, value);
+        return new JAXBElement<>(_KeyValue_QNAME, KeyValueType.class, null, value);
     }
 
     /**
@@ -397,7 +397,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Transforms")
     public JAXBElement<TransformsType> createTransforms(TransformsType value) {
-        return new JAXBElement<TransformsType>(_Transforms_QNAME, TransformsType.class, null, value);
+        return new JAXBElement<>(_Transforms_QNAME, TransformsType.class, null, value);
     }
 
     /**
@@ -405,7 +405,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DigestMethod")
     public JAXBElement<DigestMethodType> createDigestMethod(DigestMethodType value) {
-        return new JAXBElement<DigestMethodType>(_DigestMethod_QNAME, DigestMethodType.class, null, value);
+        return new JAXBElement<>(_DigestMethod_QNAME, DigestMethodType.class, null, value);
     }
 
     /**
@@ -413,7 +413,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509Data")
     public JAXBElement<X509DataType> createX509Data(X509DataType value) {
-        return new JAXBElement<X509DataType>(_X509Data_QNAME, X509DataType.class, null, value);
+        return new JAXBElement<>(_X509Data_QNAME, X509DataType.class, null, value);
     }
 
     /**
@@ -421,7 +421,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureProperty")
     public JAXBElement<SignaturePropertyType> createSignatureProperty(SignaturePropertyType value) {
-        return new JAXBElement<SignaturePropertyType>(_SignatureProperty_QNAME, SignaturePropertyType.class,
+        return new JAXBElement<>(_SignatureProperty_QNAME, SignaturePropertyType.class,
                 null, value);
     }
 
@@ -430,7 +430,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyName")
     public JAXBElement<String> createKeyName(String value) {
-        return new JAXBElement<String>(_KeyName_QNAME, String.class, null, value);
+        return new JAXBElement<>(_KeyName_QNAME, String.class, null, value);
     }
 
     /**
@@ -438,7 +438,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "RSAKeyValue")
     public JAXBElement<RSAKeyValueType> createRSAKeyValue(RSAKeyValueType value) {
-        return new JAXBElement<RSAKeyValueType>(_RSAKeyValue_QNAME, RSAKeyValueType.class, null, value);
+        return new JAXBElement<>(_RSAKeyValue_QNAME, RSAKeyValueType.class, null, value);
     }
 
     /**
@@ -446,7 +446,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "SoftwareIdentity")
     public JAXBElement<SoftwareIdentity> createSoftwareIdentity(SoftwareIdentity value) {
-        return new JAXBElement<SoftwareIdentity>(_SoftwareIdentity_QNAME, SoftwareIdentity.class, null,
+        return new JAXBElement<>(_SoftwareIdentity_QNAME, SoftwareIdentity.class, null,
                 value);
     }
 
@@ -455,7 +455,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Signature")
     public JAXBElement<SignatureType> createSignature(SignatureType value) {
-        return new JAXBElement<SignatureType>(_Signature_QNAME, SignatureType.class, null, value);
+        return new JAXBElement<>(_Signature_QNAME, SignatureType.class, null, value);
     }
 
     /**
@@ -463,7 +463,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "MgmtData")
     public JAXBElement<String> createMgmtData(String value) {
-        return new JAXBElement<String>(_MgmtData_QNAME, String.class, null, value);
+        return new JAXBElement<>(_MgmtData_QNAME, String.class, null, value);
     }
 
     /**
@@ -471,7 +471,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureMethod")
     public JAXBElement<SignatureMethodType> createSignatureMethod(SignatureMethodType value) {
-        return new JAXBElement<SignatureMethodType>(_SignatureMethod_QNAME, SignatureMethodType.class, null,
+        return new JAXBElement<>(_SignatureMethod_QNAME, SignatureMethodType.class, null,
                 value);
     }
 
@@ -480,7 +480,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Object")
     public JAXBElement<ObjectType> createObject(ObjectType value) {
-        return new JAXBElement<ObjectType>(_Object_QNAME, ObjectType.class, null, value);
+        return new JAXBElement<>(_Object_QNAME, ObjectType.class, null, value);
     }
 
     /**
@@ -488,7 +488,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureProperties")
     public JAXBElement<SignaturePropertiesType> createSignatureProperties(SignaturePropertiesType value) {
-        return new JAXBElement<SignaturePropertiesType>(_SignatureProperties_QNAME,
+        return new JAXBElement<>(_SignatureProperties_QNAME,
                 SignaturePropertiesType.class, null, value);
     }
 
@@ -497,7 +497,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Transform")
     public JAXBElement<TransformType> createTransform(TransformType value) {
-        return new JAXBElement<TransformType>(_Transform_QNAME, TransformType.class, null, value);
+        return new JAXBElement<>(_Transform_QNAME, TransformType.class, null, value);
     }
 
     /**
@@ -505,7 +505,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPData")
     public JAXBElement<PGPDataType> createPGPData(PGPDataType value) {
-        return new JAXBElement<PGPDataType>(_PGPData_QNAME, PGPDataType.class, null, value);
+        return new JAXBElement<>(_PGPData_QNAME, PGPDataType.class, null, value);
     }
 
     /**
@@ -513,7 +513,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Reference")
     public JAXBElement<ReferenceType> createReference(ReferenceType value) {
-        return new JAXBElement<ReferenceType>(_Reference_QNAME, ReferenceType.class, null, value);
+        return new JAXBElement<>(_Reference_QNAME, ReferenceType.class, null, value);
     }
 
     /**
@@ -521,7 +521,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "RetrievalMethod")
     public JAXBElement<RetrievalMethodType> createRetrievalMethod(RetrievalMethodType value) {
-        return new JAXBElement<RetrievalMethodType>(_RetrievalMethod_QNAME, RetrievalMethodType.class, null,
+        return new JAXBElement<>(_RetrievalMethod_QNAME, RetrievalMethodType.class, null,
                 value);
     }
 
@@ -530,7 +530,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DSAKeyValue")
     public JAXBElement<DSAKeyValueType> createDSAKeyValue(DSAKeyValueType value) {
-        return new JAXBElement<DSAKeyValueType>(_DSAKeyValue_QNAME, DSAKeyValueType.class, null, value);
+        return new JAXBElement<>(_DSAKeyValue_QNAME, DSAKeyValueType.class, null, value);
     }
 
     /**
@@ -538,7 +538,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DigestValue")
     public JAXBElement<byte[]> createDigestValue(byte[] value) {
-        return new JAXBElement<byte[]>(_DigestValue_QNAME, byte[].class, null, value);
+        return new JAXBElement<>(_DigestValue_QNAME, byte[].class, null, value);
     }
 
     /**
@@ -547,7 +547,7 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "CanonicalizationMethod")
     public JAXBElement<CanonicalizationMethodType> createCanonicalizationMethod(
             CanonicalizationMethodType value) {
-        return new JAXBElement<CanonicalizationMethodType>(_CanonicalizationMethod_QNAME,
+        return new JAXBElement<>(_CanonicalizationMethod_QNAME,
                 CanonicalizationMethodType.class, null, value);
     }
 
@@ -556,7 +556,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignedInfo")
     public JAXBElement<SignedInfoType> createSignedInfo(SignedInfoType value) {
-        return new JAXBElement<SignedInfoType>(_SignedInfo_QNAME, SignedInfoType.class, null, value);
+        return new JAXBElement<>(_SignedInfo_QNAME, SignedInfoType.class, null, value);
     }
 
     /**
@@ -564,7 +564,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Manifest")
     public JAXBElement<ManifestType> createManifest(ManifestType value) {
-        return new JAXBElement<ManifestType>(_Manifest_QNAME, ManifestType.class, null, value);
+        return new JAXBElement<>(_Manifest_QNAME, ManifestType.class, null, value);
     }
 
     /**
@@ -572,7 +572,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "XPath", scope = TransformType.class)
     public JAXBElement<String> createTransformTypeXPath(String value) {
-        return new JAXBElement<String>(_TransformTypeXPath_QNAME, String.class, TransformType.class, value);
+        return new JAXBElement<>(_TransformTypeXPath_QNAME, String.class, TransformType.class, value);
     }
 
     /**
@@ -580,7 +580,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509IssuerSerial", scope = X509DataType.class)
     public JAXBElement<X509IssuerSerialType> createX509DataTypeX509IssuerSerial(X509IssuerSerialType value) {
-        return new JAXBElement<X509IssuerSerialType>(_X509DataTypeX509IssuerSerial_QNAME,
+        return new JAXBElement<>(_X509DataTypeX509IssuerSerial_QNAME,
                 X509IssuerSerialType.class, X509DataType.class, value);
     }
 
@@ -589,7 +589,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509CRL", scope = X509DataType.class)
     public JAXBElement<byte[]> createX509DataTypeX509CRL(byte[] value) {
-        return new JAXBElement<byte[]>(_X509DataTypeX509CRL_QNAME, byte[].class, X509DataType.class,
+        return new JAXBElement<>(_X509DataTypeX509CRL_QNAME, byte[].class, X509DataType.class,
                 value);
     }
 
@@ -598,7 +598,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509SubjectName", scope = X509DataType.class)
     public JAXBElement<String> createX509DataTypeX509SubjectName(String value) {
-        return new JAXBElement<String>(_X509DataTypeX509SubjectName_QNAME, String.class, X509DataType.class,
+        return new JAXBElement<>(_X509DataTypeX509SubjectName_QNAME, String.class, X509DataType.class,
                 value);
     }
 
@@ -607,7 +607,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509SKI", scope = X509DataType.class)
     public JAXBElement<byte[]> createX509DataTypeX509SKI(byte[] value) {
-        return new JAXBElement<byte[]>(_X509DataTypeX509SKI_QNAME, byte[].class, X509DataType.class,
+        return new JAXBElement<>(_X509DataTypeX509SKI_QNAME, byte[].class, X509DataType.class,
                 value);
     }
 
@@ -616,7 +616,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509Certificate", scope = X509DataType.class)
     public JAXBElement<byte[]> createX509DataTypeX509Certificate(byte[] value) {
-        return new JAXBElement<byte[]>(_X509DataTypeX509Certificate_QNAME, byte[].class, X509DataType.class,
+        return new JAXBElement<>(_X509DataTypeX509Certificate_QNAME, byte[].class, X509DataType.class,
                 value);
     }
 
@@ -625,7 +625,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Link", scope = SoftwareIdentity.class)
     public JAXBElement<Link> createSoftwareIdentityLink(Link value) {
-        return new JAXBElement<Link>(_SoftwareIdentityLink_QNAME, Link.class, SoftwareIdentity.class, value);
+        return new JAXBElement<>(_SoftwareIdentityLink_QNAME, Link.class, SoftwareIdentity.class, value);
     }
 
     /**
@@ -633,7 +633,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Evidence", scope = SoftwareIdentity.class)
     public JAXBElement<Evidence> createSoftwareIdentityEvidence(Evidence value) {
-        return new JAXBElement<Evidence>(_SoftwareIdentityEvidence_QNAME, Evidence.class,
+        return new JAXBElement<>(_SoftwareIdentityEvidence_QNAME, Evidence.class,
                 SoftwareIdentity.class, value);
     }
 
@@ -642,7 +642,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Payload", scope = SoftwareIdentity.class)
     public JAXBElement<ResourceCollection> createSoftwareIdentityPayload(ResourceCollection value) {
-        return new JAXBElement<ResourceCollection>(_SoftwareIdentityPayload_QNAME, ResourceCollection.class,
+        return new JAXBElement<>(_SoftwareIdentityPayload_QNAME, ResourceCollection.class,
                 SoftwareIdentity.class, value);
     }
 
@@ -651,7 +651,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Directory", scope = ResourceCollection.class)
     public JAXBElement<FilesystemItem> createPayloadDirectory(FilesystemItem value) {
-        return new JAXBElement<FilesystemItem>(_PayloadDirectory_QNAME, FilesystemItem.class,
+        return new JAXBElement<>(_PayloadDirectory_QNAME, FilesystemItem.class,
                 ResourceCollection.class, value);
     }
 
@@ -660,7 +660,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "File", scope = ResourceCollection.class)
     public JAXBElement<FilesystemItem> createDirectoryFile(FilesystemItem value) {
-        return new JAXBElement<FilesystemItem>(_DirectoryFile_QNAME, FilesystemItem.class,
+        return new JAXBElement<>(_DirectoryFile_QNAME, FilesystemItem.class,
                 ResourceCollection.class, value);
     }
 
@@ -669,7 +669,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Entity", scope = SoftwareIdentity.class)
     public JAXBElement<Entity> createSoftwareIdentityEntity(Entity value) {
-        return new JAXBElement<Entity>(_SoftwareIdentityEntity_QNAME, Entity.class, SoftwareIdentity.class,
+        return new JAXBElement<>(_SoftwareIdentityEntity_QNAME, Entity.class, SoftwareIdentity.class,
                 value);
     }
 
@@ -678,7 +678,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Meta", scope = SoftwareIdentity.class)
     public JAXBElement<SoftwareMeta> createSoftwareIdentityMeta(SoftwareMeta value) {
-        return new JAXBElement<SoftwareMeta>(_SoftwareIdentityMeta_QNAME, SoftwareMeta.class,
+        return new JAXBElement<>(_SoftwareIdentityMeta_QNAME, SoftwareMeta.class,
                 SoftwareIdentity.class, value);
     }
 
@@ -687,7 +687,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "HMACOutputLength", scope = SignatureMethodType.class)
     public JAXBElement<BigInteger> createSignatureMethodTypeHMACOutputLength(BigInteger value) {
-        return new JAXBElement<BigInteger>(_SignatureMethodTypeHMACOutputLength_QNAME, BigInteger.class,
+        return new JAXBElement<>(_SignatureMethodTypeHMACOutputLength_QNAME, BigInteger.class,
                 SignatureMethodType.class, value);
     }
 
@@ -696,7 +696,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SPKISexp", scope = SPKIDataType.class)
     public JAXBElement<byte[]> createSPKIDataTypeSPKISexp(byte[] value) {
-        return new JAXBElement<byte[]>(_SPKIDataTypeSPKISexp_QNAME, byte[].class, SPKIDataType.class,
+        return new JAXBElement<>(_SPKIDataTypeSPKISexp_QNAME, byte[].class, SPKIDataType.class,
                 value);
     }
 
@@ -705,7 +705,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPKeyID", scope = PGPDataType.class)
     public JAXBElement<byte[]> createPGPDataTypePGPKeyID(byte[] value) {
-        return new JAXBElement<byte[]>(_PGPDataTypePGPKeyID_QNAME, byte[].class, PGPDataType.class,
+        return new JAXBElement<>(_PGPDataTypePGPKeyID_QNAME, byte[].class, PGPDataType.class,
                 value);
     }
 
@@ -714,8 +714,7 @@ public class ObjectFactory {
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPKeyPacket", scope = PGPDataType.class)
     public JAXBElement<byte[]> createPGPDataTypePGPKeyPacket(byte[] value) {
-        return new JAXBElement<byte[]>(_PGPDataTypePGPKeyPacket_QNAME, byte[].class, PGPDataType.class,
+        return new JAXBElement<>(_PGPDataTypePGPKeyPacket_QNAME, byte[].class, PGPDataType.class,
                 value);
     }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/ObjectFactory.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/ObjectFactory.java
@@ -8,83 +8,114 @@
 
 package hirs.utils.xjc;
 
-import java.math.BigInteger;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlElementDecl;
 import jakarta.xml.bind.annotation.XmlRegistry;
+
 import javax.xml.namespace.QName;
+import java.math.BigInteger;
 
 
 /**
- * This object contains factory methods for each 
- * Java content interface and Java element interface 
+ * This object contains factory methods for each
+ * Java content interface and Java element interface
  * generated in the main.java.hirs.utils.xjc package.
- * <p>An ObjectFactory allows you to programatically 
- * construct new instances of the Java representation 
- * for XML content. The Java representation of XML 
- * content can consist of schema derived interfaces 
- * and classes representing the binding of schema 
- * type definitions, element declarations and model 
- * groups.  Factory methods for each of these are 
+ * <p>An ObjectFactory allows you to programatically
+ * construct new instances of the Java representation
+ * for XML content. The Java representation of XML
+ * content can consist of schema derived interfaces
+ * and classes representing the binding of schema
+ * type definitions, element declarations and model
+ * groups.  Factory methods for each of these are
  * provided in this class.
- * 
  */
 @XmlRegistry
 public class ObjectFactory {
 
     private final static QName _SPKIData_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SPKIData");
     private final static QName _KeyInfo_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "KeyInfo");
-    private final static QName _SignatureValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureValue");
+    private final static QName _SignatureValue_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureValue");
     private final static QName _KeyValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "KeyValue");
-    private final static QName _Transforms_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Transforms");
-    private final static QName _DigestMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "DigestMethod");
+    private final static QName _Transforms_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "Transforms");
+    private final static QName _DigestMethod_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "DigestMethod");
     private final static QName _X509Data_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509Data");
-    private final static QName _SignatureProperty_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureProperty");
+    private final static QName _SignatureProperty_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureProperty");
     private final static QName _KeyName_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "KeyName");
-    private final static QName _RSAKeyValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "RSAKeyValue");
-    private final static QName _SoftwareIdentity_QNAME = new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "SoftwareIdentity");
-    private final static QName _Signature_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Signature");
+    private final static QName _RSAKeyValue_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "RSAKeyValue");
+    private final static QName _SoftwareIdentity_QNAME =
+            new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "SoftwareIdentity");
+    private final static QName _Signature_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "Signature");
     private final static QName _MgmtData_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "MgmtData");
-    private final static QName _SignatureMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureMethod");
+    private final static QName _SignatureMethod_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureMethod");
     private final static QName _Object_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Object");
-    private final static QName _SignatureProperties_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureProperties");
-    private final static QName _Transform_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Transform");
+    private final static QName _SignatureProperties_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "SignatureProperties");
+    private final static QName _Transform_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "Transform");
     private final static QName _PGPData_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "PGPData");
-    private final static QName _Reference_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Reference");
-    private final static QName _RetrievalMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "RetrievalMethod");
-    private final static QName _DSAKeyValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "DSAKeyValue");
-    private final static QName _DigestValue_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "DigestValue");
-    private final static QName _CanonicalizationMethod_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "CanonicalizationMethod");
-    private final static QName _SignedInfo_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SignedInfo");
+    private final static QName _Reference_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "Reference");
+    private final static QName _RetrievalMethod_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "RetrievalMethod");
+    private final static QName _DSAKeyValue_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "DSAKeyValue");
+    private final static QName _DigestValue_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "DigestValue");
+    private final static QName _CanonicalizationMethod_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "CanonicalizationMethod");
+    private final static QName _SignedInfo_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "SignedInfo");
     private final static QName _Manifest_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "Manifest");
-    private final static QName _TransformTypeXPath_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "XPath");
-    private final static QName _X509DataTypeX509IssuerSerial_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509IssuerSerial");
-    private final static QName _X509DataTypeX509CRL_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509CRL");
-    private final static QName _X509DataTypeX509SubjectName_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509SubjectName");
-    private final static QName _X509DataTypeX509SKI_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509SKI");
-    private final static QName _X509DataTypeX509Certificate_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "X509Certificate");
-    private final static QName _SoftwareIdentityLink_QNAME = new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Link");
-    private final static QName _SoftwareIdentityEvidence_QNAME = new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Evidence");
-    private final static QName _SoftwareIdentityPayload_QNAME = new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Payload");
-    private final static QName _PayloadDirectory_QNAME = new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Directory");
-    private final static QName _DirectoryFile_QNAME = new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "File");
-    private final static QName _SoftwareIdentityEntity_QNAME = new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Entity");
-    private final static QName _SoftwareIdentityMeta_QNAME = new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Meta");
-    private final static QName _SignatureMethodTypeHMACOutputLength_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "HMACOutputLength");
-    private final static QName _SPKIDataTypeSPKISexp_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "SPKISexp");
-    private final static QName _PGPDataTypePGPKeyID_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "PGPKeyID");
-    private final static QName _PGPDataTypePGPKeyPacket_QNAME = new QName("http://www.w3.org/2000/09/xmldsig#", "PGPKeyPacket");
+    private final static QName _TransformTypeXPath_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "XPath");
+    private final static QName _X509DataTypeX509IssuerSerial_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "X509IssuerSerial");
+    private final static QName _X509DataTypeX509CRL_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "X509CRL");
+    private final static QName _X509DataTypeX509SubjectName_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "X509SubjectName");
+    private final static QName _X509DataTypeX509SKI_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "X509SKI");
+    private final static QName _X509DataTypeX509Certificate_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "X509Certificate");
+    private final static QName _SoftwareIdentityLink_QNAME =
+            new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Link");
+    private final static QName _SoftwareIdentityEvidence_QNAME =
+            new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Evidence");
+    private final static QName _SoftwareIdentityPayload_QNAME =
+            new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Payload");
+    private final static QName _PayloadDirectory_QNAME =
+            new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Directory");
+    private final static QName _DirectoryFile_QNAME =
+            new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "File");
+    private final static QName _SoftwareIdentityEntity_QNAME =
+            new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Entity");
+    private final static QName _SoftwareIdentityMeta_QNAME =
+            new QName("http://standards.iso.org/iso/19770/-2/2015/schema.xsd", "Meta");
+    private final static QName _SignatureMethodTypeHMACOutputLength_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "HMACOutputLength");
+    private final static QName _SPKIDataTypeSPKISexp_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "SPKISexp");
+    private final static QName _PGPDataTypePGPKeyID_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "PGPKeyID");
+    private final static QName _PGPDataTypePGPKeyPacket_QNAME =
+            new QName("http://www.w3.org/2000/09/xmldsig#", "PGPKeyPacket");
 
     /**
      * Create a new ObjectFactory that can be used to create new instances of schema derived classes for package: main.java.hirs.utils.xjc
-     * 
      */
     public ObjectFactory() {
     }
 
     /**
      * Create an instance of {@link SoftwareIdentity }
-     * 
      */
     public SoftwareIdentity createSoftwareIdentity() {
         return new SoftwareIdentity();
@@ -92,7 +123,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link SoftwareMeta }
-     * 
      */
     public SoftwareMeta createSoftwareMeta() {
         return new SoftwareMeta();
@@ -100,7 +130,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Entity }
-     * 
      */
     public Entity createEntity() {
         return new Entity();
@@ -108,7 +137,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Meta }
-     * 
      */
     public Meta createMeta() {
         return new Meta();
@@ -116,7 +144,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link FilesystemItem }
-     * 
      */
     public FilesystemItem createFilesystemItem() {
         return new FilesystemItem();
@@ -124,7 +151,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Resource }
-     * 
      */
     public Resource createResource() {
         return new Resource();
@@ -132,7 +158,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Process }
-     * 
      */
     public Process createProcess() {
         return new Process();
@@ -140,7 +165,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link BaseElement }
-     * 
      */
     public BaseElement createBaseElement() {
         return new BaseElement();
@@ -148,7 +172,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Evidence }
-     * 
      */
     public Evidence createEvidence() {
         return new Evidence();
@@ -156,7 +179,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link File }
-     * 
      */
     public File createFile() {
         return new File();
@@ -164,7 +186,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Link }
-     * 
      */
     public Link createLink() {
         return new Link();
@@ -172,7 +193,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link Directory }
-     * 
      */
     public Directory createDirectory() {
         return new Directory();
@@ -180,7 +200,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link ResourceCollection }
-     * 
      */
     public ResourceCollection createResourceCollection() {
         return new ResourceCollection();
@@ -188,7 +207,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link PGPDataType }
-     * 
      */
     public PGPDataType createPGPDataType() {
         return new PGPDataType();
@@ -196,7 +214,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link KeyValueType }
-     * 
      */
     public KeyValueType createKeyValueType() {
         return new KeyValueType();
@@ -204,7 +221,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link DSAKeyValueType }
-     * 
      */
     public DSAKeyValueType createDSAKeyValueType() {
         return new DSAKeyValueType();
@@ -212,7 +228,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link ReferenceType }
-     * 
      */
     public ReferenceType createReferenceType() {
         return new ReferenceType();
@@ -220,7 +235,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RetrievalMethodType }
-     * 
      */
     public RetrievalMethodType createRetrievalMethodType() {
         return new RetrievalMethodType();
@@ -228,7 +242,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TransformsType }
-     * 
      */
     public TransformsType createTransformsType() {
         return new TransformsType();
@@ -236,7 +249,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link CanonicalizationMethodType }
-     * 
      */
     public CanonicalizationMethodType createCanonicalizationMethodType() {
         return new CanonicalizationMethodType();
@@ -244,7 +256,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link DigestMethodType }
-     * 
      */
     public DigestMethodType createDigestMethodType() {
         return new DigestMethodType();
@@ -252,7 +263,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link ManifestType }
-     * 
      */
     public ManifestType createManifestType() {
         return new ManifestType();
@@ -260,7 +270,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link SignaturePropertyType }
-     * 
      */
     public SignaturePropertyType createSignaturePropertyType() {
         return new SignaturePropertyType();
@@ -268,7 +277,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link X509DataType }
-     * 
      */
     public X509DataType createX509DataType() {
         return new X509DataType();
@@ -276,7 +284,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link SignedInfoType }
-     * 
      */
     public SignedInfoType createSignedInfoType() {
         return new SignedInfoType();
@@ -284,7 +291,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link RSAKeyValueType }
-     * 
      */
     public RSAKeyValueType createRSAKeyValueType() {
         return new RSAKeyValueType();
@@ -292,7 +298,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link SPKIDataType }
-     * 
      */
     public SPKIDataType createSPKIDataType() {
         return new SPKIDataType();
@@ -300,7 +305,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link SignatureValueType }
-     * 
      */
     public SignatureValueType createSignatureValueType() {
         return new SignatureValueType();
@@ -308,7 +312,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link KeyInfoType }
-     * 
      */
     public KeyInfoType createKeyInfoType() {
         return new KeyInfoType();
@@ -316,7 +319,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link SignatureType }
-     * 
      */
     public SignatureType createSignatureType() {
         return new SignatureType();
@@ -324,7 +326,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link SignaturePropertiesType }
-     * 
      */
     public SignaturePropertiesType createSignaturePropertiesType() {
         return new SignaturePropertiesType();
@@ -332,7 +333,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link SignatureMethodType }
-     * 
      */
     public SignatureMethodType createSignatureMethodType() {
         return new SignatureMethodType();
@@ -340,7 +340,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link ObjectType }
-     * 
      */
     public ObjectType createObjectType() {
         return new ObjectType();
@@ -348,7 +347,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link TransformType }
-     * 
      */
     public TransformType createTransformType() {
         return new TransformType();
@@ -356,7 +354,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link X509IssuerSerialType }
-     * 
      */
     public X509IssuerSerialType createX509IssuerSerialType() {
         return new X509IssuerSerialType();
@@ -364,7 +361,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link SPKIDataType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SPKIData")
     public JAXBElement<SPKIDataType> createSPKIData(SPKIDataType value) {
@@ -373,7 +369,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link KeyInfoType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyInfo")
     public JAXBElement<KeyInfoType> createKeyInfo(KeyInfoType value) {
@@ -382,16 +377,15 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link SignatureValueType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureValue")
     public JAXBElement<SignatureValueType> createSignatureValue(SignatureValueType value) {
-        return new JAXBElement<SignatureValueType>(_SignatureValue_QNAME, SignatureValueType.class, null, value);
+        return new JAXBElement<SignatureValueType>(_SignatureValue_QNAME, SignatureValueType.class, null,
+                value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link KeyValueType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyValue")
     public JAXBElement<KeyValueType> createKeyValue(KeyValueType value) {
@@ -400,7 +394,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link TransformsType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Transforms")
     public JAXBElement<TransformsType> createTransforms(TransformsType value) {
@@ -409,7 +402,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link DigestMethodType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DigestMethod")
     public JAXBElement<DigestMethodType> createDigestMethod(DigestMethodType value) {
@@ -418,7 +410,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link X509DataType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509Data")
     public JAXBElement<X509DataType> createX509Data(X509DataType value) {
@@ -427,16 +418,15 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link SignaturePropertyType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureProperty")
     public JAXBElement<SignaturePropertyType> createSignatureProperty(SignaturePropertyType value) {
-        return new JAXBElement<SignaturePropertyType>(_SignatureProperty_QNAME, SignaturePropertyType.class, null, value);
+        return new JAXBElement<SignaturePropertyType>(_SignatureProperty_QNAME, SignaturePropertyType.class,
+                null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "KeyName")
     public JAXBElement<String> createKeyName(String value) {
@@ -445,7 +435,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link RSAKeyValueType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "RSAKeyValue")
     public JAXBElement<RSAKeyValueType> createRSAKeyValue(RSAKeyValueType value) {
@@ -454,16 +443,15 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link SoftwareIdentity }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "SoftwareIdentity")
     public JAXBElement<SoftwareIdentity> createSoftwareIdentity(SoftwareIdentity value) {
-        return new JAXBElement<SoftwareIdentity>(_SoftwareIdentity_QNAME, SoftwareIdentity.class, null, value);
+        return new JAXBElement<SoftwareIdentity>(_SoftwareIdentity_QNAME, SoftwareIdentity.class, null,
+                value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link SignatureType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Signature")
     public JAXBElement<SignatureType> createSignature(SignatureType value) {
@@ -472,7 +460,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "MgmtData")
     public JAXBElement<String> createMgmtData(String value) {
@@ -481,16 +468,15 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link SignatureMethodType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureMethod")
     public JAXBElement<SignatureMethodType> createSignatureMethod(SignatureMethodType value) {
-        return new JAXBElement<SignatureMethodType>(_SignatureMethod_QNAME, SignatureMethodType.class, null, value);
+        return new JAXBElement<SignatureMethodType>(_SignatureMethod_QNAME, SignatureMethodType.class, null,
+                value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link ObjectType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Object")
     public JAXBElement<ObjectType> createObject(ObjectType value) {
@@ -499,16 +485,15 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link SignaturePropertiesType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignatureProperties")
     public JAXBElement<SignaturePropertiesType> createSignatureProperties(SignaturePropertiesType value) {
-        return new JAXBElement<SignaturePropertiesType>(_SignatureProperties_QNAME, SignaturePropertiesType.class, null, value);
+        return new JAXBElement<SignaturePropertiesType>(_SignatureProperties_QNAME,
+                SignaturePropertiesType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link TransformType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Transform")
     public JAXBElement<TransformType> createTransform(TransformType value) {
@@ -517,7 +502,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link PGPDataType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPData")
     public JAXBElement<PGPDataType> createPGPData(PGPDataType value) {
@@ -526,7 +510,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link ReferenceType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Reference")
     public JAXBElement<ReferenceType> createReference(ReferenceType value) {
@@ -535,16 +518,15 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link RetrievalMethodType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "RetrievalMethod")
     public JAXBElement<RetrievalMethodType> createRetrievalMethod(RetrievalMethodType value) {
-        return new JAXBElement<RetrievalMethodType>(_RetrievalMethod_QNAME, RetrievalMethodType.class, null, value);
+        return new JAXBElement<RetrievalMethodType>(_RetrievalMethod_QNAME, RetrievalMethodType.class, null,
+                value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link DSAKeyValueType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DSAKeyValue")
     public JAXBElement<DSAKeyValueType> createDSAKeyValue(DSAKeyValueType value) {
@@ -553,25 +535,24 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "DigestValue")
     public JAXBElement<byte[]> createDigestValue(byte[] value) {
-        return new JAXBElement<byte[]>(_DigestValue_QNAME, byte[].class, null, ((byte[]) value));
+        return new JAXBElement<byte[]>(_DigestValue_QNAME, byte[].class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link CanonicalizationMethodType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "CanonicalizationMethod")
-    public JAXBElement<CanonicalizationMethodType> createCanonicalizationMethod(CanonicalizationMethodType value) {
-        return new JAXBElement<CanonicalizationMethodType>(_CanonicalizationMethod_QNAME, CanonicalizationMethodType.class, null, value);
+    public JAXBElement<CanonicalizationMethodType> createCanonicalizationMethod(
+            CanonicalizationMethodType value) {
+        return new JAXBElement<CanonicalizationMethodType>(_CanonicalizationMethod_QNAME,
+                CanonicalizationMethodType.class, null, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link SignedInfoType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SignedInfo")
     public JAXBElement<SignedInfoType> createSignedInfo(SignedInfoType value) {
@@ -580,7 +561,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link ManifestType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "Manifest")
     public JAXBElement<ManifestType> createManifest(ManifestType value) {
@@ -589,7 +569,6 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "XPath", scope = TransformType.class)
     public JAXBElement<String> createTransformTypeXPath(String value) {
@@ -598,52 +577,51 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link X509IssuerSerialType }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509IssuerSerial", scope = X509DataType.class)
     public JAXBElement<X509IssuerSerialType> createX509DataTypeX509IssuerSerial(X509IssuerSerialType value) {
-        return new JAXBElement<X509IssuerSerialType>(_X509DataTypeX509IssuerSerial_QNAME, X509IssuerSerialType.class, X509DataType.class, value);
+        return new JAXBElement<X509IssuerSerialType>(_X509DataTypeX509IssuerSerial_QNAME,
+                X509IssuerSerialType.class, X509DataType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509CRL", scope = X509DataType.class)
     public JAXBElement<byte[]> createX509DataTypeX509CRL(byte[] value) {
-        return new JAXBElement<byte[]>(_X509DataTypeX509CRL_QNAME, byte[].class, X509DataType.class, ((byte[]) value));
+        return new JAXBElement<byte[]>(_X509DataTypeX509CRL_QNAME, byte[].class, X509DataType.class,
+                value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509SubjectName", scope = X509DataType.class)
     public JAXBElement<String> createX509DataTypeX509SubjectName(String value) {
-        return new JAXBElement<String>(_X509DataTypeX509SubjectName_QNAME, String.class, X509DataType.class, value);
+        return new JAXBElement<String>(_X509DataTypeX509SubjectName_QNAME, String.class, X509DataType.class,
+                value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509SKI", scope = X509DataType.class)
     public JAXBElement<byte[]> createX509DataTypeX509SKI(byte[] value) {
-        return new JAXBElement<byte[]>(_X509DataTypeX509SKI_QNAME, byte[].class, X509DataType.class, ((byte[]) value));
+        return new JAXBElement<byte[]>(_X509DataTypeX509SKI_QNAME, byte[].class, X509DataType.class,
+                value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "X509Certificate", scope = X509DataType.class)
     public JAXBElement<byte[]> createX509DataTypeX509Certificate(byte[] value) {
-        return new JAXBElement<byte[]>(_X509DataTypeX509Certificate_QNAME, byte[].class, X509DataType.class, ((byte[]) value));
+        return new JAXBElement<byte[]>(_X509DataTypeX509Certificate_QNAME, byte[].class, X509DataType.class,
+                value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link Link }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Link", scope = SoftwareIdentity.class)
     public JAXBElement<Link> createSoftwareIdentityLink(Link value) {
@@ -652,92 +630,92 @@ public class ObjectFactory {
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link Evidence }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Evidence", scope = SoftwareIdentity.class)
     public JAXBElement<Evidence> createSoftwareIdentityEvidence(Evidence value) {
-        return new JAXBElement<Evidence>(_SoftwareIdentityEvidence_QNAME, Evidence.class, SoftwareIdentity.class, value);
+        return new JAXBElement<Evidence>(_SoftwareIdentityEvidence_QNAME, Evidence.class,
+                SoftwareIdentity.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link ResourceCollection }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Payload", scope = SoftwareIdentity.class)
     public JAXBElement<ResourceCollection> createSoftwareIdentityPayload(ResourceCollection value) {
-        return new JAXBElement<ResourceCollection>(_SoftwareIdentityPayload_QNAME, ResourceCollection.class, SoftwareIdentity.class, value);
+        return new JAXBElement<ResourceCollection>(_SoftwareIdentityPayload_QNAME, ResourceCollection.class,
+                SoftwareIdentity.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link FilesystemItem }{@code >}}
-     *
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Directory", scope = ResourceCollection.class)
     public JAXBElement<FilesystemItem> createPayloadDirectory(FilesystemItem value) {
-        return new JAXBElement<FilesystemItem>(_PayloadDirectory_QNAME, FilesystemItem.class, ResourceCollection.class, value);
+        return new JAXBElement<FilesystemItem>(_PayloadDirectory_QNAME, FilesystemItem.class,
+                ResourceCollection.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link FilesystemItem }{@code >}}
-     *
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "File", scope = ResourceCollection.class)
     public JAXBElement<FilesystemItem> createDirectoryFile(FilesystemItem value) {
-        return new JAXBElement<FilesystemItem>(_DirectoryFile_QNAME, FilesystemItem.class, ResourceCollection.class, value);
+        return new JAXBElement<FilesystemItem>(_DirectoryFile_QNAME, FilesystemItem.class,
+                ResourceCollection.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link Entity }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Entity", scope = SoftwareIdentity.class)
     public JAXBElement<Entity> createSoftwareIdentityEntity(Entity value) {
-        return new JAXBElement<Entity>(_SoftwareIdentityEntity_QNAME, Entity.class, SoftwareIdentity.class, value);
+        return new JAXBElement<Entity>(_SoftwareIdentityEntity_QNAME, Entity.class, SoftwareIdentity.class,
+                value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link SoftwareMeta }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", name = "Meta", scope = SoftwareIdentity.class)
     public JAXBElement<SoftwareMeta> createSoftwareIdentityMeta(SoftwareMeta value) {
-        return new JAXBElement<SoftwareMeta>(_SoftwareIdentityMeta_QNAME, SoftwareMeta.class, SoftwareIdentity.class, value);
+        return new JAXBElement<SoftwareMeta>(_SoftwareIdentityMeta_QNAME, SoftwareMeta.class,
+                SoftwareIdentity.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link BigInteger }{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "HMACOutputLength", scope = SignatureMethodType.class)
     public JAXBElement<BigInteger> createSignatureMethodTypeHMACOutputLength(BigInteger value) {
-        return new JAXBElement<BigInteger>(_SignatureMethodTypeHMACOutputLength_QNAME, BigInteger.class, SignatureMethodType.class, value);
+        return new JAXBElement<BigInteger>(_SignatureMethodTypeHMACOutputLength_QNAME, BigInteger.class,
+                SignatureMethodType.class, value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "SPKISexp", scope = SPKIDataType.class)
     public JAXBElement<byte[]> createSPKIDataTypeSPKISexp(byte[] value) {
-        return new JAXBElement<byte[]>(_SPKIDataTypeSPKISexp_QNAME, byte[].class, SPKIDataType.class, ((byte[]) value));
+        return new JAXBElement<byte[]>(_SPKIDataTypeSPKISexp_QNAME, byte[].class, SPKIDataType.class,
+                value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPKeyID", scope = PGPDataType.class)
     public JAXBElement<byte[]> createPGPDataTypePGPKeyID(byte[] value) {
-        return new JAXBElement<byte[]>(_PGPDataTypePGPKeyID_QNAME, byte[].class, PGPDataType.class, ((byte[]) value));
+        return new JAXBElement<byte[]>(_PGPDataTypePGPKeyID_QNAME, byte[].class, PGPDataType.class,
+                value);
     }
 
     /**
      * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}}
-     * 
      */
     @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "PGPKeyPacket", scope = PGPDataType.class)
     public JAXBElement<byte[]> createPGPDataTypePGPKeyPacket(byte[] value) {
-        return new JAXBElement<byte[]>(_PGPDataTypePGPKeyPacket_QNAME, byte[].class, PGPDataType.class, ((byte[]) value));
+        return new JAXBElement<byte[]>(_PGPDataTypePGPKeyPacket_QNAME, byte[].class, PGPDataType.class,
+                value);
     }
 
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/ObjectType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/ObjectType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAnyElement;
@@ -20,14 +18,19 @@ import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.Getter;
+import lombok.Setter;
 import org.w3c.dom.Element;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for ObjectType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="ObjectType">
  *   &lt;complexContent>
@@ -42,52 +45,57 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ObjectType", propOrder = {
-    "content"
+        "content"
 })
 public class ObjectType {
 
     @XmlMixed
     @XmlAnyElement(lax = true)
     protected List<Object> content;
+
+    @Getter
+    @Setter
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID
     @XmlSchemaType(name = "ID")
     protected String id;
+
+    @Getter
+    @Setter
     @XmlAttribute(name = "MimeType")
     protected String mimeType;
+
+    @Getter
+    @Setter
     @XmlAttribute(name = "Encoding")
     @XmlSchemaType(name = "anyURI")
     protected String encoding;
 
     /**
      * Gets the value of the content property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the content property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getContent().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link Object }
      * {@link Element }
      * {@link String }
-     * 
-     * 
      */
     public List<Object> getContent() {
         if (content == null) {
@@ -95,77 +103,4 @@ public class ObjectType {
         }
         return this.content;
     }
-
-    /**
-     * Gets the value of the id property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Sets the value of the id property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setId(String value) {
-        this.id = value;
-    }
-
-    /**
-     * Gets the value of the mimeType property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getMimeType() {
-        return mimeType;
-    }
-
-    /**
-     * Sets the value of the mimeType property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setMimeType(String value) {
-        this.mimeType = value;
-    }
-
-    /**
-     * Gets the value of the encoding property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getEncoding() {
-        return encoding;
-    }
-
-    /**
-     * Sets the value of the encoding property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setEncoding(String value) {
-        this.encoding = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/ObjectType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/ObjectType.java
@@ -18,6 +18,7 @@ import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.w3c.dom.Element;
@@ -46,31 +47,29 @@ import java.util.List;
  * &lt;/complexType>
  * </pre>
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ObjectType", propOrder = {
         "content"
 })
 public class ObjectType {
 
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
     @XmlMixed
     @XmlAnyElement(lax = true)
     protected List<Object> content;
 
-    @Getter
-    @Setter
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID
     @XmlSchemaType(name = "ID")
     protected String id;
 
-    @Getter
-    @Setter
     @XmlAttribute(name = "MimeType")
     protected String mimeType;
 
-    @Getter
-    @Setter
     @XmlAttribute(name = "Encoding")
     @XmlSchemaType(name = "anyURI")
     protected String encoding;
@@ -99,7 +98,7 @@ public class ObjectType {
      */
     public List<Object> getContent() {
         if (content == null) {
-            content = new ArrayList<Object>();
+            content = new ArrayList<>();
         }
         return this.content;
     }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Ownership.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Ownership.java
@@ -15,7 +15,7 @@ import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for Ownership.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
  * <p>
  * <pre>
@@ -27,7 +27,6 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
- * 
  */
 @XmlType(name = "Ownership", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 @XmlEnum
@@ -35,31 +34,22 @@ public enum Ownership {
 
 
     /**
-     * 
-     *             Determines the relative strength of ownership of the target
-     *             piece of software.
-     *           
-     * 
+     * Determines the relative strength of ownership of the target
+     * piece of software.
      */
     @XmlEnumValue("abandon")
     ABANDON("abandon"),
 
     /**
-     * 
-     *             If this is uninstalled, then the [Link]'d software should be removed
-     *             too.
-     *           
-     * 
+     * If this is uninstalled, then the [Link]'d software should be removed
+     * too.
      */
     @XmlEnumValue("private")
     PRIVATE("private"),
 
     /**
-     * 
-     *             If this is uninstalled, then the [Link]'d software should be removed
-     *             if nobody else is sharing it
-     *           
-     * 
+     * If this is uninstalled, then the [Link]'d software should be removed
+     * if nobody else is sharing it
      */
     @XmlEnumValue("shared")
     SHARED("shared");
@@ -69,17 +59,17 @@ public enum Ownership {
         value = v;
     }
 
-    public String value() {
-        return value;
-    }
-
     public static Ownership fromValue(String v) {
-        for (Ownership c: Ownership.values()) {
+        for (Ownership c : Ownership.values()) {
             if (c.value.equals(v)) {
                 return c;
             }
         }
         throw new IllegalArgumentException(v);
+    }
+
+    public String value() {
+        return value;
     }
 
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/PGPDataType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/PGPDataType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -19,12 +17,15 @@ import jakarta.xml.bind.annotation.XmlElementRefs;
 import jakarta.xml.bind.annotation.XmlType;
 import org.w3c.dom.Element;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * <p>Java class for PGPDataType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="PGPDataType">
  *   &lt;complexContent>
@@ -44,56 +45,52 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "PGPDataType", propOrder = {
-    "content"
+        "content"
 })
 public class PGPDataType {
 
     @XmlElementRefs({
-        @XmlElementRef(name = "PGPKeyPacket", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "PGPKeyID", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false)
+            @XmlElementRef(name = "PGPKeyPacket", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "PGPKeyID", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false)
     })
     @XmlAnyElement(lax = true)
     protected List<Object> content;
 
     /**
-     * Gets the rest of the content model. 
-     * 
+     * Gets the rest of the content model.
+     *
      * <p>
-     * You are getting this "catch-all" property because of the following reason: 
-     * The field name "PGPKeyPacket" is used by two different parts of a schema. See: 
+     * You are getting this "catch-all" property because of the following reason:
+     * The field name "PGPKeyPacket" is used by two different parts of a schema. See:
      * line 218 of http://www.w3.org/TR/xmldsig-core/xmldsig-core-schema.xsd
      * line 213 of http://www.w3.org/TR/xmldsig-core/xmldsig-core-schema.xsd
      * <p>
-     * To get rid of this property, apply a property customization to one 
-     * of both of the following declarations to change their names: 
+     * To get rid of this property, apply a property customization to one
+     * of both of the following declarations to change their names:
      * Gets the value of the content property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the content property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getContent().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link JAXBElement }{@code <}{@link byte[]}{@code >}
      * {@link JAXBElement }{@code <}{@link byte[]}{@code >}
      * {@link Element }
      * {@link Object }
-     * 
-     * 
      */
     public List<Object> getContent() {
         if (content == null) {

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Process.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Process.java
@@ -8,18 +8,21 @@
 
 package hirs.utils.xjc;
 
-import java.math.BigInteger;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigInteger;
 
 
 /**
  * <p>Java class for Process complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="Process">
  *   &lt;complexContent>
@@ -31,66 +34,18 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Setter
+@Getter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Process", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 public class Process
-    extends Meta
-{
-
+        extends Meta {
+    
     @XmlAttribute(name = "name", required = true)
     protected String name;
+
+
     @XmlAttribute(name = "pid")
     protected BigInteger pid;
-
-    /**
-     * Gets the value of the name property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getName() {
-        return name;
-    }
-
-    /**
-     * Sets the value of the name property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setName(String value) {
-        this.name = value;
-    }
-
-    /**
-     * Gets the value of the pid property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link BigInteger }
-     *     
-     */
-    public BigInteger getPid() {
-        return pid;
-    }
-
-    /**
-     * Sets the value of the pid property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link BigInteger }
-     *     
-     */
-    public void setPid(BigInteger value) {
-        this.pid = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Process.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Process.java
@@ -35,16 +35,14 @@ import java.math.BigInteger;
  * &lt;/complexType>
  * </pre>
  */
-@Setter
 @Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Process", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 public class Process
         extends Meta {
-    
     @XmlAttribute(name = "name", required = true)
     protected String name;
-
 
     @XmlAttribute(name = "pid")
     protected BigInteger pid;

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/RSAKeyValueType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/RSAKeyValueType.java
@@ -12,13 +12,15 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
  * <p>Java class for RSAKeyValueType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="RSAKeyValueType">
  *   &lt;complexContent>
@@ -31,63 +33,19 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "RSAKeyValueType", propOrder = {
-    "modulus",
-    "exponent"
+        "modulus",
+        "exponent"
 })
 public class RSAKeyValueType {
 
     @XmlElement(name = "Modulus", required = true)
     protected byte[] modulus;
+
     @XmlElement(name = "Exponent", required = true)
     protected byte[] exponent;
-
-    /**
-     * Gets the value of the modulus property.
-     * 
-     * @return
-     *     possible object is
-     *     byte[]
-     */
-    public byte[] getModulus() {
-        return modulus;
-    }
-
-    /**
-     * Sets the value of the modulus property.
-     * 
-     * @param value
-     *     allowed object is
-     *     byte[]
-     */
-    public void setModulus(byte[] value) {
-        this.modulus = value;
-    }
-
-    /**
-     * Gets the value of the exponent property.
-     * 
-     * @return
-     *     possible object is
-     *     byte[]
-     */
-    public byte[] getExponent() {
-        return exponent;
-    }
-
-    /**
-     * Sets the value of the exponent property.
-     * 
-     * @param value
-     *     allowed object is
-     *     byte[]
-     */
-    public void setExponent(byte[] value) {
-        this.exponent = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/ReferenceType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/ReferenceType.java
@@ -17,13 +17,15 @@ import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
  * <p>Java class for ReferenceType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="ReferenceType">
  *   &lt;complexContent>
@@ -40,175 +42,37 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ReferenceType", propOrder = {
-    "transforms",
-    "digestMethod",
-    "digestValue"
+        "transforms",
+        "digestMethod",
+        "digestValue"
 })
 public class ReferenceType {
 
     @XmlElement(name = "Transforms")
     protected TransformsType transforms;
+
     @XmlElement(name = "DigestMethod", required = true)
     protected DigestMethodType digestMethod;
+
     @XmlElement(name = "DigestValue", required = true)
     protected byte[] digestValue;
+
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID
     @XmlSchemaType(name = "ID")
     protected String id;
+
     @XmlAttribute(name = "URI")
     @XmlSchemaType(name = "anyURI")
     protected String uri;
+
     @XmlAttribute(name = "Type")
     @XmlSchemaType(name = "anyURI")
     protected String type;
-
-    /**
-     * Gets the value of the transforms property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link TransformsType }
-     *     
-     */
-    public TransformsType getTransforms() {
-        return transforms;
-    }
-
-    /**
-     * Sets the value of the transforms property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link TransformsType }
-     *     
-     */
-    public void setTransforms(TransformsType value) {
-        this.transforms = value;
-    }
-
-    /**
-     * Gets the value of the digestMethod property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link DigestMethodType }
-     *     
-     */
-    public DigestMethodType getDigestMethod() {
-        return digestMethod;
-    }
-
-    /**
-     * Sets the value of the digestMethod property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link DigestMethodType }
-     *     
-     */
-    public void setDigestMethod(DigestMethodType value) {
-        this.digestMethod = value;
-    }
-
-    /**
-     * Gets the value of the digestValue property.
-     * 
-     * @return
-     *     possible object is
-     *     byte[]
-     */
-    public byte[] getDigestValue() {
-        return digestValue;
-    }
-
-    /**
-     * Sets the value of the digestValue property.
-     * 
-     * @param value
-     *     allowed object is
-     *     byte[]
-     */
-    public void setDigestValue(byte[] value) {
-        this.digestValue = value;
-    }
-
-    /**
-     * Gets the value of the id property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Sets the value of the id property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setId(String value) {
-        this.id = value;
-    }
-
-    /**
-     * Gets the value of the uri property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getURI() {
-        return uri;
-    }
-
-    /**
-     * Sets the value of the uri property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setURI(String value) {
-        this.uri = value;
-    }
-
-    /**
-     * Gets the value of the type property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * Sets the value of the type property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setType(String value) {
-        this.type = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Resource.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Resource.java
@@ -12,13 +12,15 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
  * <p>Java class for Resource complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="Resource">
  *   &lt;complexContent>
@@ -29,40 +31,14 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "Resource", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 public class Resource
-    extends Meta
-{
+        extends Meta {
 
     @XmlAttribute(name = "type", required = true)
     protected String type;
-
-    /**
-     * Gets the value of the type property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * Sets the value of the type property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setType(String value) {
-        this.type = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Resource.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Resource.java
@@ -38,7 +38,6 @@ import lombok.Setter;
 @XmlType(name = "Resource", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 public class Resource
         extends Meta {
-
     @XmlAttribute(name = "type", required = true)
     protected String type;
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/ResourceCollection.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/ResourceCollection.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
@@ -17,12 +15,15 @@ import jakarta.xml.bind.annotation.XmlElements;
 import jakarta.xml.bind.annotation.XmlSeeAlso;
 import jakarta.xml.bind.annotation.XmlType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * <p>Java class for ResourceCollection complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="ResourceCollection">
  *   &lt;complexContent>
@@ -38,52 +39,47 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "ResourceCollection", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", propOrder = {
-    "directoryOrFileOrProcess"
+        "directoryOrFileOrProcess"
 })
 @XmlSeeAlso({
-    Evidence.class
+        Evidence.class
 })
 public class ResourceCollection
-    extends BaseElement
-{
+        extends BaseElement {
 
     @XmlElements({
-        @XmlElement(name = "Directory", type = Directory.class),
-        @XmlElement(name = "File", type = File.class),
-        @XmlElement(name = "Process", type = Process.class),
-        @XmlElement(name = "Resource", type = Resource.class)
+            @XmlElement(name = "Directory", type = Directory.class),
+            @XmlElement(name = "File", type = File.class),
+            @XmlElement(name = "Process", type = Process.class),
+            @XmlElement(name = "Resource", type = Resource.class)
     })
     protected List<Meta> directoryOrFileOrProcess;
 
     /**
      * Gets the value of the directoryOrFileOrProcess property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the directoryOrFileOrProcess property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getDirectoryOrFileOrProcess().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link Directory }
      * {@link File }
      * {@link Process }
      * {@link Resource }
-     * 
-     * 
      */
     public List<Meta> getDirectoryOrFileOrProcess() {
         if (directoryOrFileOrProcess == null) {

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/RetrievalMethodType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/RetrievalMethodType.java
@@ -14,13 +14,15 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
  * <p>Java class for RetrievalMethodType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="RetrievalMethodType">
  *   &lt;complexContent>
@@ -34,94 +36,23 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "RetrievalMethodType", propOrder = {
-    "transforms"
+        "transforms"
 })
 public class RetrievalMethodType {
 
     @XmlElement(name = "Transforms")
     protected TransformsType transforms;
+
     @XmlAttribute(name = "URI")
     @XmlSchemaType(name = "anyURI")
     protected String uri;
+
     @XmlAttribute(name = "Type")
     @XmlSchemaType(name = "anyURI")
     protected String type;
-
-    /**
-     * Gets the value of the transforms property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link TransformsType }
-     *     
-     */
-    public TransformsType getTransforms() {
-        return transforms;
-    }
-
-    /**
-     * Sets the value of the transforms property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link TransformsType }
-     *     
-     */
-    public void setTransforms(TransformsType value) {
-        this.transforms = value;
-    }
-
-    /**
-     * Gets the value of the uri property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getURI() {
-        return uri;
-    }
-
-    /**
-     * Sets the value of the uri property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setURI(String value) {
-        this.uri = value;
-    }
-
-    /**
-     * Gets the value of the type property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * Sets the value of the type property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setType(String value) {
-        this.type = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SPKIDataType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SPKIDataType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -18,12 +16,15 @@ import jakarta.xml.bind.annotation.XmlElementRef;
 import jakarta.xml.bind.annotation.XmlType;
 import org.w3c.dom.Element;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * <p>Java class for SPKIDataType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="SPKIDataType">
  *   &lt;complexContent>
@@ -36,12 +37,10 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SPKIDataType", propOrder = {
-    "spkiSexpAndAny"
+        "spkiSexpAndAny"
 })
 public class SPKIDataType {
 
@@ -51,27 +50,25 @@ public class SPKIDataType {
 
     /**
      * Gets the value of the spkiSexpAndAny property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the spkiSexpAndAny property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getSPKISexpAndAny().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link JAXBElement }{@code <}{@link byte[]}{@code >}
      * {@link Object }
      * {@link Element }
-     * 
-     * 
      */
     public List<Object> getSPKISexpAndAny() {
         if (spkiSexpAndAny == null) {

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SignatureMethodType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SignatureMethodType.java
@@ -8,9 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -20,13 +17,19 @@ import jakarta.xml.bind.annotation.XmlElementRef;
 import jakarta.xml.bind.annotation.XmlMixed;
 import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for SignatureMethodType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="SignatureMethodType">
  *   &lt;complexContent>
@@ -40,12 +43,10 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SignatureMethodType", propOrder = {
-    "content"
+        "content"
 })
 public class SignatureMethodType {
 
@@ -53,33 +54,34 @@ public class SignatureMethodType {
     @XmlMixed
     @XmlAnyElement(lax = true)
     protected List<Object> content;
+
+    @Getter
+    @Setter
     @XmlAttribute(name = "Algorithm", required = true)
     @XmlSchemaType(name = "anyURI")
     protected String algorithm;
 
     /**
      * Gets the value of the content property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the content property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getContent().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link JAXBElement }{@code <}{@link BigInteger }{@code >}
      * {@link Object }
      * {@link String }
-     * 
-     * 
      */
     public List<Object> getContent() {
         if (content == null) {
@@ -87,29 +89,4 @@ public class SignatureMethodType {
         }
         return this.content;
     }
-
-    /**
-     * Gets the value of the algorithm property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getAlgorithm() {
-        return algorithm;
-    }
-
-    /**
-     * Sets the value of the algorithm property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setAlgorithm(String value) {
-        this.algorithm = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SignaturePropertiesType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SignaturePropertiesType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -19,13 +17,18 @@ import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for SignaturePropertiesType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="SignaturePropertiesType">
  *   &lt;complexContent>
@@ -38,17 +41,18 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SignaturePropertiesType", propOrder = {
-    "signatureProperty"
+        "signatureProperty"
 })
 public class SignaturePropertiesType {
 
     @XmlElement(name = "SignatureProperty", required = true)
     protected List<SignaturePropertyType> signatureProperty;
+
+    @Getter
+    @Setter
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID
@@ -57,25 +61,23 @@ public class SignaturePropertiesType {
 
     /**
      * Gets the value of the signatureProperty property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the signatureProperty property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getSignatureProperty().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link SignaturePropertyType }
-     * 
-     * 
      */
     public List<SignaturePropertyType> getSignatureProperty() {
         if (signatureProperty == null) {
@@ -83,29 +85,4 @@ public class SignaturePropertiesType {
         }
         return this.signatureProperty;
     }
-
-    /**
-     * Gets the value of the id property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Sets the value of the id property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setId(String value) {
-        this.id = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SignaturePropertyType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SignaturePropertyType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAnyElement;
@@ -20,14 +18,19 @@ import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.Getter;
+import lombok.Setter;
 import org.w3c.dom.Element;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for SignaturePropertyType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="SignaturePropertyType">
  *   &lt;complexContent>
@@ -41,21 +44,25 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SignaturePropertyType", propOrder = {
-    "content"
+        "content"
 })
 public class SignaturePropertyType {
 
     @XmlMixed
     @XmlAnyElement(lax = true)
     protected List<Object> content;
+
+    @Getter
+    @Setter
     @XmlAttribute(name = "Target", required = true)
     @XmlSchemaType(name = "anyURI")
     protected String target;
+
+    @Getter
+    @Setter
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID
@@ -64,27 +71,25 @@ public class SignaturePropertyType {
 
     /**
      * Gets the value of the content property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the content property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getContent().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link Object }
      * {@link Element }
      * {@link String }
-     * 
-     * 
      */
     public List<Object> getContent() {
         if (content == null) {
@@ -92,53 +97,4 @@ public class SignaturePropertyType {
         }
         return this.content;
     }
-
-    /**
-     * Gets the value of the target property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getTarget() {
-        return target;
-    }
-
-    /**
-     * Sets the value of the target property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setTarget(String value) {
-        this.target = value;
-    }
-
-    /**
-     * Gets the value of the id property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Sets the value of the id property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setId(String value) {
-        this.id = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SignaturePropertyType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SignaturePropertyType.java
@@ -18,6 +18,7 @@ import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.w3c.dom.Element;
@@ -45,24 +46,24 @@ import java.util.List;
  * &lt;/complexType>
  * </pre>
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SignaturePropertyType", propOrder = {
         "content"
 })
 public class SignaturePropertyType {
 
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
     @XmlMixed
     @XmlAnyElement(lax = true)
     protected List<Object> content;
 
-    @Getter
-    @Setter
     @XmlAttribute(name = "Target", required = true)
     @XmlSchemaType(name = "anyURI")
     protected String target;
 
-    @Getter
-    @Setter
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID
@@ -93,7 +94,7 @@ public class SignaturePropertyType {
      */
     public List<Object> getContent() {
         if (content == null) {
-            content = new ArrayList<Object>();
+            content = new ArrayList<>();
         }
         return this.content;
     }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SignatureType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SignatureType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -19,13 +17,19 @@ import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for SignatureType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="SignatureType">
  *   &lt;complexContent>
@@ -41,26 +45,32 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SignatureType", propOrder = {
-    "signedInfo",
-    "signatureValue",
-    "keyInfo",
-    "object"
+        "signedInfo",
+        "signatureValue",
+        "keyInfo",
+        "object"
 })
 public class SignatureType {
 
     @XmlElement(name = "SignedInfo", required = true)
     protected SignedInfoType signedInfo;
+
     @XmlElement(name = "SignatureValue", required = true)
     protected SignatureValueType signatureValue;
+    
     @XmlElement(name = "KeyInfo")
     protected KeyInfoType keyInfo;
+
+    @Setter(AccessLevel.NONE)
+    @Getter(AccessLevel.NONE)
     @XmlElement(name = "Object")
     protected List<ObjectType> object;
+
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID
@@ -68,128 +78,29 @@ public class SignatureType {
     protected String id;
 
     /**
-     * Gets the value of the signedInfo property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link SignedInfoType }
-     *     
-     */
-    public SignedInfoType getSignedInfo() {
-        return signedInfo;
-    }
-
-    /**
-     * Sets the value of the signedInfo property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link SignedInfoType }
-     *     
-     */
-    public void setSignedInfo(SignedInfoType value) {
-        this.signedInfo = value;
-    }
-
-    /**
-     * Gets the value of the signatureValue property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link SignatureValueType }
-     *     
-     */
-    public SignatureValueType getSignatureValue() {
-        return signatureValue;
-    }
-
-    /**
-     * Sets the value of the signatureValue property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link SignatureValueType }
-     *     
-     */
-    public void setSignatureValue(SignatureValueType value) {
-        this.signatureValue = value;
-    }
-
-    /**
-     * Gets the value of the keyInfo property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link KeyInfoType }
-     *     
-     */
-    public KeyInfoType getKeyInfo() {
-        return keyInfo;
-    }
-
-    /**
-     * Sets the value of the keyInfo property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link KeyInfoType }
-     *     
-     */
-    public void setKeyInfo(KeyInfoType value) {
-        this.keyInfo = value;
-    }
-
-    /**
      * Gets the value of the object property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the object property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getObject().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link ObjectType }
-     * 
-     * 
      */
     public List<ObjectType> getObject() {
         if (object == null) {
-            object = new ArrayList<ObjectType>();
+            object = new ArrayList<>();
         }
         return this.object;
     }
-
-    /**
-     * Gets the value of the id property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Sets the value of the id property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setId(String value) {
-        this.id = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SignatureValueType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SignatureValueType.java
@@ -43,10 +43,8 @@ import lombok.Setter;
         "value"
 })
 public class SignatureValueType {
-
     @XmlValue
     protected byte[] value;
-
 
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SignatureValueType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SignatureValueType.java
@@ -17,13 +17,15 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
  * <p>Java class for SignatureValueType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="SignatureValueType">
  *   &lt;simpleContent>
@@ -33,67 +35,22 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *   &lt;/simpleContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SignatureValueType", propOrder = {
-    "value"
+        "value"
 })
 public class SignatureValueType {
 
     @XmlValue
     protected byte[] value;
+
+
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID
     @XmlSchemaType(name = "ID")
     protected String id;
-
-    /**
-     * Gets the value of the value property.
-     * 
-     * @return
-     *     possible object is
-     *     byte[]
-     */
-    public byte[] getValue() {
-        return value;
-    }
-
-    /**
-     * Sets the value of the value property.
-     * 
-     * @param value
-     *     allowed object is
-     *     byte[]
-     */
-    public void setValue(byte[] value) {
-        this.value = value;
-    }
-
-    /**
-     * Gets the value of the id property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Sets the value of the id property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setId(String value) {
-        this.id = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SignedInfoType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SignedInfoType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -19,13 +17,19 @@ import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for SignedInfoType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="SignedInfoType">
  *   &lt;complexContent>
@@ -40,23 +44,28 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SignedInfoType", propOrder = {
-    "canonicalizationMethod",
-    "signatureMethod",
-    "reference"
+        "canonicalizationMethod",
+        "signatureMethod",
+        "reference"
 })
 public class SignedInfoType {
 
     @XmlElement(name = "CanonicalizationMethod", required = true)
     protected CanonicalizationMethodType canonicalizationMethod;
+
     @XmlElement(name = "SignatureMethod", required = true)
     protected SignatureMethodType signatureMethod;
+
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
     @XmlElement(name = "Reference", required = true)
     protected List<ReferenceType> reference;
+
     @XmlAttribute(name = "Id")
     @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
     @XmlID
@@ -64,104 +73,29 @@ public class SignedInfoType {
     protected String id;
 
     /**
-     * Gets the value of the canonicalizationMethod property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link CanonicalizationMethodType }
-     *     
-     */
-    public CanonicalizationMethodType getCanonicalizationMethod() {
-        return canonicalizationMethod;
-    }
-
-    /**
-     * Sets the value of the canonicalizationMethod property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link CanonicalizationMethodType }
-     *     
-     */
-    public void setCanonicalizationMethod(CanonicalizationMethodType value) {
-        this.canonicalizationMethod = value;
-    }
-
-    /**
-     * Gets the value of the signatureMethod property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link SignatureMethodType }
-     *     
-     */
-    public SignatureMethodType getSignatureMethod() {
-        return signatureMethod;
-    }
-
-    /**
-     * Sets the value of the signatureMethod property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link SignatureMethodType }
-     *     
-     */
-    public void setSignatureMethod(SignatureMethodType value) {
-        this.signatureMethod = value;
-    }
-
-    /**
      * Gets the value of the reference property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the reference property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getReference().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link ReferenceType }
-     * 
-     * 
      */
     public List<ReferenceType> getReference() {
         if (reference == null) {
-            reference = new ArrayList<ReferenceType>();
+            reference = new ArrayList<>();
         }
         return this.reference;
     }
-
-    /**
-     * Gets the value of the id property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getId() {
-        return id;
-    }
-
-    /**
-     * Sets the value of the id property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setId(String value) {
-        this.id = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SoftwareIdentity.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SoftwareIdentity.java
@@ -8,9 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -24,12 +21,16 @@ import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import org.w3c.dom.Element;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * <p>Java class for SoftwareIdentity complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="SoftwareIdentity">
  *   &lt;complexContent>
@@ -56,23 +57,20 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SoftwareIdentity", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", propOrder = {
-    "entityOrEvidenceOrLink"
+        "entityOrEvidenceOrLink"
 })
 public class SoftwareIdentity
-    extends BaseElement
-{
+        extends BaseElement {
 
     @XmlElementRefs({
-        @XmlElementRef(name = "Meta", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "Link", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "Entity", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "Payload", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "Evidence", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", type = JAXBElement.class, required = false)
+            @XmlElementRef(name = "Meta", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "Link", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "Entity", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "Payload", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "Evidence", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd", type = JAXBElement.class, required = false)
     })
     @XmlAnyElement(lax = true)
     protected List<Object> entityOrEvidenceOrLink;
@@ -99,20 +97,20 @@ public class SoftwareIdentity
 
     /**
      * Gets the value of the entityOrEvidenceOrLink property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the entityOrEvidenceOrLink property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getEntityOrEvidenceOrLink().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link JAXBElement }{@code <}{@link SoftwareMeta }{@code >}
@@ -122,8 +120,6 @@ public class SoftwareIdentity
      * {@link JAXBElement }{@code <}{@link ResourceCollection }{@code >}
      * {@link Element }
      * {@link JAXBElement }{@code <}{@link Evidence }{@code >}
-     * 
-     * 
      */
     public List<Object> getEntityOrEvidenceOrLink() {
         if (entityOrEvidenceOrLink == null) {
@@ -134,11 +130,9 @@ public class SoftwareIdentity
 
     /**
      * Gets the value of the corpus property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link Boolean }
-     *     
+     *
+     * @return possible object is
+     * {@link Boolean }
      */
     public boolean isCorpus() {
         if (corpus == null) {
@@ -150,11 +144,9 @@ public class SoftwareIdentity
 
     /**
      * Sets the value of the corpus property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link Boolean }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link Boolean }
      */
     public void setCorpus(Boolean value) {
         this.corpus = value;
@@ -162,11 +154,9 @@ public class SoftwareIdentity
 
     /**
      * Gets the value of the patch property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link Boolean }
-     *     
+     *
+     * @return possible object is
+     * {@link Boolean }
      */
     public boolean isPatch() {
         if (patch == null) {
@@ -178,11 +168,9 @@ public class SoftwareIdentity
 
     /**
      * Sets the value of the patch property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link Boolean }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link Boolean }
      */
     public void setPatch(Boolean value) {
         this.patch = value;
@@ -190,11 +178,9 @@ public class SoftwareIdentity
 
     /**
      * Gets the value of the media property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getMedia() {
         return media;
@@ -202,11 +188,9 @@ public class SoftwareIdentity
 
     /**
      * Sets the value of the media property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setMedia(String value) {
         this.media = value;
@@ -214,11 +198,9 @@ public class SoftwareIdentity
 
     /**
      * Gets the value of the name property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getName() {
         return name;
@@ -226,11 +208,9 @@ public class SoftwareIdentity
 
     /**
      * Sets the value of the name property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setName(String value) {
         this.name = value;
@@ -238,11 +218,9 @@ public class SoftwareIdentity
 
     /**
      * Gets the value of the supplemental property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link Boolean }
-     *     
+     *
+     * @return possible object is
+     * {@link Boolean }
      */
     public boolean isSupplemental() {
         if (supplemental == null) {
@@ -254,11 +232,9 @@ public class SoftwareIdentity
 
     /**
      * Sets the value of the supplemental property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link Boolean }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link Boolean }
      */
     public void setSupplemental(Boolean value) {
         this.supplemental = value;
@@ -266,11 +242,9 @@ public class SoftwareIdentity
 
     /**
      * Gets the value of the tagId property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getTagId() {
         return tagId;
@@ -278,11 +252,9 @@ public class SoftwareIdentity
 
     /**
      * Sets the value of the tagId property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setTagId(String value) {
         this.tagId = value;
@@ -290,11 +262,9 @@ public class SoftwareIdentity
 
     /**
      * Gets the value of the tagVersion property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link BigInteger }
-     *     
+     *
+     * @return possible object is
+     * {@link BigInteger }
      */
     public BigInteger getTagVersion() {
         if (tagVersion == null) {
@@ -306,11 +276,9 @@ public class SoftwareIdentity
 
     /**
      * Sets the value of the tagVersion property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link BigInteger }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link BigInteger }
      */
     public void setTagVersion(BigInteger value) {
         this.tagVersion = value;
@@ -318,11 +286,9 @@ public class SoftwareIdentity
 
     /**
      * Gets the value of the version property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getVersion() {
         if (version == null) {
@@ -334,11 +300,9 @@ public class SoftwareIdentity
 
     /**
      * Sets the value of the version property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setVersion(String value) {
         this.version = value;
@@ -346,11 +310,9 @@ public class SoftwareIdentity
 
     /**
      * Gets the value of the versionScheme property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getVersionScheme() {
         if (versionScheme == null) {
@@ -362,11 +324,9 @@ public class SoftwareIdentity
 
     /**
      * Sets the value of the versionScheme property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setVersionScheme(String value) {
         this.versionScheme = value;

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SoftwareMeta.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SoftwareMeta.java
@@ -16,9 +16,9 @@ import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for SoftwareMeta complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="SoftwareMeta">
  *   &lt;complexContent>
@@ -43,14 +43,11 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SoftwareMeta", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 public class SoftwareMeta
-    extends Meta
-{
+        extends Meta {
 
     @XmlAttribute(name = "activationStatus")
     protected String activationStatus;
@@ -85,11 +82,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the activationStatus property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getActivationStatus() {
         return activationStatus;
@@ -97,11 +92,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the activationStatus property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setActivationStatus(String value) {
         this.activationStatus = value;
@@ -109,11 +102,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the channelType property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getChannelType() {
         return channelType;
@@ -121,11 +112,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the channelType property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setChannelType(String value) {
         this.channelType = value;
@@ -133,11 +122,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the colloquialVersion property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getColloquialVersion() {
         return colloquialVersion;
@@ -145,11 +132,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the colloquialVersion property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setColloquialVersion(String value) {
         this.colloquialVersion = value;
@@ -157,11 +142,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the description property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getDescription() {
         return description;
@@ -169,11 +152,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the description property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setDescription(String value) {
         this.description = value;
@@ -181,11 +162,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the edition property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getEdition() {
         return edition;
@@ -193,11 +172,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the edition property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setEdition(String value) {
         this.edition = value;
@@ -205,11 +182,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the entitlementDataRequired property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link Boolean }
-     *     
+     *
+     * @return possible object is
+     * {@link Boolean }
      */
     public Boolean isEntitlementDataRequired() {
         return entitlementDataRequired;
@@ -217,11 +192,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the entitlementDataRequired property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link Boolean }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link Boolean }
      */
     public void setEntitlementDataRequired(Boolean value) {
         this.entitlementDataRequired = value;
@@ -229,11 +202,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the entitlementKey property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getEntitlementKey() {
         return entitlementKey;
@@ -241,11 +212,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the entitlementKey property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setEntitlementKey(String value) {
         this.entitlementKey = value;
@@ -253,11 +222,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the generator property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getGenerator() {
         return generator;
@@ -265,11 +232,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the generator property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setGenerator(String value) {
         this.generator = value;
@@ -277,11 +242,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the persistentId property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getPersistentId() {
         return persistentId;
@@ -289,11 +252,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the persistentId property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setPersistentId(String value) {
         this.persistentId = value;
@@ -301,11 +262,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the product property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getProduct() {
         return product;
@@ -313,11 +272,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the product property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setProduct(String value) {
         this.product = value;
@@ -325,11 +282,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the productFamily property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getProductFamily() {
         return productFamily;
@@ -337,11 +292,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the productFamily property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setProductFamily(String value) {
         this.productFamily = value;
@@ -349,11 +302,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the revision property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getRevision() {
         return revision;
@@ -361,11 +312,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the revision property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setRevision(String value) {
         this.revision = value;
@@ -373,11 +322,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the summary property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getSummary() {
         return summary;
@@ -385,11 +332,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the summary property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setSummary(String value) {
         this.summary = value;
@@ -397,11 +342,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the unspscCode property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getUnspscCode() {
         return unspscCode;
@@ -409,11 +352,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the unspscCode property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setUnspscCode(String value) {
         this.unspscCode = value;
@@ -421,11 +362,9 @@ public class SoftwareMeta
 
     /**
      * Gets the value of the unspscVersion property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getUnspscVersion() {
         return unspscVersion;
@@ -433,11 +372,9 @@ public class SoftwareMeta
 
     /**
      * Sets the value of the unspscVersion property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setUnspscVersion(String value) {
         this.unspscVersion = value;

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/SoftwareMeta.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/SoftwareMeta.java
@@ -12,6 +12,8 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
 
 
 /**
@@ -44,340 +46,54 @@ import jakarta.xml.bind.annotation.XmlType;
  * &lt;/complexType>
  * </pre>
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "SoftwareMeta", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 public class SoftwareMeta
         extends Meta {
-
     @XmlAttribute(name = "activationStatus")
     protected String activationStatus;
+
     @XmlAttribute(name = "channelType")
     protected String channelType;
+
     @XmlAttribute(name = "colloquialVersion")
     protected String colloquialVersion;
+
     @XmlAttribute(name = "description")
     protected String description;
+
     @XmlAttribute(name = "edition")
     protected String edition;
+
     @XmlAttribute(name = "entitlementDataRequired")
     protected Boolean entitlementDataRequired;
+
     @XmlAttribute(name = "entitlementKey")
     protected String entitlementKey;
+
     @XmlAttribute(name = "generator")
     protected String generator;
+
     @XmlAttribute(name = "persistentId")
     protected String persistentId;
+
     @XmlAttribute(name = "product")
     protected String product;
+
     @XmlAttribute(name = "productFamily")
     protected String productFamily;
+
     @XmlAttribute(name = "revision")
     protected String revision;
+
     @XmlAttribute(name = "summary")
     protected String summary;
+
     @XmlAttribute(name = "unspscCode")
     protected String unspscCode;
+
     @XmlAttribute(name = "unspscVersion")
     protected String unspscVersion;
-
-    /**
-     * Gets the value of the activationStatus property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getActivationStatus() {
-        return activationStatus;
-    }
-
-    /**
-     * Sets the value of the activationStatus property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setActivationStatus(String value) {
-        this.activationStatus = value;
-    }
-
-    /**
-     * Gets the value of the channelType property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getChannelType() {
-        return channelType;
-    }
-
-    /**
-     * Sets the value of the channelType property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setChannelType(String value) {
-        this.channelType = value;
-    }
-
-    /**
-     * Gets the value of the colloquialVersion property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getColloquialVersion() {
-        return colloquialVersion;
-    }
-
-    /**
-     * Sets the value of the colloquialVersion property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setColloquialVersion(String value) {
-        this.colloquialVersion = value;
-    }
-
-    /**
-     * Gets the value of the description property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getDescription() {
-        return description;
-    }
-
-    /**
-     * Sets the value of the description property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setDescription(String value) {
-        this.description = value;
-    }
-
-    /**
-     * Gets the value of the edition property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getEdition() {
-        return edition;
-    }
-
-    /**
-     * Sets the value of the edition property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setEdition(String value) {
-        this.edition = value;
-    }
-
-    /**
-     * Gets the value of the entitlementDataRequired property.
-     *
-     * @return possible object is
-     * {@link Boolean }
-     */
-    public Boolean isEntitlementDataRequired() {
-        return entitlementDataRequired;
-    }
-
-    /**
-     * Sets the value of the entitlementDataRequired property.
-     *
-     * @param value allowed object is
-     *              {@link Boolean }
-     */
-    public void setEntitlementDataRequired(Boolean value) {
-        this.entitlementDataRequired = value;
-    }
-
-    /**
-     * Gets the value of the entitlementKey property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getEntitlementKey() {
-        return entitlementKey;
-    }
-
-    /**
-     * Sets the value of the entitlementKey property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setEntitlementKey(String value) {
-        this.entitlementKey = value;
-    }
-
-    /**
-     * Gets the value of the generator property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getGenerator() {
-        return generator;
-    }
-
-    /**
-     * Sets the value of the generator property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setGenerator(String value) {
-        this.generator = value;
-    }
-
-    /**
-     * Gets the value of the persistentId property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getPersistentId() {
-        return persistentId;
-    }
-
-    /**
-     * Sets the value of the persistentId property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setPersistentId(String value) {
-        this.persistentId = value;
-    }
-
-    /**
-     * Gets the value of the product property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getProduct() {
-        return product;
-    }
-
-    /**
-     * Sets the value of the product property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setProduct(String value) {
-        this.product = value;
-    }
-
-    /**
-     * Gets the value of the productFamily property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getProductFamily() {
-        return productFamily;
-    }
-
-    /**
-     * Sets the value of the productFamily property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setProductFamily(String value) {
-        this.productFamily = value;
-    }
-
-    /**
-     * Gets the value of the revision property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getRevision() {
-        return revision;
-    }
-
-    /**
-     * Sets the value of the revision property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setRevision(String value) {
-        this.revision = value;
-    }
-
-    /**
-     * Gets the value of the summary property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getSummary() {
-        return summary;
-    }
-
-    /**
-     * Sets the value of the summary property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setSummary(String value) {
-        this.summary = value;
-    }
-
-    /**
-     * Gets the value of the unspscCode property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getUnspscCode() {
-        return unspscCode;
-    }
-
-    /**
-     * Sets the value of the unspscCode property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setUnspscCode(String value) {
-        this.unspscCode = value;
-    }
-
-    /**
-     * Gets the value of the unspscVersion property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getUnspscVersion() {
-        return unspscVersion;
-    }
-
-    /**
-     * Sets the value of the unspscVersion property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setUnspscVersion(String value) {
-        this.unspscVersion = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/TransformType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/TransformType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -19,14 +17,19 @@ import jakarta.xml.bind.annotation.XmlElementRef;
 import jakarta.xml.bind.annotation.XmlMixed;
 import jakarta.xml.bind.annotation.XmlSchemaType;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
 import org.w3c.dom.Element;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
  * <p>Java class for TransformType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="TransformType">
  *   &lt;complexContent>
@@ -40,12 +43,10 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "TransformType", propOrder = {
-    "content"
+        "content"
 })
 public class TransformType {
 
@@ -53,34 +54,35 @@ public class TransformType {
     @XmlMixed
     @XmlAnyElement(lax = true)
     protected List<Object> content;
+    
+    @Getter
+    @Setter
     @XmlAttribute(name = "Algorithm", required = true)
     @XmlSchemaType(name = "anyURI")
     protected String algorithm;
 
     /**
      * Gets the value of the content property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the content property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getContent().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link Element }
      * {@link String }
      * {@link JAXBElement }{@code <}{@link String }{@code >}
      * {@link Object }
-     * 
-     * 
      */
     public List<Object> getContent() {
         if (content == null) {
@@ -88,29 +90,4 @@ public class TransformType {
         }
         return this.content;
     }
-
-    /**
-     * Gets the value of the algorithm property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
-     */
-    public String getAlgorithm() {
-        return algorithm;
-    }
-
-    /**
-     * Sets the value of the algorithm property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
-     */
-    public void setAlgorithm(String value) {
-        this.algorithm = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/TransformsType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/TransformsType.java
@@ -8,19 +8,20 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * <p>Java class for TransformsType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="TransformsType">
  *   &lt;complexContent>
@@ -32,12 +33,10 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "TransformsType", propOrder = {
-    "transform"
+        "transform"
 })
 public class TransformsType {
 
@@ -46,25 +45,23 @@ public class TransformsType {
 
     /**
      * Gets the value of the transform property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the transform property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getTransform().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link TransformType }
-     * 
-     * 
      */
     public List<TransformType> getTransform() {
         if (transform == null) {

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/Use.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/Use.java
@@ -15,7 +15,7 @@ import jakarta.xml.bind.annotation.XmlType;
 
 /**
  * <p>Java class for Use.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
  * <p>
  * <pre>
@@ -27,7 +27,6 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/restriction>
  * &lt;/simpleType>
  * </pre>
- * 
  */
 @XmlType(name = "Use", namespace = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd")
 @XmlEnum
@@ -35,28 +34,19 @@ public enum Use {
 
 
     /**
-     * 
-     *             The [Link]'d software is absolutely required for installation
-     *           
-     * 
+     * The [Link]'d software is absolutely required for installation
      */
     @XmlEnumValue("required")
     REQUIRED("required"),
 
     /**
-     * 
-     *             Not absolutely required, but install unless directed not to
-     *           
-     * 
+     * Not absolutely required, but install unless directed not to
      */
     @XmlEnumValue("recommended")
     RECOMMENDED("recommended"),
 
     /**
-     * 
-     *             Not absolutely required, install only when asked
-     *           
-     * 
+     * Not absolutely required, install only when asked
      */
     @XmlEnumValue("optional")
     OPTIONAL("optional");
@@ -66,17 +56,17 @@ public enum Use {
         value = v;
     }
 
-    public String value() {
-        return value;
-    }
-
     public static Use fromValue(String v) {
-        for (Use c: Use.values()) {
+        for (Use c : Use.values()) {
             if (c.value.equals(v)) {
                 return c;
             }
         }
         throw new IllegalArgumentException(v);
+    }
+
+    public String value() {
+        return value;
     }
 
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/X509DataType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/X509DataType.java
@@ -8,8 +8,6 @@
 
 package hirs.utils.xjc;
 
-import java.util.ArrayList;
-import java.util.List;
 import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
@@ -19,12 +17,15 @@ import jakarta.xml.bind.annotation.XmlElementRefs;
 import jakarta.xml.bind.annotation.XmlType;
 import org.w3c.dom.Element;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 /**
  * <p>Java class for X509DataType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="X509DataType">
  *   &lt;complexContent>
@@ -43,41 +44,39 @@ import org.w3c.dom.Element;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "X509DataType", propOrder = {
-    "x509IssuerSerialOrX509SKIOrX509SubjectName"
+        "x509IssuerSerialOrX509SKIOrX509SubjectName"
 })
 public class X509DataType {
 
     @XmlElementRefs({
-        @XmlElementRef(name = "X509SubjectName", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "X509CRL", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "X509IssuerSerial", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "X509SKI", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
-        @XmlElementRef(name = "X509Certificate", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false)
+            @XmlElementRef(name = "X509SubjectName", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "X509CRL", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "X509IssuerSerial", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "X509SKI", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false),
+            @XmlElementRef(name = "X509Certificate", namespace = "http://www.w3.org/2000/09/xmldsig#", type = JAXBElement.class, required = false)
     })
     @XmlAnyElement(lax = true)
     protected List<Object> x509IssuerSerialOrX509SKIOrX509SubjectName;
 
     /**
      * Gets the value of the x509IssuerSerialOrX509SKIOrX509SubjectName property.
-     * 
+     *
      * <p>
      * This accessor method returns a reference to the live list,
      * not a snapshot. Therefore any modification you make to the
      * returned list will be present inside the JAXB object.
      * This is why there is not a <CODE>set</CODE> method for the x509IssuerSerialOrX509SKIOrX509SubjectName property.
-     * 
+     *
      * <p>
      * For example, to add a new item, do as follows:
      * <pre>
      *    getX509IssuerSerialOrX509SKIOrX509SubjectName().add(newItem);
      * </pre>
-     * 
-     * 
+     *
+     *
      * <p>
      * Objects of the following type(s) are allowed in the list
      * {@link JAXBElement }{@code <}{@link String }{@code >}
@@ -87,8 +86,6 @@ public class X509DataType {
      * {@link JAXBElement }{@code <}{@link byte[]}{@code >}
      * {@link Element }
      * {@link JAXBElement }{@code <}{@link byte[]}{@code >}
-     * 
-     * 
      */
     public List<Object> getX509IssuerSerialOrX509SKIOrX509SubjectName() {
         if (x509IssuerSerialOrX509SKIOrX509SubjectName == null) {

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/X509IssuerSerialType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/X509IssuerSerialType.java
@@ -8,18 +8,19 @@
 
 package hirs.utils.xjc;
 
-import java.math.BigInteger;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
 
+import java.math.BigInteger;
+
 
 /**
  * <p>Java class for X509IssuerSerialType complex type.
- * 
+ *
  * <p>The following schema fragment specifies the expected content contained within this class.
- * 
+ *
  * <pre>
  * &lt;complexType name="X509IssuerSerialType">
  *   &lt;complexContent>
@@ -32,13 +33,11 @@ import jakarta.xml.bind.annotation.XmlType;
  *   &lt;/complexContent>
  * &lt;/complexType>
  * </pre>
- * 
- * 
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "X509IssuerSerialType", propOrder = {
-    "x509IssuerName",
-    "x509SerialNumber"
+        "x509IssuerName",
+        "x509SerialNumber"
 })
 public class X509IssuerSerialType {
 
@@ -49,11 +48,9 @@ public class X509IssuerSerialType {
 
     /**
      * Gets the value of the x509IssuerName property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link String }
-     *     
+     *
+     * @return possible object is
+     * {@link String }
      */
     public String getX509IssuerName() {
         return x509IssuerName;
@@ -61,11 +58,9 @@ public class X509IssuerSerialType {
 
     /**
      * Sets the value of the x509IssuerName property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link String }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link String }
      */
     public void setX509IssuerName(String value) {
         this.x509IssuerName = value;
@@ -73,11 +68,9 @@ public class X509IssuerSerialType {
 
     /**
      * Gets the value of the x509SerialNumber property.
-     * 
-     * @return
-     *     possible object is
-     *     {@link BigInteger }
-     *     
+     *
+     * @return possible object is
+     * {@link BigInteger }
      */
     public BigInteger getX509SerialNumber() {
         return x509SerialNumber;
@@ -85,11 +78,9 @@ public class X509IssuerSerialType {
 
     /**
      * Sets the value of the x509SerialNumber property.
-     * 
-     * @param value
-     *     allowed object is
-     *     {@link BigInteger }
-     *     
+     *
+     * @param value allowed object is
+     *              {@link BigInteger }
      */
     public void setX509SerialNumber(BigInteger value) {
         this.x509SerialNumber = value;

--- a/HIRS_Utils/src/main/java/hirs/utils/xjc/X509IssuerSerialType.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/xjc/X509IssuerSerialType.java
@@ -12,6 +12,8 @@ import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.math.BigInteger;
 
@@ -34,56 +36,17 @@ import java.math.BigInteger;
  * &lt;/complexType>
  * </pre>
  */
+@Getter
+@Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlType(name = "X509IssuerSerialType", propOrder = {
         "x509IssuerName",
         "x509SerialNumber"
 })
 public class X509IssuerSerialType {
-
     @XmlElement(name = "X509IssuerName", required = true)
     protected String x509IssuerName;
+
     @XmlElement(name = "X509SerialNumber", required = true)
     protected BigInteger x509SerialNumber;
-
-    /**
-     * Gets the value of the x509IssuerName property.
-     *
-     * @return possible object is
-     * {@link String }
-     */
-    public String getX509IssuerName() {
-        return x509IssuerName;
-    }
-
-    /**
-     * Sets the value of the x509IssuerName property.
-     *
-     * @param value allowed object is
-     *              {@link String }
-     */
-    public void setX509IssuerName(String value) {
-        this.x509IssuerName = value;
-    }
-
-    /**
-     * Gets the value of the x509SerialNumber property.
-     *
-     * @return possible object is
-     * {@link BigInteger }
-     */
-    public BigInteger getX509SerialNumber() {
-        return x509SerialNumber;
-    }
-
-    /**
-     * Sets the value of the x509SerialNumber property.
-     *
-     * @param value allowed object is
-     *              {@link BigInteger }
-     */
-    public void setX509SerialNumber(BigInteger value) {
-        this.x509SerialNumber = value;
-    }
-
 }

--- a/HIRS_Utils/src/main/resources/identity_transform.xslt
+++ b/HIRS_Utils/src/main/resources/identity_transform.xslt
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-    <xsl:output indent="no" />
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+    <xsl:output indent="no"/>
     <xsl:strip-space elements="*"/>
     <xsl:template match="@*|node()">
         <xsl:copy>

--- a/HIRS_Utils/src/main/resources/swid_schema.xsd
+++ b/HIRS_Utils/src/main/resources/swid_schema.xsd
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <xs:schema
-        xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd"
-        xmlns:swid="http://standards.iso.org/iso/19770/-2/2015/schema.xsd"
-        xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
         xmlns:xs="http://www.w3.org/2001/XMLSchema"
-        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
         xmlns:xml="http://www.w3.org/XML/1998/namespace"
+        xmlns="http://standards.iso.org/iso/19770/-2/2015/schema.xsd"
 
         targetNamespace="http://standards.iso.org/iso/19770/-2/2015/schema.xsd"
         elementFormDefault="qualified">
     <xs:annotation>
         <xs:documentation>
-            This is the XML Schema for the Jakarta XML Binding binding customization descriptor. All binding customization descriptors must indicate the descriptor schema by using the Jakarta XML Binding namespace: https://jakarta.ee/xml/ns/jaxb and by indicating the version of the schema by using the version element as shown below:
-            <bindings xmlns="https://jakarta.ee/xml/ns/jaxb" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jaxb https://jakarta.ee/xml/ns/jaxb/bindingschema_3_0.xsd" version="3.0"> ... </bindings>
-            The instance documents may indicate the published version of the schema using the xsi:schemaLocation attribute for Jakarta XML Binding namespace with the following location: https://jakarta.ee/xml/ns/jaxb/bindingschema_3_0.xsd
+            This is the XML Schema for the Jakarta XML Binding binding customization descriptor. All binding
+            customization descriptors must indicate the descriptor schema by using the Jakarta XML Binding namespace:
+            https://jakarta.ee/xml/ns/jaxb and by indicating the version of the schema by using the version element as
+            shown below:
+            <bindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="https://jakarta.ee/xml/ns/jaxb"
+                      xsi:schemaLocation="https://jakarta.ee/xml/ns/jaxb https://jakarta.ee/xml/ns/jaxb/bindingschema_3_0.xsd"
+                      version="3.0">...
+            </bindings>
+            The instance documents may indicate the published version of the schema using the xsi:schemaLocation
+            attribute for Jakarta XML Binding namespace with the following location:
+            https://jakarta.ee/xml/ns/jaxb/bindingschema_3_0.xsd
         </xs:documentation>
     </xs:annotation>
     <xs:import
@@ -62,7 +67,7 @@
         </xs:annotation>
 
         <xs:attribute
-                ref="xml:lang" >
+                ref="xml:lang">
             <xs:annotation>
                 <xs:documentation>
                     Allow xml:lang attribute on any element.
@@ -125,7 +130,7 @@
                         default="http://invalid.unavailable">
                     <xs:annotation>
                         <xs:documentation>
-                            The regid of the organization.  If the regid is unknown, the
+                            The regid of the organization. If the regid is unknown, the
                             value "invalid.unavailable" is provided by default (see
                             RFC 6761 for more details on the default value).
                         </xs:documentation>
@@ -139,7 +144,7 @@
                     <xs:annotation>
                         <xs:documentation>
                             The relationship between this organization and this tag e.g. tag,
-                            softwareCreator, licensor, tagCreator, etc.  The role of
+                            softwareCreator, licensor, tagCreator, etc. The role of
                             tagCreator is required for every SWID tag.
 
                             EntityRole may include any role value, but the pre-defined roles
@@ -219,7 +224,7 @@
                     <xs:annotation>
                         <xs:documentation>
                             Files that are considered important or required for the use of
-                            a software component.  Typical key files would be those which,
+                            a software component. Typical key files would be those which,
                             if not available on a system, would cause the software not to
                             execute.
 
@@ -236,7 +241,7 @@
                     <xs:annotation>
                         <xs:documentation>
                             The directory or location where a file was found or can expected
-                            to be located.  does not include the filename itself.  This can
+                            to be located. does not include the filename itself. This can
                             be relative path from the 'root' attribute.
                         </xs:documentation>
                     </xs:annotation>
@@ -504,7 +509,7 @@
                 <xs:attribute
                         name="href"
                         type="xs:anyURI"
-                        use="required" >
+                        use="required">
                     <xs:annotation>
                         <xs:documentation>
                             The link to the item being referenced.
@@ -524,7 +529,7 @@
                             swidtags.( ie, "swid:2df9de35-0aff-4a86-ace6-f7dddd1ade4c" )
 
                             - an URI with "swidpath:" as the scheme, which refers to another
-                            swid by an XPATH query.  This URI would need to be resolved in
+                            swid by an XPATH query. This URI would need to be resolved in
                             the context of the system by software that can lookup other
                             swidtags, and select the appropriate one based on an XPATH
                             query. Examples:
@@ -664,7 +669,7 @@
                             <xs:documentation>
                                 This element is used to provide results from a scan of a
                                 system where software that does not have a SWID tag is
-                                discovered.  This information is not provided by the
+                                discovered. This information is not provided by the
                                 software creator, but is instead created when a system
                                 is being scanned and the evidence for why software is
                                 believed to be installed on the device is provided in the
@@ -685,7 +690,7 @@
                                 downloads can be found, vulnerability database associations,
                                 use rights, etc).
 
-                                Note:  This is modelled directly to match the HTML [LINK]
+                                Note: This is modelled directly to match the HTML [LINK]
                                 element; it is critical for streamlining software discovery
                                 scenarios that these are kept consistent.
                             </xs:documentation>
@@ -712,7 +717,7 @@
                         <xs:annotation>
                             <xs:documentation>
                                 The items that may be installed on a device when the software is
-                                installed.  Note that Payload may be a superset of the items
+                                installed. Note that Payload may be a superset of the items
                                 installed and, depending on optimization systems for a device,
                                 may or may not include every item that could be created or
                                 executed on a device when software is installed.
@@ -731,7 +736,7 @@
                             namespace="##other"
                             processContents="lax"
                             minOccurs="0"
-                            maxOccurs="unbounded" >
+                            maxOccurs="unbounded">
                         <xs:annotation>
                             <xs:documentation>
                                 Allows any undeclared elements in the SoftwareIdentity element
@@ -785,7 +790,7 @@
                 <xs:attribute
                         name="media"
                         type="Media"
-                        use="optional" >
+                        use="optional">
                     <xs:annotation>
                         <xs:documentation>
                             media is a hint to the tag consumer to understand what this
@@ -801,7 +806,7 @@
                     <xs:annotation>
                         <xs:documentation>
                             This attribute provides the software component name as it would
-                            typically be referenced.  For example, what would be seen in the
+                            typically be referenced. For example, what would be seen in the
                             add/remove dialog on a Windows device, or what is specified as
                             the name of a packaged software product or a patch identifier
                             name on a Linux device.
@@ -830,7 +835,7 @@
                 <xs:attribute
                         name="tagId"
                         type="xs:string"
-                        use="required" >
+                        use="required">
                     <xs:annotation>
                         <xs:documentation>
                             tagId shall be a globally unique identifier and should be
@@ -839,7 +844,7 @@
 
                             The tagID provides a unique reference for the specific product,
                             version, edition, revision, etc (essentially, the same binary
-                            distribution).  If two tagIDs match and the tagCreator is the
+                            distribution). If two tagIDs match and the tagCreator is the
                             same, the underlying products they represent are expected to be
                             exactly the same.
 
@@ -856,7 +861,7 @@
                             unique ID may be constructed, this ID should include a unique
                             naming authority for the tagCreator and sufficient additional
                             details that the tagId is unique for the software product,
-                            version, edition, revision, etc.  This would likely look as
+                            version, edition, revision, etc. This would likely look as
                             follows (+ is used as a string concatenation symbol):
 
                             regid + productName + version + edition + revision + ...
@@ -873,12 +878,12 @@
                         <xs:documentation>
                             The tagVersion indicates if a specific release of a software
                             product has more than one tag that can represent that specific
-                            release.  This may be the case if a software tag producer creates
+                            release. This may be the case if a software tag producer creates
                             and releases an incorrect tag that they subsequently want to fix,
                             but with no underlying changes to the product the SWID tag
-                            represents.  This could happen if, for example, a patch is
+                            represents. This could happen if, for example, a patch is
                             distributed that has a Link reference that does not cover all the
-                            various software releases it can patch.  A newer SWID tag for that
+                            various software releases it can patch. A newer SWID tag for that
                             patch can be generated and the tagVersion value incremented to
                             indicate that the data is updated.
                         </xs:documentation>
@@ -889,7 +894,7 @@
                         name="version"
                         type="xs:string"
                         use="optional"
-                        default="0.0" >
+                        default="0.0">
                     <xs:annotation>
                         <xs:documentation>
                             Underlying development version for the software component.
@@ -903,7 +908,7 @@
                         default="multipartnumeric">
                     <xs:annotation>
                         <xs:documentation>
-                            Scheme used for the version number.  Some possible common values are:
+                            Scheme used for the version number. Some possible common values are:
 
                             value="alphanumeric"
                             Strictly a string, sorting alphanumericaly
@@ -913,7 +918,7 @@
 
                             value="multipartnumeric"
                             Numbers seperated by dots, where the numbers are interpreted as
-                            integers (ie, 1.2.3 ,  1.4.5.6 , 1.2.3.4.5.6.7 )
+                            integers (ie, 1.2.3 , 1.4.5.6 , 1.2.3.4.5.6.7 )
 
                             value="multipartnumeric+suffix"
                             Numbers seperated by dots, where the numbers are interpreted as
@@ -940,7 +945,7 @@
                         An open-ended collection of key/value data related to this SWID.
 
                         The attributes included in this Element are predefined attributes
-                        to ensure common usage across the industry.  The schema allows for
+                        to ensure common usage across the industry. The schema allows for
                         any additional attribute to be included in a SWID tag, though it is
                         recommended that industry norms for new attributes are defined and
                         followed to the degree possible.
@@ -954,7 +959,7 @@
                     <xs:annotation>
                         <xs:documentation>
                             Identification of the activation status of this software title
-                            (e.g. Trial, Serialized, Licensed, Unlicensed, etc).  Typically,
+                            (e.g. Trial, Serialized, Licensed, Unlicensed, etc). Typically,
                             this is used in supplemental tags.
                         </xs:documentation>
                     </xs:annotation>
@@ -968,7 +973,7 @@
                         <xs:documentation>
                             Provides information on which channel this particular
                             software was targeted for (e.g. Volume, Retail, OEM,
-                            Academic, etc).  Typically used in supplemental tags.
+                            Academic, etc). Typically used in supplemental tags.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -988,7 +993,7 @@
                             Note that this representation of version is typically used to
                             identify a group of specific software releases that are part of
                             the same release/support infrastructure
-                            (i.e. Fabrikam Office 2013).  This version is used for string
+                            (i.e. Fabrikam Office 2013). This version is used for string
                             comparisons only and is not compared to be an earlier or later
                             release (that is done via the SoftwareEntity version).
                         </xs:documentation>
@@ -1001,7 +1006,7 @@
                         use="optional">
                     <xs:annotation>
                         <xs:documentation>
-                            A longer, detailed description of the software.  This description
+                            A longer, detailed description of the software. This description
                             can be multiple sentences (differentiated from summary which is
                             a very short, one-sentence description).
                         </xs:documentation>
@@ -1052,7 +1057,7 @@
                         use="optional">
                     <xs:annotation>
                         <xs:documentation>
-                            The name of the software tool that created a SWID tag.  This
+                            The name of the software tool that created a SWID tag. This
                             element is typically used if tags are created on the fly, or
                             based on a catalogue based analysis for data found on a
                             computing device.
@@ -1067,7 +1072,7 @@
                     <xs:annotation>
                         <xs:documentation>
                             A GUID used to represent products installed where the products
-                            are related, but may be different versions.  See one
+                            are related, but may be different versions. See one
                             representation of this value through the use of what, in a
                             windows installation process is referred to as an upgradeCode
                             - http://msdn.microsoft.com/en-us/library/aa372375(v=vs.85).aspx
@@ -1094,7 +1099,7 @@
                         use="optional">
                     <xs:annotation>
                         <xs:documentation>
-                            The overall product family this software belongs to.  Product
+                            The overall product family this software belongs to. Product
                             family is not used to identify that a product is part of a
                             suite, but is instead used when a set of products that are all
                             related may be installed on multiple different devices.
@@ -1102,7 +1107,7 @@
                             For example, an Enterprise backup system may consist of a backup
                             server, multiple different backup systems that support mail
                             servers, databases and ERP systems as well as individual software
-                            items that backup client devices.  In this case all software
+                            items that backup client devices. In this case all software
                             titles that are part of the backup system would have the same
                             productFamily name so they can be grouped together in reporting
                             systems.
@@ -1117,7 +1122,7 @@
                     <xs:annotation>
                         <xs:documentation>
                             The informal or colloquial representation of the sub-version of
-                            the given product (ie, SP1, R2, RC1, Beta 2, etc).  Note that the
+                            the given product (ie, SP1, R2, RC1, Beta 2, etc). Note that the
                             SoftwareIdentity.version will provide very exact version details,
                             the revision is intended for use in environments where reporting
                             on the informal or colloquial representation of the software is
@@ -1152,7 +1157,7 @@
                     <xs:annotation>
                         <xs:documentation>
                             An 8 digit code that provides UNSPSC classification of the
-                            software product this SWID tag identifies.  For more
+                            software product this SWID tag identifies. For more
                             information see, http://www.unspsc.org/
                         </xs:documentation>
                     </xs:annotation>
@@ -1217,8 +1222,8 @@
                 architecture
 
                 PREFIX is defined as one of:
-                MIN    # property has a minimum value of VALUE
-                MAX    # property has a maximum value of VALUE
+                MIN # property has a minimum value of VALUE
+                MAX # property has a maximum value of VALUE
 
                 if a PREFIX is not provided, then the property should equal VALUE
 

--- a/HIRS_Utils/src/test/java/hirs/data/persist/PolicyTest.java
+++ b/HIRS_Utils/src/test/java/hirs/data/persist/PolicyTest.java
@@ -1,12 +1,10 @@
 package hirs.data.persist;
 
 import hirs.attestationca.persist.entity.Policy;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * <code>PolicyTest</code> is a unit test class for the <code>Policy</code>

--- a/HIRS_Utils/src/test/java/hirs/data/persist/TestPolicy.java
+++ b/HIRS_Utils/src/test/java/hirs/data/persist/TestPolicy.java
@@ -21,7 +21,7 @@ public class TestPolicy extends Policy {
     /**
      * Creates a new <code>TestPolicy</code> with the set name and description.
      *
-     * @param name name
+     * @param name        name
      * @param description description
      */
     public TestPolicy(final String name, final String description) {

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -109,10 +109,7 @@
 
         <!-- Checks for Naming Conventions.                  -->
         <!-- See https://checkstyle.org/checks/naming/index.html -->
-        <module name="ConstantName">
-            <property name="format"
-                      value="[A-Z_][A-Z0-9]*(_[A-Z0-9]+)*$"/>
-        </module>
+        <module name="ConstantName"/>
         <module name="LocalFinalVariableName"/>
         <module name="LocalVariableName"/>
         <module name="MemberName"/>


### PR DESCRIPTION
### Description
I recently modified one of the modules in checkstyles.xml to ignore checks for Java constants that begin with an underscore. However, after further research and discussions with my colleagues, I believe we should revert this rule and instead update the Java constants to align with recommended Java guidelines. This change will help maintain code consistency and adherence to best practices. Apply the new changes to the entire HIRS_UTILS module.

### Other Changes You Might Have Noticed:
Asides from undoing one of the checkstyle modules in the checkstyles.xml file, I also "lombok-ed" a lot of java files in the UTILS files and a good portion of the files in the HIRS_UTILS module were formatted according to checkstyles guidelines. 

### Test Instructions:
1. Run `./gradlew clean HIRS_UTILS:check --rerun-tasks` in your terminal window to verify there are no checkstyle errors.
2. Run `./gradlew clean build --rerun-tasks` in your terminal window to verify there are no build errors.
3. Go to the SwidTagsConstants.java file and verify none of the constants start with an underscore.
