### PR TITLE
Add Component Class Registries to the Provisioner

### DIFF
--- a/HIRS_Provisioner.NET/hirs/Directory.Build.targets
+++ b/HIRS_Provisioner.NET/hirs/Directory.Build.targets
@@ -36,10 +36,11 @@
     <ItemGroup>
       <PaccorScriptsDll Include="$(OUTDIR)paccor_scripts.dll"/>
       <PaccorPcieDll Include="$(OUTDIR)Pcie.dll"/>
+      <PaccorSmbiosDll Include="$(OUTDIR)Smbios.dll"/>
       <PaccorStorageDll Include="$(OUTDIR)Storage.dll"/>
     </ItemGroup>
     <Copy
-      SourceFiles="@(PaccorScriptsDll);@(PaccorPcieDll);@(PaccorStorageDll)"
+      SourceFiles="@(PaccorScriptsDll);@(PaccorPcieDll);@(PaccorSmbiosDll);@(PaccorStorageDll)"
       DestinationFolder="$(PublishDir)plugins"
     />
   </Target>

--- a/HIRS_Provisioner.NET/hirs/Directory.Build.targets
+++ b/HIRS_Provisioner.NET/hirs/Directory.Build.targets
@@ -35,9 +35,11 @@
   <Target Name="CopyFiles" AfterTargets="DeletePDB">
     <ItemGroup>
       <PaccorScriptsDll Include="$(OUTDIR)paccor_scripts.dll"/>
+      <PaccorPcieDll Include="$(OUTDIR)Pcie.dll"/>
+      <PaccorStorageDll Include="$(OUTDIR)Storage.dll"/>
     </ItemGroup>
     <Copy
-      SourceFiles="@(PaccorScriptsDll)"
+      SourceFiles="@(PaccorScriptsDll);@(PaccorPcieDll);@(PaccorStorageDll)"
       DestinationFolder="$(PublishDir)plugins"
     />
   </Target>

--- a/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
+++ b/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="paccor.HardwareManifestPluginManager" Version="2.0.5" />
     <PackageReference Include="paccor.paccor_scripts" Version="2.0.5" />
     <PackageReference Include="paccor.pcie" Version="0.5.0" />
+    <PackageReference Include="paccor.smbios" Version="0.5.0" />
     <PackageReference Include="paccor.storage" Version="0.5.0" />
     <PackageReference Include="Packaging.Targets" Version="0.1.226">
       <PrivateAssets>all</PrivateAssets> <!-- These assets will be consumed but won't flow to the parent project -->
@@ -46,7 +47,7 @@
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="System.Management" Version="6.0.0" />
+    <PackageReference Include="System.Management" Version="8.0.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageReference Include="WiX" Version="3.14.1">
         <PrivateAssets>all</PrivateAssets> <!-- These assets will be consumed but won't flow to the parent project -->

--- a/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
+++ b/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
@@ -6,9 +6,10 @@
     <RuntimeIdentifiers>linux-x64;win-x64</RuntimeIdentifiers>
     <StartupObject>hirs.Program</StartupObject>
     <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageVersion>3.0.1</PackageVersion>
+    <PackageVersion>3.0.5</PackageVersion>
     <Release></Release> 
 </PropertyGroup>
 
@@ -24,22 +25,24 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Google.Protobuf" Version="3.20.1" />
-    <PackageReference Include="Google.Protobuf.Tools" Version="3.20.1">
+    <PackageReference Include="Google.Protobuf" Version="3.28.3" />
+    <PackageReference Include="Google.Protobuf.Tools" Version="3.28.3">
         <PrivateAssets>all</PrivateAssets> <!-- These assets will be consumed but won't flow to the parent project -->
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.TSS" Version="2.1.1" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="paccor.HardwareManifestPlugin" Version="1.0.0" />
-    <PackageReference Include="paccor.HardwareManifestPluginManager" Version="1.0.0" />
-    <PackageReference Include="paccor.paccor_scripts" Version="1.0.1" />
+    <PackageReference Include="paccor.HardwareManifestPlugin" Version="2.0.5" />
+    <PackageReference Include="paccor.HardwareManifestPluginManager" Version="2.0.5" />
+    <PackageReference Include="paccor.paccor_scripts" Version="2.0.5" />
+    <PackageReference Include="paccor.pcie" Version="0.5.0" />
+    <PackageReference Include="paccor.storage" Version="0.5.0" />
     <PackageReference Include="Packaging.Targets" Version="0.1.226">
       <PrivateAssets>all</PrivateAssets> <!-- These assets will be consumed but won't flow to the parent project -->
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog" Version="2.11.0" />
+    <PackageReference Include="Serilog" Version="4.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
@@ -81,7 +84,7 @@
     <Exec Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))'" Command="for /f %%i in ('dir /s /b $(FOLDER_PROTO)\*.proto') do (  $(protoc) -I=$(FOLDER_PROTO) --csharp_out=$(FOLDER_OUT) %%i )" />
     <Exec Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'" Command="for file in `ls -1R $(FOLDER_PROTO)/*.proto` ; do $(protoc) -I=$(FOLDER_PROTO) --csharp_out=$(FOLDER_OUT) $file; done " />
   </Target>
-  <Import Project="$(NuGetPackageRoot)paccor.paccor_scripts/1.0.1/contentFiles/any/net6.0/resources/paccor.paccor_scripts.targets" Condition="Exists('$(NuGetPackageRoot)paccor.paccor_scripts/1.0.1/contentFiles/any/net6.0/resources/paccor.paccor_scripts.targets')" />
+  <Import Project="$(NuGetPackageRoot)paccor.paccor_scripts/2.0.5/contentFiles/any/net8.0/resources/paccor.paccor_scripts.targets" Condition="Exists('$(NuGetPackageRoot)paccor.paccor_scripts/2.0.5/contentFiles/any/net8.0/resources/paccor.paccor_scripts.targets')" />
   <Target Name="ImportPaccorScripts" BeforeTargets="PreBuildEvent">
     <ItemGroup>
       <PaccorScriptsLinux Include="$(dotnet_paccor_scripts_directory)/*" />

--- a/HIRS_Provisioner.NET/hirs/appsettings.json
+++ b/HIRS_Provisioner.NET/hirs/appsettings.json
@@ -5,7 +5,7 @@
   "certificate_output_directory": "",
   "paccor_output_file": "",
   "event_log_file":  "",
-  "hardware_manifest_collectors": "paccor_scripts",
+  "hardware_manifest_collectors": "paccor_scripts,paccor.pcie,paccor.storage",
 
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],

--- a/HIRS_Provisioner.NET/hirs/appsettings.json
+++ b/HIRS_Provisioner.NET/hirs/appsettings.json
@@ -5,7 +5,7 @@
   "certificate_output_directory": "",
   "paccor_output_file": "",
   "event_log_file":  "",
-  "hardware_manifest_collectors": "paccor_scripts,paccor.pcie,paccor.storage",
+  "hardware_manifest_collectors": "paccor_scripts,paccor.pcie,paccor.smbios,paccor.storage",
 
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],

--- a/HIRS_Provisioner.NET/hirs/src/provisioner/Provisioner.cs
+++ b/HIRS_Provisioner.NET/hirs/src/provisioner/Provisioner.cs
@@ -3,6 +3,7 @@ using Hirs.Pb;
 using Serilog;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;

--- a/HIRS_Provisioner.NET/hirs/src/tpm/CommandTpm.cs
+++ b/HIRS_Provisioner.NET/hirs/src/tpm/CommandTpm.cs
@@ -30,14 +30,14 @@ namespace hirs {
         
         private readonly Tpm2 tpm;
 
-        private readonly Boolean simulator;
+        private readonly bool simulator;
 
         private List<AuthSession> sessionTracking = new List<AuthSession>();
 
         /**
          * For TCP TpmDevices
          */
-        public CommandTpm(Boolean sim, string ip, int port) {
+        public CommandTpm(bool sim, string ip, int port) {
             simulator = sim;
             Tpm2Device tpmDevice = new TcpTpmDevice(ip, port);
             tpm = TpmSetupByType(tpmDevice);


### PR DESCRIPTION
This PR extends the component information collection of the .NET Provisioner.

The provisioner will still collect component identifier data using paccor's scripts.

It will also collect component identifier data from specific protocols as specified in the following documents published by the TCG:

| Protocol | Document | 
| ----- | ----- |
| SMBIOS | [SMBIOS-based Component Class Registry](https://trustedcomputinggroup.org/wp-content/uploads/SMBIOS-Component-Class-Registry_v1.01_finalpublication.pdf) |
| PCIe | [PCIe-based Component Class Registry](https://trustedcomputinggroup.org/wp-content/uploads/TCG_PCIe_Component_Class_Registry_v1_r18_pub10272021.pdf) | 
| NVMe<br/>WIP:<br/>ATA<br/>SCSI | [Storage Component Class Registry](https://trustedcomputinggroup.org/wp-content/uploads/Storage-Component-Class-Registry-Version-1.0-Revision-22_pub.pdf) |

Support for using this new component information in the ACA is coming.