### PR TITLE
[#922] Fixed 404 Error When Downloading Validation Report

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationSummaryReportsService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationSummaryReportsService.java
@@ -366,11 +366,7 @@ public class ValidationSummaryReportsService {
                 log.debug("Parsed Component Identifiers V1: {}",
                         String.join(",", componentData));
             }
-
-        }
-
-        // if the platform credential's has a list of version 2 component identifiers
-        else if (pc.getPlatformConfigurationV2() != null && pc.getComponentIdentifiersV2() != null) {
+        } else if (pc.getPlatformConfigurationV2() != null && pc.getComponentIdentifiersV2() != null) {
             List<ComponentIdentifierV2> componentIdentifiersV2 = pc.getComponentIdentifiersV2();
 
             // combine all components in each certificate

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationSummaryReportsService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ValidationSummaryReportsService.java
@@ -36,6 +36,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -172,7 +173,8 @@ public class ValidationSummaryReportsService {
         String contractNumber = "";
         Pattern pattern = Pattern.compile("^\\w*$");
         DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("uuuu-MM-dd");
-        DateTimeFormatter dateTimeFormat = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss");
+        DateTimeFormatter dateTimeFormat =
+                DateTimeFormatter.ofPattern("EEE, dd MMM uuuu HH:mm:ss z");
         LocalDate startDate = null;
         LocalDate endDate = null;
         ArrayList<LocalDate> createTimes = new ArrayList<>();
@@ -225,10 +227,15 @@ public class ValidationSummaryReportsService {
                     //todo issue #922
                     if (!parameterValue.equals(UNDEFINED)
                             && !parameterValue.isEmpty()) {
-                        String[] timestamps = parameterValue.split(",");
+                        String[] timestamps = parameterValue.split(";");
+
                         for (String timestamp : timestamps) {
-                            createTimes.add(LocalDateTime.parse(timestamp,
-                                    dateTimeFormat).toLocalDate());
+                            ZonedDateTime zonedDateTime = ZonedDateTime.parse(timestamp, dateTimeFormat);
+
+                            // Convert to LocalDateTime (drops time zone info)
+                            LocalDate localDate = zonedDateTime.toLocalDate();
+
+                            createTimes.add(localDate);
                         }
                     }
                     break;

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/validation-reports.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/validation-reports.jsp
@@ -173,7 +173,7 @@
         $("#reportTable tr")
           .not("thead tr")
           .each(function () {
-            createTimes += $(this).find("td").eq(1).html() + ",";
+            createTimes += $(this).find("td").eq(1).html() + ";";
             deviceNames += $(this).find("td").eq(2).html() + ",";
           });
         createTimes = createTimes.substring(0, createTimes.length - 1);


### PR DESCRIPTION
### Description
This PR fixes a bug that caused a 404 error when attempting to download the validation report CSV file.

### Test Instructions:
1. Run the ACA using your preferred method: bootrun, docker, or using an installed RPM.
2. Head on over to the Validation Reports page and click on the download icon.
3. Fill out the "form" however you like and click on save.
4. Verify that a csv is downloaded and that the page no longer displays a 404 error.
5. Verify that the CSV shows the device system information and the device's components' info in a csv format.

### Issues this PR addresses:
Closes #922 