### PR TITLE
[#926] Save PROTOBUF Data To ACA Log

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/RestfulAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/RestfulAttestationCertificateAuthority.java
@@ -102,10 +102,6 @@ public class RestfulAttestationCertificateAuthority extends AttestationCertifica
     @PostMapping(value = "/identity-claim-tpm2/process",
             consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public byte[] processIdentityClaimTpm2(@RequestBody final byte[] identityClaim) {
-        log.info(
-                "Received a POST request to process the provided byte array representation "
-                        + "of the identity claim");
-        log.debug("The provided byte array representation of the identity claim: {}", identityClaim);
         return super.processIdentityClaimTpm2(identityClaim);
     }
 
@@ -123,11 +119,6 @@ public class RestfulAttestationCertificateAuthority extends AttestationCertifica
     @PostMapping(value = "/request-certificate-tpm2",
             consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public byte[] processCertificateRequest(@RequestBody final byte[] certificateRequest) {
-        log.info(
-                "Received a POST request to process the provided byte array representation "
-                        + "of the certificate request");
-        log.debug("The provided byte array representation of the certificate request: {}",
-                certificateRequest);
         return super.processCertificateRequest(certificateRequest);
     }
 
@@ -142,7 +133,6 @@ public class RestfulAttestationCertificateAuthority extends AttestationCertifica
     @ResponseBody
     @GetMapping("/public-key")
     public byte[] getPublicKey() {
-        log.info("Received a GET request for the public key");
         return super.getPublicKey();
     }
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/RestfulAttestationCertificateAuthority.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/RestfulAttestationCertificateAuthority.java
@@ -11,6 +11,7 @@ import hirs.attestationca.persist.entity.manager.ReferenceManifestRepository;
 import hirs.attestationca.persist.entity.manager.TPM2ProvisionerStateRepository;
 import hirs.attestationca.persist.service.SupplyChainValidationService;
 import hirs.structs.converters.StructConverter;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,6 +39,7 @@ import java.security.cert.X509Certificate;
         @PropertySource(value = "file:C:/ProgramData/hirs/aca/application.win.properties",
                 ignoreResourceNotFound = true)
 })
+@Log4j2
 @RestController
 @RequestMapping("/HIRS_AttestationCA")
 public class RestfulAttestationCertificateAuthority extends AttestationCertificateAuthority
@@ -100,6 +102,10 @@ public class RestfulAttestationCertificateAuthority extends AttestationCertifica
     @PostMapping(value = "/identity-claim-tpm2/process",
             consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public byte[] processIdentityClaimTpm2(@RequestBody final byte[] identityClaim) {
+        log.info(
+                "Received a POST request to process the provided byte array representation "
+                        + "of the identity claim");
+        log.debug("The provided byte array representation of the identity claim: {}", identityClaim);
         return super.processIdentityClaimTpm2(identityClaim);
     }
 
@@ -117,6 +123,11 @@ public class RestfulAttestationCertificateAuthority extends AttestationCertifica
     @PostMapping(value = "/request-certificate-tpm2",
             consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public byte[] processCertificateRequest(@RequestBody final byte[] certificateRequest) {
+        log.info(
+                "Received a POST request to process the provided byte array representation "
+                        + "of the certificate request");
+        log.debug("The provided byte array representation of the certificate request: {}",
+                certificateRequest);
         return super.processCertificateRequest(certificateRequest);
     }
 
@@ -131,6 +142,7 @@ public class RestfulAttestationCertificateAuthority extends AttestationCertifica
     @ResponseBody
     @GetMapping("/public-key")
     public byte[] getPublicKey() {
+        log.info("Received a GET request for the public key");
         return super.getPublicKey();
     }
 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/CertificateRequestProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/CertificateRequestProcessor.java
@@ -85,7 +85,7 @@ public class CertificateRequestProcessor extends AbstractProcessor {
         ProvisionerTpm2.CertificateRequest request;
         try {
             request = ProvisionerTpm2.CertificateRequest.parseFrom(certificateRequest);
-            log.debug("Certificate request object: {}", request);
+            log.info("Certificate request object: {}", request);
         } catch (InvalidProtocolBufferException ipbe) {
             throw new CertificateProcessingException(
                     "Could not deserialize Protobuf Certificate Request object.", ipbe);
@@ -189,13 +189,9 @@ public class CertificateRequestProcessor extends AbstractProcessor {
                     ProvisionerTpm2.CertificateResponse certificateResponse =
                             certificateResponseBuilder.build();
 
-                    log.debug("Certificate Request Response "
+                    log.info("Certificate Request Response "
                             + "object after a successful validation and if the LDevID "
                             + "public key exists : {}", certificateResponse);
-
-                    log.debug("Byte array representation of the Certificate Request Response "
-                            + "after a successful validation and if the LDevID "
-                            + "public key exists : {}", certificateResponse.toByteArray());
 
                     return certificateResponse.toByteArray();
                 } else {
@@ -221,13 +217,9 @@ public class CertificateRequestProcessor extends AbstractProcessor {
                     ProvisionerTpm2.CertificateResponse certificateResponse =
                             certificateResponseBuilder.build();
 
-                    log.debug("Certificate Request Response "
+                    log.info("Certificate Request Response "
                             + "object after a successful validation and if the LDevID "
                             + "public key does not exist : {}", certificateResponse);
-
-                    log.debug("Byte array representation of the Certificate Request Response "
-                            + "after a successful validation and if the LDevID "
-                            + "public key does not exist : {}", certificateResponse.toByteArray());
 
                     return certificateResponse.toByteArray();
                 }
@@ -239,11 +231,8 @@ public class CertificateRequestProcessor extends AbstractProcessor {
                         .setStatus(ProvisionerTpm2.ResponseStatus.FAIL)
                         .build();
 
-                log.debug("Certificate Request Response "
+                log.info("Certificate Request Response "
                         + "object after a failed validation: {}", certificateResponse);
-
-                log.debug("Byte array representation of the Certificate Request Response "
-                        + "after a failed validation: {}", certificateResponse.toByteArray());
 
                 return certificateResponse.toByteArray();
             }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/CertificateRequestProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/CertificateRequestProcessor.java
@@ -74,7 +74,7 @@ public class CertificateRequestProcessor extends AbstractProcessor {
      * @return a certificateResponse containing the signed certificate
      */
     public byte[] processCertificateRequest(final byte[] certificateRequest) {
-        log.info("Certificate Request received...");
+        log.info("Certificate Request has been received and is ready to be processed");
 
         if (ArrayUtils.isEmpty(certificateRequest)) {
             throw new IllegalArgumentException("The CertificateRequest sent by the client"
@@ -184,6 +184,10 @@ public class CertificateRequestProcessor extends AbstractProcessor {
                     }
                     ProvisionerTpm2.CertificateResponse response = builder.build();
 
+                    log.debug("Byte array representation of the certificate request response "
+                            + "after a successful validation and if the LDevID "
+                            + "public key exists : {}", response.toByteArray());
+
                     return response.toByteArray();
                 } else {
                     byte[] derEncodedAttestationCertificate = ProvisionUtils.getDerEncodedCertificate(
@@ -205,21 +209,29 @@ public class CertificateRequestProcessor extends AbstractProcessor {
                     }
                     ProvisionerTpm2.CertificateResponse response = builder.build();
 
+                    log.debug("Byte array representation of the certificate request response "
+                            + "after a successful validation and if the LDevID "
+                            + "public key does not exist : {}", response.toByteArray());
+
                     return response.toByteArray();
                 }
             } else {
-                log.error("Supply chain validation did not succeed. "
-                        + "Firmware Quote Validation failed. Result is: "
-                        + validationResult);
+                log.error("Supply chain validation did not succeed. Firmware Quote Validation failed."
+                                + " Result is: {}",
+                        validationResult);
                 ProvisionerTpm2.CertificateResponse response = ProvisionerTpm2.CertificateResponse
                         .newBuilder()
                         .setStatus(ProvisionerTpm2.ResponseStatus.FAIL)
                         .build();
+
+                log.debug("Byte array representation of the certificate request response "
+                        + "after a failed validation: {}", response.toByteArray());
+
                 return response.toByteArray();
             }
         } else {
-            log.error("Could not process credential request. Invalid nonce provided: "
-                    + request.getNonce());
+            log.error("Could not process credential request."
+                    + " Invalid nonce provided: {}", request.getNonce());
             throw new CertificateProcessingException("Invalid nonce given in request by client.");
         }
     }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
@@ -142,6 +142,8 @@ public class IdentityClaimProcessor extends AbstractProcessor {
         // attempt to deserialize Protobuf IdentityClaim
         ProvisionerTpm2.IdentityClaim claim = ProvisionUtils.parseIdentityClaim(identityClaim);
 
+        log.debug("Identity Claim object: {}", claim);
+
         // parse the EK Public key from the IdentityClaim once for use in supply chain validation
         // and later tpm20MakeCredential function
         RSAPublicKey ekPub = ProvisionUtils.parsePublicKey(claim.getEkPublicArea().toByteArray());
@@ -177,29 +179,35 @@ public class IdentityClaimProcessor extends AbstractProcessor {
             }
 
             // Package response
-            ProvisionerTpm2.IdentityClaimResponse response
+            ProvisionerTpm2.IdentityClaimResponse identityClaimResponse
                     = ProvisionerTpm2.IdentityClaimResponse.newBuilder()
                     .setCredentialBlob(blobStr).setPcrMask(pcrQuoteMask)
                     .setStatus(ProvisionerTpm2.ResponseStatus.PASS)
                     .build();
 
-            log.debug("Byte array representation of the identity claim response "
+            log.debug("Identity Claim Response object after a "
+                    + "successful validation: {}", identityClaimResponse);
+
+            log.debug("Byte array representation of the Identity Claim Response object "
                             + "after a successful validation: {}",
-                    response.toByteArray());
-            return response.toByteArray();
+                    identityClaimResponse.toByteArray());
+            return identityClaimResponse.toByteArray();
         } else {
             log.error("Supply chain validation did not succeed. Result is: {}", validationResult);
             // empty response
-            ProvisionerTpm2.IdentityClaimResponse response
+            ProvisionerTpm2.IdentityClaimResponse identityClaimResponse
                     = ProvisionerTpm2.IdentityClaimResponse.newBuilder()
                     .setCredentialBlob(blobStr)
                     .setStatus(ProvisionerTpm2.ResponseStatus.FAIL)
                     .build();
 
-            log.debug("Byte array representation of the identity claim response after "
+            log.debug("Identity Claim Response object after a "
+                    + "failed validation: {}", identityClaimResponse);
+
+            log.debug("Byte array representation of the Identity Claim Response object after "
                             + "a failed validation: {}",
-                    response.toByteArray());
-            return response.toByteArray();
+                    identityClaimResponse.toByteArray());
+            return identityClaimResponse.toByteArray();
         }
     }
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
@@ -142,7 +142,7 @@ public class IdentityClaimProcessor extends AbstractProcessor {
         // attempt to deserialize Protobuf IdentityClaim
         ProvisionerTpm2.IdentityClaim claim = ProvisionUtils.parseIdentityClaim(identityClaim);
 
-        log.debug("Identity Claim object: {}", claim);
+        log.info("Identity Claim object: {}", claim);
 
         // parse the EK Public key from the IdentityClaim once for use in supply chain validation
         // and later tpm20MakeCredential function
@@ -185,12 +185,9 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                     .setStatus(ProvisionerTpm2.ResponseStatus.PASS)
                     .build();
 
-            log.debug("Identity Claim Response object after a "
+            log.info("Identity Claim Response object after a "
                     + "successful validation: {}", identityClaimResponse);
 
-            log.debug("Byte array representation of the Identity Claim Response object "
-                            + "after a successful validation: {}",
-                    identityClaimResponse.toByteArray());
             return identityClaimResponse.toByteArray();
         } else {
             log.error("Supply chain validation did not succeed. Result is: {}", validationResult);
@@ -204,9 +201,6 @@ public class IdentityClaimProcessor extends AbstractProcessor {
             log.debug("Identity Claim Response object after a "
                     + "failed validation: {}", identityClaimResponse);
 
-            log.debug("Byte array representation of the Identity Claim Response object after "
-                            + "a failed validation: {}",
-                    identityClaimResponse.toByteArray());
             return identityClaimResponse.toByteArray();
         }
     }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
@@ -131,7 +131,7 @@ public class IdentityClaimProcessor extends AbstractProcessor {
      * @return an identity claim response for the specified request containing a wrapped blob
      */
     public byte[] processIdentityClaimTpm2(final byte[] identityClaim) {
-        log.info("Identity Claim received...");
+        log.info("Identity Claim has been received and is ready to be processed");
 
         if (ArrayUtils.isEmpty(identityClaim)) {
             log.error("Identity claim empty throwing exception.");
@@ -183,6 +183,9 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                     .setStatus(ProvisionerTpm2.ResponseStatus.PASS)
                     .build();
 
+            log.debug("Byte array representation of the identity claim response "
+                            + "after a successful validation: {}",
+                    response.toByteArray());
             return response.toByteArray();
         } else {
             log.error("Supply chain validation did not succeed. Result is: {}", validationResult);
@@ -192,6 +195,10 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                     .setCredentialBlob(blobStr)
                     .setStatus(ProvisionerTpm2.ResponseStatus.FAIL)
                     .build();
+
+            log.debug("Byte array representation of the identity claim response after "
+                            + "a failed validation: {}",
+                    response.toByteArray());
             return response.toByteArray();
         }
     }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/HelpPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/HelpPageService.java
@@ -63,8 +63,8 @@ public class HelpPageService {
             if (loggerLevelsDescriptor.getConfiguredLevel() != null) {
                 logLevel = LogLevel.valueOf(loggerLevelsDescriptor.getConfiguredLevel());
             } else {
-                // if the log level has not been configured (current configured log level is null), set the log
-                // level to info
+                // if the log level has not been configured (current configured log level is null),
+                // set the log level to info
                 logLevel = LogLevel.INFO;
             }
 


### PR DESCRIPTION
### Description
Save key information such as the Identity Claim, Identity Claim response, Certificate Request and Certificate Request response to the ACA Log during the provisioning process.

### Test Instructions:
1.Run the HIRS Application.
2. Go to the help page and search for IdentityClaimProcessor, CertificateRequestProcessor and RestfulAttestationCertificateAuthority and set each file's logger to debug mode.
3. Open a terminal window and run the following command to view the aca log in real time: `sudo tail -f /var/log/hirs/HIRS_AttestationCA_Portal.log`
4. Open another new terminal window and run the command `sudo tpm_aca_provision`
5. Verify that while the proviosining is occurring, you can see the four objects we are looking for in the aca log.


### Issues this PR addresses:
Closes https://github.com/nsacyber/HIRS/issues/926