### PR TITLE
ComponentResult and ComponentInfo would never agree hashCommonElements

### DIFF
--- a/.ci/docker/Dockerfile.aca-rocky
+++ b/.ci/docker/Dockerfile.aca-rocky
@@ -84,4 +84,4 @@ HEALTHCHECK --start-period=50s --interval=1s --timeout=90s CMD curl -f https://l
 WORKDIR /hirs
 
 # On container launch, the database will be set up. Then bootRun should utilize build artifacts stored in the image.
-CMD ["bash", "-c", "/hirs/package/linux/aca/aca_check_env.sh && /hirs/package/linux/aca/aca_setup.sh --unattended && /tmp/hirs_add_aca_tls_path_to_os.sh && /hirs/package/linux/aca/aca_bootRun.sh"]
+CMD ["bash", "-c", "/hirs/package/linux/aca/aca_check_env.sh && /hirs/package/linux/aca/aca_setup.sh --unattended && /tmp/hirs_add_aca_tls_path_to_os.sh && /hirs/package/linux/aca/aca_bootRun.sh -d"]

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
@@ -67,6 +67,8 @@ public class ComponentResult extends ArchivableEntity {
     @Setter
     private String componentClassValue;
 
+    private String componentClassRegistry;
+
     private String componentClassStr;
 
     private String componentClassType;
@@ -152,6 +154,7 @@ public class ComponentResult extends ArchivableEntity {
         componentAddress = sb.toString();
 
         this.componentClassValue = componentIdentifierV2.getComponentClass().getComponentIdentifier();
+        this.componentClassRegistry = componentIdentifierV2.getComponentClass().getRegistryOid();
         this.componentClassStr = componentIdentifierV2.getComponentClass().toString();
         this.componentClassType = componentIdentifierV2.getComponentClass().getRegistryType();
         this.attributeStatus = componentIdentifierV2.getAttributeStatus();
@@ -193,7 +196,7 @@ public class ComponentResult extends ArchivableEntity {
      */
     public int hashCommonElements() {
         return Objects.hash(manufacturer,
-                model, serialNumber, revisionNumber, componentClassValue);
+                model, serialNumber, revisionNumber, componentClassValue, componentClassRegistry);
     }
 
     /**
@@ -204,6 +207,6 @@ public class ComponentResult extends ArchivableEntity {
     public String toString() {
         return String.format("ComponentResult: certificateSerialNumber=[%s] "
                         + "manufacturer=[%s] model=[%s] componentClass=[%s]",
-                boardSerialNumber, manufacturer, model, componentClassValue);
+                boardSerialNumber, manufacturer, model, componentClassValue, componentClassRegistry);
     }
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/ComponentClass.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/attributes/ComponentClass.java
@@ -74,6 +74,8 @@ ComponentClass {
 
     private String componentStr;
 
+    private final String registryOid;
+
     /**
      * Default class constructor.
      */
@@ -122,6 +124,8 @@ ComponentClass {
         } else {
             this.componentIdentifier = verifyComponentValue(componentIdentifier);
         }
+
+        this.registryOid = registryOid;
 
         this.registryType = switch (registryOid) {
             case TCG_COMPONENT_REGISTRY -> "TCG";


### PR DESCRIPTION
ComponentInfo.hashCommonElements should now have a chance to agree with ComponentResult.hashCommonElements re-enabling one validation check that was being skipped.