### PR TITLE
Take only first cert in multi part PEM

### DIFF
--- a/.github/workflows/dotnet_provisioner_unit_tests.yml
+++ b/.github/workflows/dotnet_provisioner_unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - os: windows-2022
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
           # - os: windows-2019 Cannot Target windows-2019 because the .NET 6 SDK won't receive security patches for this image
     steps:
       - name: Set git to use LF

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/CredentialHelper.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/CredentialHelper.java
@@ -58,9 +58,15 @@ public final class CredentialHelper {
     public static byte[] stripPemHeaderFooter(final String pemFile) {
         String strippedFile;
         strippedFile = pemFile.replace(CertificateVariables.PEM_HEADER, "");
-        strippedFile = strippedFile.substring(0, strippedFile.indexOf(CertificateVariables.PEM_FOOTER));
+        int keyFooterPos = strippedFile.indexOf(CertificateVariables.PEM_FOOTER);
+        if (keyFooterPos >= 0) {
+            strippedFile = strippedFile.substring(0, keyFooterPos);
+        }
         strippedFile = strippedFile.replace(CertificateVariables.PEM_ATTRIBUTE_HEADER, "");
-        strippedFile = strippedFile.substring(0, strippedFile.indexOf(CertificateVariables.PEM_ATTRIBUTE_FOOTER));
+        int attrFooterPos = strippedFile.indexOf(CertificateVariables.PEM_ATTRIBUTE_FOOTER);
+        if (attrFooterPos >= 0) {
+            strippedFile = strippedFile.substring(0, attrFooterPos);
+        }
         return Base64.decode(strippedFile);
     }
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/CredentialHelper.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/CredentialHelper.java
@@ -58,9 +58,9 @@ public final class CredentialHelper {
     public static byte[] stripPemHeaderFooter(final String pemFile) {
         String strippedFile;
         strippedFile = pemFile.replace(CertificateVariables.PEM_HEADER, "");
-        strippedFile = strippedFile.replace(CertificateVariables.PEM_FOOTER, "");
+        strippedFile = strippedFile.substring(0, strippedFile.indexOf(CertificateVariables.PEM_FOOTER));
         strippedFile = strippedFile.replace(CertificateVariables.PEM_ATTRIBUTE_HEADER, "");
-        strippedFile = strippedFile.replace(CertificateVariables.PEM_ATTRIBUTE_FOOTER, "");
+        strippedFile = strippedFile.substring(0, strippedFile.indexOf(CertificateVariables.PEM_ATTRIBUTE_FOOTER));
         return Base64.decode(strippedFile);
     }
 


### PR DESCRIPTION
This change should tell the ACA to take only the first certificate in a PEM file.

Also saw GitHub Actions was removing the ubuntu 20 runner. Pointed one of the workflows to a newer runner.