### PR TITLE
ComponentInfo should not trim

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
@@ -138,10 +138,10 @@ public class ComponentResult extends ArchivableEntity {
         this.boardSerialNumber = boardSerialNumber;
         this.certificateSerialNumber = certificateSerialNumber;
         this.certificateType = certificateType;
-        this.manufacturer = componentIdentifierV2.getComponentManufacturer().toString();
-        this.model = componentIdentifierV2.getComponentModel().toString();
-        this.serialNumber = componentIdentifierV2.getComponentSerial().toString();
-        this.revisionNumber = componentIdentifierV2.getComponentRevision().toString();
+        this.manufacturer = componentIdentifierV2.getComponentManufacturer().toString().trim();
+        this.model = componentIdentifierV2.getComponentModel().toString().trim();
+        this.serialNumber = componentIdentifierV2.getComponentSerial().toString().trim();
+        this.revisionNumber = componentIdentifierV2.getComponentRevision().toString().trim();
         if (componentIdentifierV2.getFieldReplaceable() != null) {
             this.fieldReplaceable = componentIdentifierV2.getFieldReplaceable().isTrue();
         }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/ComponentResult.java
@@ -138,10 +138,10 @@ public class ComponentResult extends ArchivableEntity {
         this.boardSerialNumber = boardSerialNumber;
         this.certificateSerialNumber = certificateSerialNumber;
         this.certificateType = certificateType;
-        this.manufacturer = componentIdentifierV2.getComponentManufacturer().toString().trim();
-        this.model = componentIdentifierV2.getComponentModel().toString().trim();
-        this.serialNumber = componentIdentifierV2.getComponentSerial().toString().trim();
-        this.revisionNumber = componentIdentifierV2.getComponentRevision().toString().trim();
+        this.manufacturer = componentIdentifierV2.getComponentManufacturer().toString();
+        this.model = componentIdentifierV2.getComponentModel().toString();
+        this.serialNumber = componentIdentifierV2.getComponentSerial().toString();
+        this.revisionNumber = componentIdentifierV2.getComponentRevision().toString();
         if (componentIdentifierV2.getFieldReplaceable() != null) {
             this.fieldReplaceable = componentIdentifierV2.getFieldReplaceable().isTrue();
         }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/info/ComponentInfo.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/info/ComponentInfo.java
@@ -103,24 +103,24 @@ public class ComponentInfo extends ArchivableEntity {
             log.error("Component Info's manufacturer cannot be null.");
             this.componentManufacturer = "";
         } else {
-            this.componentManufacturer = componentManufacturer.trim();
+            this.componentManufacturer = componentManufacturer;
         }
 
         if (componentModel == null) {
             log.error("Component Info's model cannot be null.");
             this.componentModel = "";
         } else {
-            this.componentModel = componentModel.trim();
+            this.componentModel = componentModel;
         }
 
         if (componentSerial != null) {
-            this.componentSerial = componentSerial.trim();
+            this.componentSerial = componentSerial;
         } else {
             this.componentSerial = ComponentIdentifier.NOT_SPECIFIED_COMPONENT;
         }
 
         if (componentRevision != null) {
-            this.componentRevision = componentRevision.trim();
+            this.componentRevision = componentRevision;
         } else {
             this.componentRevision = ComponentIdentifier.NOT_SPECIFIED_COMPONENT;
         }

--- a/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
+++ b/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="paccor.HardwareManifestPlugin" Version="2.0.5" />
     <PackageReference Include="paccor.HardwareManifestPluginManager" Version="2.0.5" />
-    <PackageReference Include="paccor.paccor_scripts" Version="2.0.5" />
+    <PackageReference Include="paccor.paccor_scripts" Version="2.2.0" />
     <PackageReference Include="paccor.pcie" Version="0.7.6" />
     <PackageReference Include="paccor.smbios" Version="0.7.6" />
     <PackageReference Include="paccor.storage" Version="0.7.6" />

--- a/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
+++ b/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
@@ -85,7 +85,7 @@
     <Exec Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))'" Command="for /f %%i in ('dir /s /b $(FOLDER_PROTO)\*.proto') do (  $(protoc) -I=$(FOLDER_PROTO) --csharp_out=$(FOLDER_OUT) %%i )" />
     <Exec Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'" Command="for file in `ls -1R $(FOLDER_PROTO)/*.proto` ; do $(protoc) -I=$(FOLDER_PROTO) --csharp_out=$(FOLDER_OUT) $file; done " />
   </Target>
-  <Import Project="$(NuGetPackageRoot)paccor.paccor_scripts/2.0.5/contentFiles/any/net8.0/resources/paccor.paccor_scripts.targets" Condition="Exists('$(NuGetPackageRoot)paccor.paccor_scripts/2.0.5/contentFiles/any/net8.0/resources/paccor.paccor_scripts.targets')" />
+  <Import Project="$(NuGetPackageRoot)paccor.paccor_scripts/2.2.0/contentFiles/any/net8.0/resources/paccor.paccor_scripts.targets" Condition="Exists('$(NuGetPackageRoot)paccor.paccor_scripts/2.2.0/contentFiles/any/net8.0/resources/paccor.paccor_scripts.targets')" />
   <Target Name="ImportPaccorScripts" BeforeTargets="PreBuildEvent">
     <ItemGroup>
       <PaccorScriptsLinux Include="$(dotnet_paccor_scripts_directory)/*" />


### PR DESCRIPTION
ComponentInfo is trimming whitespace characters where ComponentResult isn't and can cause incorrect mismatch. 
Also needed to update paccor to account for a bug in nvme-cli JSON output, requiring an update to the provisioner.