### PR TITLE
Updated to upload-artifact@v4

### DIFF
--- a/.github/workflows/dotnet_provisioner_unit_tests.yml
+++ b/.github/workflows/dotnet_provisioner_unit_tests.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           mkdir artifacts
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/.github/workflows/hirs_unit_tests.yml
+++ b/.github/workflows/hirs_unit_tests.yml
@@ -84,7 +84,7 @@ jobs:
           fi; popd;'
     # Upload build report files
     - name: Archive report files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: HIRS_Build_Reports
         path: artifacts/upload_reports/*


### PR DESCRIPTION
CI builds are failing because upload-artifact v3 is deprecated; upated to v4.