### PR TITLE
[#901] HIRS Application Log File Is Empty/Not Found In Correct Directory

### DIFF
--- a/HIRS_AttestationCA/build.gradle
+++ b/HIRS_AttestationCA/build.gradle
@@ -4,6 +4,9 @@ plugins {
 }
 
 configurations {
+    all {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -38,9 +41,6 @@ dependencies {
     // explicitly include the patched version of the spring framework webmvc dependency
     implementation libs.spring.framework.webmvc
 
-    // explicitly include the patched version of the logback-core dependency
-    implementation libs.logback.classic
-
     compileOnly libs.lombok
     annotationProcessor libs.lombok
 
@@ -48,12 +48,7 @@ dependencies {
     annotationProcessor libs.spotbugs.annotations
 
     testImplementation libs.commons.io
-
-    // explicitly include the patched version of the logback-core dependency
-    testImplementation libs.logback.classic
-
     testImplementation libs.spring.boot.starter.test
-
 
     testCompileOnly libs.lombok
     testAnnotationProcessor libs.lombok

--- a/HIRS_AttestationCAPortal/build.gradle
+++ b/HIRS_AttestationCAPortal/build.gradle
@@ -19,10 +19,12 @@ bootRun {
 }
 
 configurations {
+    all {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
     compileOnly {
         extendsFrom annotationProcessor
     }
-    all*.exclude module: 'spring-boot-starter-logging'
 }
 
 dependencies {

--- a/HIRS_Structs/build.gradle
+++ b/HIRS_Structs/build.gradle
@@ -1,3 +1,9 @@
+configurations {
+    all {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
+}
+
 dependencies {
     implementation libs.commons.lang3
 
@@ -5,9 +11,6 @@ dependencies {
     annotationProcessor libs.lombok
 
     testImplementation libs.spring.boot.starter.test
-
-    // explicitly include the patched version of the logback-core dependency
-    testImplementation libs.logback.classic
 
     testCompileOnly libs.lombok
     testAnnotationProcessor libs.lombok

--- a/HIRS_Utils/build.gradle
+++ b/HIRS_Utils/build.gradle
@@ -4,6 +4,9 @@ def jarVersion = properties.get("jarVersion")
 //println "packageVersion is ${projVersion}"
 
 configurations {
+    all {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -32,9 +35,6 @@ dependencies {
     annotationProcessor libs.lombok
 
     testImplementation libs.spring.boot.starter.test
-
-    // explicitly include the patched version of the logback-core dependency
-    testImplementation libs.logback.classic
 
     testImplementation project(path: ':HIRS_AttestationCA')
 

--- a/gradle/versions.toml
+++ b/gradle/versions.toml
@@ -14,7 +14,6 @@ jakartaServletVersion = "3.0.0"
 jakartaXmlVersion = "4.0.2"
 jcommanderVersion = "2.0"
 lombokVersion = "1.18.36"
-logbackClassicVersion = "1.5.13"
 mariadbVersion = "3.5.1"
 minimalJsonVersion = "0.9.5"
 ospackageVersion = "11.2.0"
@@ -48,7 +47,6 @@ jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-ap
 jakarta-servlet = { module = "org.glassfish.web:jakarta.servlet.jsp.jstl", version.ref = "jakartaServletVersion" }
 jakarta-xml = { module = "jakarta.xml.bind:jakarta.xml.bind-api", version.ref = "jakartaXmlVersion" }
 jcommander = { module = "org.jcommander:jcommander", version.ref = "jcommanderVersion" }
-logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logbackClassicVersion" }
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombokVersion" }
 mariadb-java-client = { module = "org.mariadb.jdbc:mariadb-java-client", version.ref = "mariadbVersion" }
 minimal-json = { module = "com.eclipsesource.minimal-json:minimal-json", version.ref = "minimalJsonVersion" }

--- a/tools/tcg_rim_tool/build.gradle
+++ b/tools/tcg_rim_tool/build.gradle
@@ -7,6 +7,12 @@ plugins {
 def packVersion = properties.get("packageVersion");
 def jarVersion = properties.get("jarVersion");
 
+configurations {
+    all {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
+}
+
 dependencies {
     implementation project(':HIRS_Utils')
 
@@ -21,7 +27,6 @@ dependencies {
     implementation libs.jakarta.xml
     implementation libs.spring.boot.starter.log4j2
     implementation libs.spring.boot.starter.data.jpa
-    implementation libs.logback.classic
 
     compileOnly libs.lombok
     annotationProcessor libs.lombok


### PR DESCRIPTION
### Description
We found out recently that the HIRS log file is not only not recording any activities that are occurring in the application but that it is located in a completely directory.

### Test Instructions:
1. Run the application either by creating an RPM/Debian file or using the setup scripts located in the package/linux/aca folder.

2. You can upload a bunch of PEM/CER files to the pages that allow you to upload certificates (such as the Trust Chain Management page) or even the Platform Certificate page and run the `sudo tpm_aca_provision` command. Pretty much try to perform some basic activities on the application

3. Go to the `/var/log/hirs `directory and verify that the `HIRS_AttestationCA_Portal.log` log file is there and open it up in your favorite code editor.

4. Verify that all the activities that you performed on the application has been recorded to the log file.

### Issues this PR addresses:
Closes https://github.com/nsacyber/HIRS/issues/901