### PR TITLE
Update windows runner in create_aca_images.yml

### DIFF
--- a/.github/workflows/create_aca_images.yml
+++ b/.github/workflows/create_aca_images.yml
@@ -119,7 +119,7 @@ jobs:
 
   windows-compat-image: # This job uses a different runner and build arg than the other windows job.
     needs: setup
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       TAG: ${{ needs.setup.outputs.WINDOWS_COMPAT_IMAGE_TAG }}
     steps:


### PR DESCRIPTION
The action used to create the ACA docker images uses a runner that will be removed at the end of June.

create_aca_images.yml will use windows-2022 to generate the Win10-compatible ACA docker image.