### PR TITLE
[#940] Update error message for RIM signature validation failure

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
@@ -352,6 +352,7 @@ public class SupplyChainValidationService {
                     } else {
                         fwStatus.setMessage("Firmware validation of TPM Quote failed."
                                 + "\nPCR hash and Quote hash do not match.");
+                        log.debug(pcrValidator.validatePcrs(storedPcrs, getPolicySettings()));
                     }
                     eventLog.setOverallValidationResult(fwStatus.getAppStatus());
                     this.referenceManifestRepository.save(eventLog);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
@@ -352,6 +352,9 @@ public class SupplyChainValidationService {
                     } else {
                         fwStatus.setMessage("Firmware validation of TPM Quote failed."
                                 + "\nPCR hash and Quote hash do not match.");
+                        for (int i = 0;i < storedPcrs.length;i++) {
+                            log.debug(String.format("PCR[%d]: %s", i, storedPcrs[i]));
+                        }
                         log.debug(pcrValidator.validatePcrs(storedPcrs, getPolicySettings()));
                     }
                     eventLog.setOverallValidationResult(fwStatus.getAppStatus());

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/SupplyChainValidationService.java
@@ -343,8 +343,8 @@ public class SupplyChainValidationService {
                     String[] storedPcrs = eventLog.getExpectedPCRList();
                     PcrValidator pcrValidator = new PcrValidator(sRim.getExpectedPCRList());
                     // grab the quote
-                    byte[] hash = device.getDeviceInfo().getTpmInfo().getTpmQuoteHash();
-                    if (pcrValidator.validateQuote(hash, storedPcrs, getPolicySettings())) {
+                    byte[] quote = device.getDeviceInfo().getTpmInfo().getTpmQuoteHash();
+                    if (pcrValidator.validateQuote(quote, storedPcrs, getPolicySettings())) {
                         level = Level.INFO;
                         fwStatus = new AppraisalStatus(PASS,
                                 SupplyChainCredentialValidator.FIRMWARE_VALID);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
@@ -227,9 +227,12 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
 
         if (passed && !referenceManifestValidator.isSignatureValid()) {
             passed = false;
-            rimSignatureStatus = new AppraisalStatus(FAIL,
-                    "RIM signature validation failed: Signature validation "
-                            + "failed for Base RIM.");
+            String validationErrorMessage = referenceManifestValidator.getValidationErrorMessage();
+            if (!validationErrorMessage.isEmpty()) {
+                rimSignatureStatus = new AppraisalStatus(FAIL, validationErrorMessage);
+            } else {
+                rimSignatureStatus = new AppraisalStatus(FAIL,"Base RIM signature invalid.");
+            }
         }
 
         if (passed && !referenceManifestValidator.isSupportRimValid()) {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/PcrValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/PcrValidator.java
@@ -149,7 +149,7 @@ public class PcrValidator {
                 }
 
                 if (!baselinePcrs[i].equals(storedPcrs[i])) {
-                    log.error(String.format("%s =/= %s", baselinePcrs[i], storedPcrs[i]));
+                    log.debug(String.format("PCR[%d]: %s =/= %s", i, baselinePcrs[i], storedPcrs[i]));
                     sb.append(String.format(failureMsg, i));
                 }
             }


### PR DESCRIPTION
Updated the ACA to report a more useful error when signature validation fails because an issuer cert is missing.

Closes #940 
Closes #948 