### PR TITLE
[#821] HIRS Attestation ACA  Should Download ACA Certificate chain

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/RestfulAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/RestfulAttestationCertificateAuthority.java
@@ -12,6 +12,7 @@ import hirs.attestationca.persist.entity.manager.TPM2ProvisionerStateRepository;
 import hirs.attestationca.persist.service.SupplyChainValidationService;
 import hirs.structs.converters.StructConverter;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
@@ -64,7 +65,7 @@ public class RestfulAttestationCertificateAuthority extends AttestationCertifica
     public RestfulAttestationCertificateAuthority(
             final SupplyChainValidationService supplyChainValidationService,
             final PrivateKey privateKey,
-            final X509Certificate acaCertificate,
+            @Qualifier("leafACACert") final X509Certificate acaCertificate,
             final StructConverter structConverter,
             final ComponentResultRepository componentResultRepository,
             final ComponentInfoRepository componentInfoRepository,

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/CertificateService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/CertificateService.java
@@ -340,8 +340,6 @@ public class CertificateService {
                             "IDevIDCertificate");
             case ISSUED_CERTIFICATES -> this.certificateRepository.
                     findByType("IssuedAttestationCertificate");
-            default -> throw new IllegalArgumentException("The provided certificate type {"
-                    + certificateType + "} does not exist");
         };
     }
 

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/PersistenceJPAConfig.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/PersistenceJPAConfig.java
@@ -248,8 +248,8 @@ public class PersistenceJPAConfig implements WebMvcConfigurer {
             validateCertificateChain(leafThreeACACert, intermediateACACert, rootACACert);
 
             X509Certificate[] certsChainArray =
-                    new X509Certificate[] {leafOneACACert, leafTwoACACert, leafThreeACACert
-                            , intermediateACACert, rootACACert};
+                    new X509Certificate[] {leafOneACACert, leafTwoACACert, leafThreeACACert,
+                            intermediateACACert, rootACACert};
 
             log.info("The ACA certificate chain is valid and trusted");
             return certsChainArray;
@@ -257,14 +257,15 @@ public class PersistenceJPAConfig implements WebMvcConfigurer {
             throw new BeanInitializationException("Encountered error loading ACA certificates "
                     + "from key store: " + ksEx.getMessage(), ksEx);
         } catch (CertificateException certificateException) {
-            throw new BeanInitializationException("Encountered an error loading up the certificate factory.");
+            throw new BeanInitializationException("Encountered an error loading up the certificate factory.",
+                    certificateException);
         } catch (CertPathValidatorException | InvalidAlgorithmParameterException exception) {
             throw new BeanInitializationException(
                     "Encountered an error while validating the leaf, intermediate and root "
                             + " ACA certificates.", exception);
         } catch (NoSuchAlgorithmException noSuchAlgorithmException) {
             throw new BeanInitializationException(
-                    "Encountered an error while initializing Cert Path validator, exception",
+                    "Encountered an error while initializing Cert Path validator",
                     noSuchAlgorithmException);
         }
     }
@@ -316,23 +317,25 @@ public class PersistenceJPAConfig implements WebMvcConfigurer {
     }
 
     /**
-     * Helper method that validates the provided leaf certificate against the established intermediate and root certificates.
+     * Helper method that validates the provided leaf certificate against the
+     * established intermediate and root certificates.
      *
-     * @param leaf         leaf certificate
-     * @param intermediate intermediate certificate
-     * @param root         root certificate
+     * @param leafCert         leaf certificate
+     * @param intermediateCert intermediate certificate
+     * @param rootCert         root certificate
      * @throws CertificateException               if there is an error parsing certificates
      *                                            /creating the CertPath
      * @throws InvalidAlgorithmParameterException if the PKIX parameters are invalid
      * @throws NoSuchAlgorithmException           if the PKIX algorithm is not available in the environment
      * @throws CertPathValidatorException         if the certificate chain is invalid or cannot be validated
      */
-    private void validateCertificateChain(X509Certificate leaf, X509Certificate intermediate,
-                                          X509Certificate root)
+    private void validateCertificateChain(final X509Certificate leafCert,
+                                          final X509Certificate intermediateCert,
+                                          final X509Certificate rootCert)
             throws CertificateException, InvalidAlgorithmParameterException, NoSuchAlgorithmException,
             CertPathValidatorException {
         List<X509Certificate> certChain =
-                List.of(leaf, intermediate);
+                List.of(leafCert, intermediateCert);
 
         // Create a CertPath from the certificate chain
         CertificateFactory certFactory = CertificateFactory.getInstance("X.509");
@@ -342,7 +345,7 @@ public class PersistenceJPAConfig implements WebMvcConfigurer {
         CertPathValidator certPathValidator = CertPathValidator.getInstance("PKIX");
 
         // Create TrustAnchor from the root certificate
-        Set<TrustAnchor> trustAnchors = Set.of(new TrustAnchor(root, null));
+        Set<TrustAnchor> trustAnchors = Set.of(new TrustAnchor(rootCert, null));
 
         // Initialize PKIX parameters
         PKIXParameters pkixParams = new PKIXParameters(trustAnchors);

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/PersistenceJPAConfig.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/PersistenceJPAConfig.java
@@ -86,12 +86,6 @@ public class PersistenceJPAConfig implements WebMvcConfigurer {
     @Value("${server.ssl.key-store-password:''}")
     private String keyStorePassword;
 
-    @Value("${aca.certificates.leaf-one-key-alias}")
-    private String leaf1KeyAlias;
-
-    @Value("${aca.certificates.leaf-two-key-alias}")
-    private String leaf2KeyAlias;
-
     @Value("${aca.certificates.leaf-three-key-alias}")
     private String leaf3KeyAlias;
 
@@ -182,14 +176,14 @@ public class PersistenceJPAConfig implements WebMvcConfigurer {
         try {
 
             // load the key from the key store
-            PrivateKey acaKey = (PrivateKey) keyStore.getKey(leaf1KeyAlias,
+            PrivateKey acaKey = (PrivateKey) keyStore.getKey(leaf3KeyAlias,
                     keyStorePassword.toCharArray());
 
             // break early if the certificate is not available.
             if (acaKey == null) {
                 throw new BeanInitializationException(String.format("Key with alias "
                         + "%s was not in KeyStore %s. Ensure that the KeyStore has the "
-                        + "specified certificate. ", leaf1KeyAlias, keyStoreLocation));
+                        + "specified certificate. ", leaf3KeyAlias, keyStoreLocation));
             }
             return acaKey;
         } catch (Exception ex) {
@@ -207,13 +201,13 @@ public class PersistenceJPAConfig implements WebMvcConfigurer {
         KeyStore keyStore = keyStore();
 
         try {
-            X509Certificate leafACACertificate = (X509Certificate) keyStore.getCertificate(leaf1KeyAlias);
+            X509Certificate leafACACertificate = (X509Certificate) keyStore.getCertificate(leaf3KeyAlias);
 
             // break early if the certificate is not available.
             if (leafACACertificate == null) {
                 throw new BeanInitializationException(String.format("Leaf ACA certificate with alias "
                         + "%s was not in KeyStore %s. Ensure that the KeyStore has the "
-                        + "specified certificate. ", leaf1KeyAlias, keyStoreLocation));
+                        + "specified certificate. ", leaf3KeyAlias, keyStoreLocation));
             }
 
             return leafACACertificate;
@@ -237,18 +231,14 @@ public class PersistenceJPAConfig implements WebMvcConfigurer {
             X509Certificate intermediateACACert =
                     (X509Certificate) keyStore.getCertificate(intermediateKeyAlias);
 
-            X509Certificate leafOneACACert = (X509Certificate) keyStore.getCertificate(leaf1KeyAlias);
-            X509Certificate leafTwoACACert = (X509Certificate) keyStore.getCertificate(leaf2KeyAlias);
             X509Certificate leafThreeACACert = (X509Certificate) keyStore.getCertificate(leaf3KeyAlias);
 
-            // validate the three leaf ACA certs against the intermediate and root ACA certs
-            // we want to verify that the root and intermediate ACA certs have signed the three leaf certs
-            validateCertificateChain(leafOneACACert, intermediateACACert, rootACACert);
-            validateCertificateChain(leafTwoACACert, intermediateACACert, rootACACert);
+            // verify that the leaf ACA cert has been signed by the intermediate certificate and that
+            // intermediate certificate has been signed by the root certificate
             validateCertificateChain(leafThreeACACert, intermediateACACert, rootACACert);
 
             X509Certificate[] certsChainArray =
-                    new X509Certificate[] {leafOneACACert, leafTwoACACert, leafThreeACACert,
+                    new X509Certificate[] {leafThreeACACert,
                             intermediateACACert, rootACACert};
 
             log.info("The ACA certificate chain is valid and trusted");

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/TrustChainCertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/TrustChainCertificatePageController.java
@@ -257,28 +257,17 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
 
         log.info("Received request to download the ACA server trust chain certificates");
 
-        final int positionOfIntermediateCert = 3;
-        final int positionOfRootCert = 4;
-
         // Get the output stream of the response
         try (OutputStream outputStream = response.getOutputStream()) {
-            final CertificateAuthorityCredential intermediateCertificate =
-                    certificateAuthorityCredentials.get(positionOfIntermediateCert);
-
-            final CertificateAuthorityCredential rootCertificate =
-                    certificateAuthorityCredentials.get(positionOfRootCert);
-
-            // PEM file of all three leaf certificates, intermediate certificate and root certificate
+            // PEM file of the leaf certificate, intermediate certificate and root certificate (in that order)
             final String fullChainPEM =
                     ControllerPagesUtils.convertCertificateArrayToPem(
                             new CertificateAuthorityCredential[] {certificateAuthorityCredentials.get(0),
                                     certificateAuthorityCredentials.get(1),
-                                    certificateAuthorityCredentials.get(2),
-                                    intermediateCertificate,
-                                    rootCertificate});
+                                    certificateAuthorityCredentials.get(2)});
 
             final String PEMFileName = "hirs-aca-trust_chain.pem ";
-            
+
             // Set the response headers for file download
             response.setContentType("application/x-pem-file");  // MIME type for PEM files
             response.setHeader("Content-Disposition", "attachment; filename=" + PEMFileName);

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/TrustChainCertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/TrustChainCertificatePageController.java
@@ -266,11 +266,11 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
                                     certificateAuthorityCredentials.get(1),
                                     certificateAuthorityCredentials.get(2)});
 
-            final String PEMFileName = "hirs-aca-trust_chain.pem ";
+            final String pemFileName = "hirs-aca-trust_chain.pem ";
 
             // Set the response headers for file download
             response.setContentType("application/x-pem-file");  // MIME type for PEM files
-            response.setHeader("Content-Disposition", "attachment; filename=" + PEMFileName);
+            response.setHeader("Content-Disposition", "attachment; filename=" + pemFileName);
             response.setContentLength(fullChainPEM.length());
 
             // Write the PEM string to the output stream

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -258,7 +258,6 @@ public final class CertificateStringMapBuilder {
         HashMap<String, String> data = new HashMap<>();
 
         if (certificates != null) {
-
             for (CertificateAuthorityCredential certificate : certificates) {
                 data.putAll(
                         getGeneralCertificateInfo(certificate, certificateRepository,

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -230,41 +230,47 @@ public final class CertificateStringMapBuilder {
         String notFoundMessage = "Unable to find Certificate Authority "
                 + "Credential with ID: " + uuid;
 
-        return getCertificateAuthorityInfoHelper(certificateRepository, caCertificateRepository, certificate,
+        return getCertificateAuthorityInfoHelper(certificateRepository, caCertificateRepository,
+                List.of(certificate),
                 notFoundMessage);
     }
 
     /**
      * Returns the Trust Chain credential information.
      *
-     * @param certificate             the certificate
+     * @param certificates            the certificates
      * @param certificateRepository   the certificate repository for retrieving certs.
      * @param caCertificateRepository the certificate repository for retrieving certs.
      * @return a hash map with the endorsement certificate information.
      */
     public static HashMap<String, String> getCertificateAuthorityInformation(
-            final CertificateAuthorityCredential certificate,
+            final List<CertificateAuthorityCredential> certificates,
             final CertificateRepository certificateRepository,
             final CACredentialRepository caCertificateRepository) {
-        return getCertificateAuthorityInfoHelper(certificateRepository, caCertificateRepository, certificate,
+        return getCertificateAuthorityInfoHelper(certificateRepository, caCertificateRepository, certificates,
                 "No cert provided for mapping");
     }
 
     private static HashMap<String, String> getCertificateAuthorityInfoHelper(
             final CertificateRepository certificateRepository,
             final CACredentialRepository caCertificateRepository,
-            final CertificateAuthorityCredential certificate, final String notFoundMessage) {
+            final List<CertificateAuthorityCredential> certificates, final String notFoundMessage) {
         HashMap<String, String> data = new HashMap<>();
 
-        if (certificate != null) {
-            data.putAll(
-                    getGeneralCertificateInfo(certificate, certificateRepository, caCertificateRepository));
-            data.put("subjectKeyIdentifier",
-                    Arrays.toString(certificate.getSubjectKeyIdentifier()));
-            //x509 credential version
-            data.put("x509Version", Integer.toString(certificate
-                    .getX509CredentialVersion()));
-            data.put("credentialType", certificate.getCredentialType());
+        if (certificates != null) {
+
+            for (CertificateAuthorityCredential certificate : certificates) {
+                data.putAll(
+                        getGeneralCertificateInfo(certificate, certificateRepository,
+                                caCertificateRepository));
+                data.put("subjectKeyIdentifier",
+                        Arrays.toString(certificate.getSubjectKeyIdentifier()));
+                //x509 credential version
+                data.put("x509Version", Integer.toString(certificate
+                        .getX509CredentialVersion()));
+                data.put("credentialType", certificate.getCredentialType());
+            }
+
         } else {
             log.error(notFoundMessage);
         }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/ControllerPagesUtils.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/ControllerPagesUtils.java
@@ -1,5 +1,6 @@
 package hirs.attestationca.portal.page.utils;
 
+import hirs.attestationca.persist.entity.userdefined.Certificate;
 import hirs.attestationca.persist.entity.userdefined.certificate.PlatformCredential;
 import hirs.attestationca.portal.datatables.Column;
 import lombok.extern.log4j.Log4j2;
@@ -7,6 +8,7 @@ import lombok.extern.log4j.Log4j2;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -102,5 +104,33 @@ public final class ControllerPagesUtils {
         }
 
         return validSearchableColumnNames;
+    }
+
+    /**
+     * Helper method that converts any kind of certificate into a PEM string.
+     *
+     * @param certificate certificate
+     * @return PEM string of certificate
+     */
+    public static String convertCertificateToPem(final Certificate certificate) {
+        return "-----BEGIN CERTIFICATE-----\n"
+                + Base64.getEncoder()
+                .encodeToString(certificate.getRawBytes())
+                + "\n-----END CERTIFICATE-----\n";
+    }
+
+    /**
+     * Helper method that converts an array of certificates (presumably a trust chain of certificates)
+     * into a PEM string.
+     *
+     * @param certificates array of certificates
+     * @return PEM string of array of certificates
+     */
+    public static String convertCertificateArrayToPem(final Certificate[] certificates) {
+        StringBuilder trustChainPEM = new StringBuilder();
+        for (Certificate certificate : certificates) {
+            trustChainPEM.append(convertCertificateToPem(certificate));
+        }
+        return trustChainPEM.toString();
     }
 }

--- a/HIRS_AttestationCAPortal/src/main/resources/application.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.properties
@@ -33,8 +33,6 @@ server.ssl.key-alias=hirs_aca_tls_rsa_3k_sha384
 server.ssl.enabled-protocols=TLSv1.2, TLSv1.3
 server.ssl.ciphers=TLS_AES_256_GCM_SHA384, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384
 # ACA specific default properties
-aca.certificates.leaf-one-key-alias=HIRS_leaf_ca1_rsa_3k_sha384
-aca.certificates.leaf-two-key-alias=HIRS_leaf_ca2_rsa_3k_sha384
 aca.certificates.leaf-three-key-alias=HIRS_leaf_ca3_rsa_3k_sha384
 aca.certificates.intermediate-key-alias=HIRS_intermediate_ca_rsa_3k_sha384
 aca.certificates.root-key-alias=HIRS_root_ca_rsa_3k_sha384

--- a/HIRS_AttestationCAPortal/src/main/resources/application.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.properties
@@ -33,7 +33,9 @@ server.ssl.key-alias=hirs_aca_tls_rsa_3k_sha384
 server.ssl.enabled-protocols=TLSv1.2, TLSv1.3
 server.ssl.ciphers=TLS_AES_256_GCM_SHA384, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384
 # ACA specific default properties
-aca.certificates.signing-key-alias=HIRS_leaf_ca3_rsa_3k_sha384
+aca.certificates.leaf-one-key-alias=HIRS_leaf_ca1_rsa_3k_sha384
+aca.certificates.leaf-two-key-alias=HIRS_leaf_ca2_rsa_3k_sha384
+aca.certificates.leaf-three-key-alias=HIRS_leaf_ca3_rsa_3k_sha384
 aca.certificates.intermediate-key-alias=HIRS_intermediate_ca_rsa_3k_sha384
 aca.certificates.root-key-alias=HIRS_root_ca_rsa_3k_sha384
 aca.certificates.validity=3652

--- a/HIRS_AttestationCAPortal/src/main/resources/application.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.properties
@@ -34,6 +34,8 @@ server.ssl.enabled-protocols=TLSv1.2, TLSv1.3
 server.ssl.ciphers=TLS_AES_256_GCM_SHA384, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384
 # ACA specific default properties
 aca.certificates.signing-key-alias=HIRS_leaf_ca3_rsa_3k_sha384
+aca.certificates.intermediate-key-alias=HIRS_intermediate_ca_rsa_3k_sha384
+aca.certificates.root-key-alias=HIRS_root_ca_rsa_3k_sha384
 aca.certificates.validity=3652
 # Compression settings
 server.compression.enabled=true

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/trust-chain.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/trust-chain.jsp
@@ -16,7 +16,7 @@
   <jsp:attribute name="pageHeaderTitle">Trust Chain Management</jsp:attribute>
 
   <jsp:body>
-    <span class="aca-input-box-header"> HIRS Attestation CA Certificate Chain </span>
+    <span class="aca-input-box-header"> HIRS Attestation Certificate Chain </span>
     <my:details-viewer
       id="aca-cert-viewer"
       label="HIRS Attestation Root Certificate"
@@ -86,7 +86,7 @@
     </my:details-viewer>
 
     <a href="${portal}/certificate-request/trust-chain/download-aca-cert-chain">
-      <img src="${baseURL}/images/icons/ic_file_download_black_24dp.png" title="Download ACA Certificate Trust Chain">
+      <img src="${baseURL}/images/icons/ic_file_download_black_24dp.png" title="Download Certificate Chain">
     </a>
     <div class="aca-input-box-header">
       <form:form

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/trust-chain.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/trust-chain.jsp
@@ -16,10 +16,10 @@
   <jsp:attribute name="pageHeaderTitle">Trust Chain Management</jsp:attribute>
 
   <jsp:body>
-    <span class="aca-input-box-header"> HIRS Attestation CA Certificate </span>
+    <span class="aca-input-box-header"> HIRS Attestation CA Certificate Chain </span>
     <my:details-viewer
       id="aca-cert-viewer"
-      label="HIRS Attestation CA Certificate"
+      label="HIRS Attestation Root Certificate"
     >
       <div class="container-fluid">
         <div class="row">
@@ -85,8 +85,8 @@
       </div>
     </my:details-viewer>
 
-    <a href="${portal}/certificate-request/trust-chain/download-aca-cert">
-      <img src="${baseURL}/images/icons/ic_file_download_black_24dp.png" title="Download ACA Certificate">
+    <a href="${portal}/certificate-request/trust-chain/download-aca-cert-chain">
+      <img src="${baseURL}/images/icons/ic_file_download_black_24dp.png" title="Download ACA Certificate Trust Chain">
     </a>
     <div class="aca-input-box-header">
       <form:form

--- a/HIRS_AttestationCAPortal/src/test/java/hirs/attestationca/portal/page/PageControllerTest.java
+++ b/HIRS_AttestationCAPortal/src/test/java/hirs/attestationca/portal/page/PageControllerTest.java
@@ -46,12 +46,15 @@ public abstract class PageControllerTest {
     // Pre-prefix path for all the Controllers.
     // There's an option in Page to add prefix path used for some Controllers.
     private static final String PRE_PREFIX_PATH = "/HIRS_AttestationCAPortal/portal/";
+
     // Represents the Page for the Controller under test.
     private final Page page;
+
     // Contains server-side support for testing Spring MVC applications
     // via WebTestClient with MockMvc for server request handling.
     @Autowired
     private WebApplicationContext webApplicationContext;
+
     // Used to set up mocked servlet environment to test the HTTP controller
     // endpoints without the need to launch the embedded servlet container.
     private MockMvc mockMvc;
@@ -70,7 +73,7 @@ public abstract class PageControllerTest {
      *
      * @return a blank model for initPage tests.
      */
-    protected static final Model getBlankModel() {
+    protected static Model getBlankModel() {
         return new ExtendedModelMap();
     }
 
@@ -86,7 +89,7 @@ public abstract class PageControllerTest {
      * @param err         the AssertionError to indicate if the error is a redirected URL error
      * @throws AssertionError with added information if a redirected URL error or the original error
      */
-    protected static final void enhanceRedirectedUrlError(
+    protected static void enhanceRedirectedUrlError(
             final String expectedURL,
             final ResultActions actions,
             final AssertionError err) throws AssertionError {

--- a/HIRS_AttestationCAPortal/src/test/java/hirs/attestationca/portal/page/controllers/TrustChainManagementPageControllerTest.java
+++ b/HIRS_AttestationCAPortal/src/test/java/hirs/attestationca/portal/page/controllers/TrustChainManagementPageControllerTest.java
@@ -175,10 +175,12 @@ public class TrustChainManagementPageControllerTest extends PageControllerTest {
 
     /**
      * Helper method to create the byte array for the ZIP content.
+     *
+     * @return byte array representation of the test zip file content
      */
     private byte[] createZipFileContent() throws IOException, CertificateEncodingException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (ZipOutputStream zipOut = new ZipOutputStream(baos)) {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (ZipOutputStream zipOut = new ZipOutputStream(byteArrayOutputStream)) {
             for (X509Certificate cert : acaTrustChain) {
                 // create a certificate authority credential off of the x509 cert
                 CertificateAuthorityCredential cac = new CertificateAuthorityCredential(cert.getEncoded());
@@ -199,7 +201,7 @@ public class TrustChainManagementPageControllerTest extends PageControllerTest {
                 zipOut.closeEntry();
             }
         }
-        return baos.toByteArray(); // Return the ZIP file content as byte array
+        return byteArrayOutputStream.toByteArray(); // Return the ZIP file content as byte array
     }
 
     /**

--- a/HIRS_AttestationCAPortal/src/test/java/hirs/attestationca/portal/page/controllers/TrustChainManagementPageControllerTest.java
+++ b/HIRS_AttestationCAPortal/src/test/java/hirs/attestationca/portal/page/controllers/TrustChainManagementPageControllerTest.java
@@ -2,22 +2,29 @@ package hirs.attestationca.portal.page.controllers;
 
 import hirs.attestationca.persist.entity.manager.CertificateRepository;
 import hirs.attestationca.persist.entity.userdefined.Certificate;
+import hirs.attestationca.persist.entity.userdefined.certificate.CertificateAuthorityCredential;
 import hirs.attestationca.portal.page.PageControllerTest;
 import hirs.attestationca.portal.page.PageMessages;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.servlet.FlashMap;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static hirs.attestationca.portal.page.Page.TRUST_CHAIN;
 import static org.hamcrest.Matchers.hasEntry;
@@ -43,8 +50,12 @@ public class TrustChainManagementPageControllerTest extends PageControllerTest {
     // Repository manager to handle data access between certificate entity and data storage in db
     @Autowired
     private CertificateRepository certificateRepository;
+
     @Autowired
-    private X509Certificate acaCert;
+    @Qualifier("acaTrustChainCerts")
+    private X509Certificate[] acaTrustChain;
+
+
     // A file that contains a cert that is not an UTC Cert. Should be parsable as a general
     // cert, but should (eventually) not be stored as an UTC because it isn't one.
     private MockMultipartFile nonCaCertFile;
@@ -105,17 +116,17 @@ public class TrustChainManagementPageControllerTest extends PageControllerTest {
      */
     @Test
     @Rollback
-    public void testDownloadAcaCert() throws Exception {
+    public void testDownloadAcaCertChain() throws Exception {
 
         // verify cert file attachment and content
         getMockMvc()
                 .perform(MockMvcRequestBuilders.get(
-                        pagePath + "/download-aca-cert"))
+                        pagePath + "/download-aca-cert-chain"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType("application/octet-stream"))
+                .andExpect(content().contentType("application/zip"))
                 .andExpect(header().string("Content-Disposition",
-                        "attachment; filename=\"hirs-aca-cert.cer\""))
-                .andExpect(content().bytes(acaCert.getEncoded()));
+                        "attachment; filename=hirs-aca-trust-chain-certs.zip"))
+                .andExpect(content().bytes(createZipFileContent()));
     }
 
     /**
@@ -160,6 +171,35 @@ public class TrustChainManagementPageControllerTest extends PageControllerTest {
     public void uploadAndArchiveCaTrustCert() throws Exception {
         Certificate cert = uploadTestCert();
         archiveTestCert(cert);
+    }
+
+    /**
+     * Helper method to create the byte array for the ZIP content.
+     */
+    private byte[] createZipFileContent() throws IOException, CertificateEncodingException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zipOut = new ZipOutputStream(baos)) {
+            for (X509Certificate cert : acaTrustChain) {
+                // create a certificate authority credential off of the x509 cert
+                CertificateAuthorityCredential cac = new CertificateAuthorityCredential(cert.getEncoded());
+
+                // retrieve the certificate's common name
+                String commonName = cac.getSubject().split("CN=")[1];
+
+                // use the common name and the certificate's hash to create the file name
+                String fileName = String.format("%s[%s].cer", commonName,
+                        Integer.toHexString(cac.getCertificateHash()));
+
+                ZipEntry zipEntry = new ZipEntry(fileName);
+                zipEntry.setSize((long) cac.getRawBytes().length * Byte.SIZE);
+                zipEntry.setTime(System.currentTimeMillis());
+                zipOut.putNextEntry(zipEntry);
+                // the content of the resource
+                StreamUtils.copy(cac.getRawBytes(), zipOut);
+                zipOut.closeEntry();
+            }
+        }
+        return baos.toByteArray(); // Return the ZIP file content as byte array
     }
 
     /**


### PR DESCRIPTION
### Description
This ticket focuses on allowing the ACA the ability to download the Certificate Trust Chain (Root, intermediate, and all leaf certificates).

### Test Instructions:
1. Run the ACA using your preferred method: bootrun, docker, or using an installed RPM.
2. Head on over to the Trust Chain Management page and click on the clipboard icon next to the words **HIRS Attestation Certificate Chain**.
3. Verify that it displays a new title **HIRS Attestation Root Certificate**.
4. Back out of the modal window and click on the download icon.
5. Verify that the browser downloads a PEM file that contains 3 certificates.
6. Open up the PEM file and confirm that the ACA's leaf certificate, intermediate certificate and root certificate are all in there.

### Issues this PR addresses:
Closes https://github.com/nsacyber/HIRS/issues/821