### PR TITLE
[#848] Rename properties and methods of firmware validation objects

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
@@ -350,7 +350,7 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                 dv.getHw().getProductName());
         BaseReferenceManifest baseRim = null;
         SupportReferenceManifest supportRim = null;
-        EventLogMeasurements measurements;
+        EventLogMeasurements integrityMeasurements;
         boolean isReplacement = false;
         String replacementRimId = "";
         String tagId = "";
@@ -542,30 +542,30 @@ public class IdentityClaimProcessor extends AbstractProcessor {
             fileName = String.format("%s.measurement",
                     dv.getNw().getHostname());
             try {
-                EventLogMeasurements temp = new EventLogMeasurements(fileName,
+                EventLogMeasurements deviceLiveLog = new EventLogMeasurements(fileName,
                         dv.getLivelog().toByteArray());
                 // find previous version.
-                measurements = referenceManifestRepository
+                integrityMeasurements = referenceManifestRepository
                         .byMeasurementDeviceName(dv.getNw().getHostname());
 
-                if (measurements != null) {
+                if (integrityMeasurements != null) {
                     // Find previous log and delete it
-                    referenceManifestRepository.delete(measurements);
+                    referenceManifestRepository.delete(integrityMeasurements);
                 }
 
                 List<BaseReferenceManifest> baseRims = referenceManifestRepository
                         .getBaseByManufacturerModel(dv.getHw().getManufacturer(),
                                 dv.getHw().getProductName());
-                measurements = temp;
-                measurements.setPlatformManufacturer(dv.getHw().getManufacturer());
-                measurements.setPlatformModel(dv.getHw().getProductName());
+                integrityMeasurements = deviceLiveLog;
+                integrityMeasurements.setPlatformManufacturer(dv.getHw().getManufacturer());
+                integrityMeasurements.setPlatformModel(dv.getHw().getProductName());
                 if (tagId != null && !tagId.trim().isEmpty()) {
-                    measurements.setTagId(tagId);
+                    integrityMeasurements.setTagId(tagId);
                 }
-                measurements.setDeviceName(dv.getNw().getHostname());
-                measurements.archive();
+                integrityMeasurements.setDeviceName(dv.getNw().getHostname());
+                integrityMeasurements.archive();
 
-                this.referenceManifestRepository.save(measurements);
+                this.referenceManifestRepository.save(integrityMeasurements);
 
                 for (BaseReferenceManifest bRim : baseRims) {
                     if (bRim != null) {
@@ -573,8 +573,8 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                         // event log hash for use during provision
                         SupportReferenceManifest sBaseRim = referenceManifestRepository
                                 .getSupportRimEntityById(bRim.getAssociatedRim());
-                        bRim.setEventLogHash(temp.getHexDecHash());
-                        sBaseRim.setEventLogHash(temp.getHexDecHash());
+                        bRim.setEventLogHash(deviceLiveLog.getHexDecHash());
+                        sBaseRim.setEventLogHash(deviceLiveLog.getHexDecHash());
                         referenceManifestRepository.save(bRim);
                         referenceManifestRepository.save(sBaseRim);
                     }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
@@ -206,10 +206,10 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
             }
 
             if (passed) {
-                TCGEventLog logProcessor;
+                TCGEventLog expectedEventLog;
                 try {
-                    logProcessor = new TCGEventLog(supportReferenceManifest.getRimBytes());
-                    baseline = logProcessor.getExpectedPCRValues();
+                    expectedEventLog = new TCGEventLog(supportReferenceManifest.getRimBytes());
+                    baseline = expectedEventLog.getExpectedPCRValues();
                 } catch (CertificateException cEx) {
                     log.error(cEx);
                 } catch (NoSuchAlgorithmException noSaEx) {
@@ -242,21 +242,21 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
                         // part 2 of firmware validation check: bios measurements
                         // vs baseline tcg event log
                         // find the measurement
-                        TCGEventLog eventLog;
+                        TCGEventLog actualEventLog;
                         LinkedList<TpmPcrEvent> failedPcrValues = new LinkedList<>();
-                        List<ReferenceDigestValue> eventValue;
-                        HashMap<String, ReferenceDigestValue> eventValueMap = new HashMap<>();
+                        List<ReferenceDigestValue> rimIntegrityMeasurements;
+                        HashMap<String, ReferenceDigestValue> expectedEventLogRecords = new HashMap<>();
                         try {
                             if (measurement.getDeviceName().equals(hostName)) {
-                                eventLog = new TCGEventLog(measurement.getRimBytes());
-                                eventValue = referenceDigestValueRepository
+                                actualEventLog = new TCGEventLog(measurement.getRimBytes());
+                                rimIntegrityMeasurements = referenceDigestValueRepository
                                         .findValuesByBaseRimId(baseReferenceManifest.getId());
-                                for (ReferenceDigestValue rdv : eventValue) {
-                                    eventValueMap.put(rdv.getDigestValue(), rdv);
+                                for (ReferenceDigestValue rdv : rimIntegrityMeasurements) {
+                                    expectedEventLogRecords.put(rdv.getDigestValue(), rdv);
                                 }
 
                                 failedPcrValues.addAll(pcrValidator.validateTpmEvents(
-                                        eventLog, eventValueMap, policySettings));
+                                        actualEventLog, expectedEventLogRecords, policySettings));
                             }
                         } catch (CertificateException cEx) {
                             log.error(cEx);


### PR DESCRIPTION
The following identifiers have been refactored as of the first push:

IdentityClaimProcessor
- dbBaseRim -> baseRim
- support -> supportRim
- measurements -> integrityMeasurements
- sourcedValues -> expectedValues
- logProcessor -> eventLog

FirmwareScvValidator
- tcgMeasurementLog -> eventLog
- tpmPcrEvents -> failedPcrValues


Testing entails running a firmware provision as usual to make sure these name changes do not cause any logic differences.  The new names should be reviewed against the tcg documentation for accuracy.

Closes #848