### PR TITLE
[#954] Move CoSwid RIM core code to HIRS_Utils /crypto module

### DIFF
--- a/HIRS_Utils/build.gradle
+++ b/HIRS_Utils/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation libs.jakarta.xml
     implementation libs.spring.boot.starter.log4j2
     implementation libs.minimal.json
+    implementation libs.nimbus.jwt
 
     implementation libs.pci
     // explicitly include the patched version of the apache http client dependency

--- a/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/PciIds.java
@@ -271,7 +271,7 @@ public final class PciIds {
             if (devSc != null && !Strings.isNullOrEmpty(devSc.getName())) {
                 translatedClassCode.set(1, devSc.getName());
             }
-            
+
             if (progI != null && !Strings.isNullOrEmpty(progI.getName())) {
                 translatedClassCode.set(2, progI.getName());
             }

--- a/HIRS_Utils/src/main/java/hirs/utils/crypto/AlgorithmsIds.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/crypto/AlgorithmsIds.java
@@ -1,0 +1,333 @@
+package hirs.utils.crypto;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.NoSuchElementException;
+
+/**
+ * Class to translate algorithm identifiers whose names differ between the following specs.
+ * <ul>
+ *   <li>TCG (TCG Algorithm Registry):<br>
+ *     <ul>
+ *       <li>https://trustedcomputinggroup.org/resource/tcg-algorithm-registry/<br>
+ *       Table 3 — Definition of (UINT16) TPM_ALG_ID Constants</li>
+ *     </ul>
+ *   </li>
+ *   <li>XML (XML Security Algorithm Cross-Reference):
+ *     <ul>
+ *       <li>https://www.w3.org/TR/xmlsec-algorithms/</li>
+ *     </ul>
+ *   </li>
+ *   <li>RFC6931 (Additional XML Security Uniform Resource Identifiers (URIs)):
+ *     <ul>
+ *       <li>https://datatracker.ietf.org/doc/rfc6931/</li>
+ *     </ul>
+ *   </li>
+ *   <li>CoSwid (Named Information Hash Algorithm Registry):
+ *     <ul>
+ *       <li>https://www.rfc-editor.org/rfc/rfc9393.html</li>
+ *       <li>https://www.iana.org/assignments/named-information/named-information.xhtml</li>
+ *     </ul>
+ *   </li>
+ *   <li>COSE (COSE Header Algorithm Parameters):<br>
+ *     <ul>
+ *       <li>https://www.iana.org/assignments/cose/cose.xhtml#algorithms</li>
+ *     </ul>
+ *   </li>
+ * </ul>
+ *
+ * <p>Notes:</p>
+ * <ul>
+ *   <li>Only includes asymmetric signature algorithms and hash algorithms.</li>
+ *   <li>Only includes algorithms listed in the TCG Registry, since RIMs are defined by
+ *       the TCG and must use TCG-defined algorithms.</li>
+ * </ul>
+ */
+
+public final class AlgorithmsIds {
+
+    /**
+     * Hash Algorithm.
+     */
+    public static final String ALG_TYPE_HASH = "hash";
+    /**
+     * Signature Algorithm.
+     */
+    public static final String ALG_TYPE_SIG = "signature";
+    /**
+     * Algorithm from TCG Spec (matches with table column).
+     */
+    public static final int SPEC_TCG_ALG = 0;
+    /**
+     * Algorithm from XML Spec (matches with table column).
+     */
+    public static final int SPEC_XML_ALG = 1;
+    /**
+     * Algorithm from CoSwid Spec (matches with table column).
+     */
+    public static final int SPEC_COSWID_ALG = 2;
+    /**
+     * Algorithm from COSE Spec (matches with table column).
+     */
+    public static final int SPEC_COSE_ALG = 3;
+    /**
+     * String Description Column.
+     */
+    public static final int STR_DESC_COL = 4;
+
+    /**
+     * Algorithm from X.509.
+     */
+    public static final int SPEC_X509_ALG = 5;
+    /**
+     * Algorithm Family (Such as "ECC", "RSA", etc).
+     */
+    public static final int FAMILY_ALG = 6;
+
+    /**
+     * Array that holds the human-readable name of the spec, in the same column
+     * order as the subsequent tables.
+     */
+    private static final String[][] ALG_TABLES_SPEC_COLUMNS = {
+            // Specification order: TCG, XML, CoSwid, COSE, X509
+            {"TCG", "XML", "CoSwid", "COSE", "X509"},
+            {"TCG Algorithm Registry", "XML Security Algorithm Cross-Reference",
+                    "Named Information Hash Algorithm Registry", "COSE Header Algorithm Parameters",
+                    "Java X509Certificate algorithm identifiers"}};
+
+    /**
+     * Array that holds the hash alg names used in each of 4 specifications.
+     */
+    private static final String[][] HASH_ALGORITHMS = {
+            // Specification order: TCG, XML, CoSwid, COSE, X509 string
+            // description
+            {"TPM_ALG_SHA1", "SHA-1", "", "SHA-1", "SHA1", "SHA1"},
+            {"TPM_ALG_SHA256", "SHA-256", "sha-256", "SHA-256", "SHA256", "SHA256"},
+            {"TPM_ALG_SHA384", "SHA-384", "sha-384", "SHA-384", "SHA384", "SHA384"},
+            {"TPM_ALG_SHA512", "SHA-512", "sha-512", "SHA-512", "SHA512", "SHA512"},
+            {"TPM_ALG_SHA3_256", "", "sha3-256", "", "SHA3-256", "SHA3256"},
+            {"TPM_ALG_SHA3_384", "", "sha3-384", "", "SHA3-384", "SHA384"},
+            {"TPM_ALG_SHA3_512", "", "sha3-512", "SHA3-512", "SHA512"}};
+
+    /**
+     * Array that holds the signing alg names used in each of 4 specifications.
+     */
+    private static final String[][] SIG_ALGORITHMS = {
+            // RFC8017: Signature scheme for RSASSA-PSS and RSASSA-PKCS1-v1_5, Sections 8.1 and 8.2
+            //    https://datatracker.ietf.org/doc/html/rfc8017
+            //    https://www.rfc-editor.org/rfc/rfc8017
+            // TPM
+            //    TPM_ALG_RSASSA:
+            //       RSASSA-PKCS1-v1_5 combines RSASP1 and RSAVP1 primitives w/ EMSA-PKCS1-v1_5 encoding
+            //                          method
+            //    TPM_ALG_RSAPSS:
+            //       RSASSA-PSS combines RSASP1 and RSAVP1 primitives w/ EMSA-PSS encoding method
+            // XML RSA-SHA256, RSA-SHA384, RSA-SHA512:
+            //    This implies the PKCS#1 v1.5 padding algorithm [RFC3447]
+            //    XML doesn't account for PSS padding so these will be blank
+            // COSWID
+            //    COSWID has only hash algorithms so there's no column for this
+            //
+            // COSE
+            //    RS256: RSASSA-PKCS1-v1_5 using SHA-256
+            //    PS256: RSASSA-PSS w/ SHA-256
+
+            // Specification order: TCG assymmetric & TCG hash, XML, CoSwid, COSE, X509 string descriptions,
+            //                          Signature family(Ecc vd Rsa)
+            // Note: TCG does not combine assymmetric & hash into one name for a signing algorithm,
+            //       so table combines these 2 names with a * (in the first columnn)
+            //       CoSwid empty column left in for column # alignment consistent with the other tables
+            {"TPM_ALG_ECDSA*TPM_ALG_SHA256", "ECDSA-SHA256", "", "ES256", "ECDSA and SHA256",
+                    "SHA256withECDSA", "ECC"},
+            {"TPM_ALG_ECDSA*TPM_ALG_SHA384", "ECDSA-SHA384", "", "ES384", "ECDSA and SHA384",
+                    "SHA384withECDSA", "ECC"},
+            {"TPM_ALG_ECDSA*TPM_ALG_SHA512", "ECDSA-SHA512", "", "ES512", "ECDSA and SHA512",
+                    "SHA512withECDSA", "ECC"},
+            {"TPM_ALG_RSASSA*TPM_ALG_SHA256", "RSA-SHA256", "", "RS256",
+                    "RSA with PKCS1-v1_5 padding and SHA256", "SHA256withRSA", "RSA"},
+            {"TPM_ALG_RSASSA*TPM_ALG_SHA384", "RSA-SHA384", "", "RS384",
+                    "RSA with PKCS1-v1_5 padding and SHA384", "SHA384withRSA", "RSA"},
+            {"TPM_ALG_RSASSA*TPM_ALG_SHA512", "RSA-SHA512", "", "RS512",
+                    "RSA with PKCS1-v1_5 padding and SHA512", "SHA512withRSA", "RSA"},
+            {"TPM_ALG_RSAPSS*TPM_ALG_SHA256", "", "", "PS256", "RSA with PSS padding and SHA256", "TBD",
+                    "RSA"},
+            {"TPM_ALG_RSAPSS*TPM_ALG_SHA384", "", "", "PS384", "RSA with PSS padding and SHA384", "TBD",
+                    "RSA"},
+            {"TPM_ALG_RSAPSS*TPM_ALG_SHA512", "", "", "PS512", "RSA with PSS padding and SHA512", "TBD",
+                    "RSA"}};
+
+    /**
+     * Default constructor.
+     */
+    private AlgorithmsIds() {
+
+    }
+
+    /**
+     * Searches algorithm array for match to original spec's alg string,
+     * translates that to desired spec alg name.
+     *
+     * @param algType type of algorithm (hash, signature)
+     * @param originalSpec int id of specification for original algorithm
+     * @param originalAlg string id of original algorithm
+     * @param newSpec int id of specification for new algorithm
+     * @throws NoSuchAlgorithmException if the original algorithm cannot be
+     * found
+     * @return Name of new algorithm ID
+     */
+    public static String translateAlgId(final String algType, final int originalSpec,
+                                        final String originalAlg, final int newSpec)
+            throws NoSuchAlgorithmException {
+
+        String newAlgId = "";
+
+        if ((newSpec != SPEC_TCG_ALG) && (newSpec != SPEC_XML_ALG) && (newSpec != SPEC_COSWID_ALG)
+                && (newSpec != SPEC_COSE_ALG) && (newSpec != SPEC_X509_ALG)) {
+            throw new IllegalArgumentException("Invalid new spec");
+        }
+
+        final int algIdRow = findAlgId(algType, originalSpec, originalAlg);
+        if (algIdRow >= 0) {
+            if (algType.compareTo(ALG_TYPE_HASH) == 0) {
+                newAlgId = HASH_ALGORITHMS[algIdRow][newSpec];
+            } else if (algType.compareTo(ALG_TYPE_SIG) == 0) {
+                newAlgId = SIG_ALGORITHMS[algIdRow][newSpec];
+            }
+
+            if (newAlgId.compareTo("") == 0) {
+                throw new NoSuchElementException("Algorithm " + algType + " from "
+                        + ALG_TABLES_SPEC_COLUMNS[0][originalSpec] + " spec is not defined in "
+                        + ALG_TABLES_SPEC_COLUMNS[0][newSpec] + " spec");
+            }
+        }
+
+        return newAlgId;
+    }
+
+    /**
+     * Searches algorithm array for match to spec's alg string, returns true if
+     * found.
+     *
+     * @param algType type of algorithm (hash, signature)
+     * @param spec int id of specification for algorithm
+     * @param alg string id of algorithm
+     * @return true if alg found
+     * @throws NoSuchAlgorithmException if the original algorithm is not found
+     */
+    public static boolean isValid(final String algType, final int spec, final String alg)
+            throws NoSuchAlgorithmException {
+        return findAlgId(algType, spec, alg) >= 0;
+    }
+
+    /**
+     * Searches algorithm array for match to spec's alg string, returns row in
+     * array where found.
+     *
+     * @param algType type of algorithm (hash, signature)
+     * @param spec int id of specification for original algorithm
+     * @param alg string id of algorithm
+     * @return row in array if alg found, -1 if not found
+     * @throws NoSuchAlgorithmException if the original algorithm type is
+     * invalid
+     */
+    private static int findAlgId(final String algType, final int spec, final String alg)
+            throws NoSuchAlgorithmException {
+
+        int index = -1;
+
+        if ((spec != SPEC_TCG_ALG) && (spec != SPEC_XML_ALG) && (spec != SPEC_COSWID_ALG)
+                && (spec != SPEC_COSE_ALG) && (spec != SPEC_X509_ALG)) {
+            throw new IllegalArgumentException("Invalid original spec");
+
+        }
+
+        if (algType.compareTo(ALG_TYPE_HASH) == 0) {
+            for (int i = 0; i < HASH_ALGORITHMS.length; i++) {
+                if (alg.compareTo(HASH_ALGORITHMS[i][spec]) == 0) {
+                    index = i;
+                }
+            }
+        } else if (algType.compareTo(ALG_TYPE_SIG) == 0) {
+            if (spec == SPEC_COSWID_ALG) {
+                throw new NoSuchElementException("There is no COSWID signing algorithm");
+            }
+            for (int i = 0; i < SIG_ALGORITHMS.length; i++) {
+                if (alg.compareTo(SIG_ALGORITHMS[i][spec]) == 0) {
+                    index = i;
+                }
+            }
+        } else {
+            throw new NoSuchAlgorithmException("Invalid algorithm type " + algType);
+        }
+        if (index == -1) {
+            throw new NoSuchElementException("Algorithm " + algType + " is not defined in "
+                    + ALG_TABLES_SPEC_COLUMNS[0][spec] + " spec");
+        }
+        return index;
+    }
+
+    /**
+     * Returns string with name of specification for algorithm and name of
+     * algorithm.
+     *
+     * @param algType type of algorithm (hash, signature)
+     * @param originalSpec int id of specification for original algorithm
+     * @param originalAlg string id of original algorithm
+     * @param newSpec int id of specification for new algorithm
+     * @return human-readable name of spec and algorithm
+     * @throws NoSuchAlgorithmException if the original algorithm cannot be
+     * found
+     */
+    public static String toString(final String algType, final int originalSpec, final String originalAlg,
+                                  final int newSpec) throws NoSuchAlgorithmException {
+        final String newAlg = translateAlgId(algType, originalSpec, originalAlg, newSpec);
+
+        return "Original specification: " + ALG_TABLES_SPEC_COLUMNS[0][originalSpec] + " ("
+                + ALG_TABLES_SPEC_COLUMNS[1][originalSpec] + ")\nOriginal " + algType + " algorithm: "
+                + originalAlg + "\nNew specification: " + ALG_TABLES_SPEC_COLUMNS[0][newSpec] + " ("
+                + ALG_TABLES_SPEC_COLUMNS[1][newSpec] + ")\nNew " + algType + " algorithm: " + newAlg
+                + "\nDescription of algorithm: " + STR_DESC_COL;
+    }
+
+    /**
+     * Returns the algorithm family for a given algorithm in the specified
+     * specification.
+     *
+     * @param spec int id of specification for original algorithm
+     * @param alg string id of algorithm
+     * @return string of algorithm family
+     * @throws NoSuchAlgorithmException if the original algorithm cannot be
+     * found
+     */
+    public static String algFamily(final int spec, final String alg) throws NoSuchAlgorithmException {
+        final int row = findAlgId(ALG_TYPE_SIG, spec, alg);
+        return SIG_ALGORITHMS[row][FAMILY_ALG];
+    }
+
+    /**
+     * Returns true if the algorithm is from the ECC family.
+     *
+     * @param spec int id of specification for original algorithm
+     * @param alg string id of algorithm
+     * @return true if algorithm is ECC
+     * @throws NoSuchAlgorithmException if the original algorithm cannot be
+     * found
+     */
+    public static boolean isEcc(final int spec, final String alg) throws NoSuchAlgorithmException {
+        final String algFamily = algFamily(spec, alg);
+        return algFamily.compareToIgnoreCase("ECC") == 0;
+    }
+
+    /**
+     * Returns true if the algorithm is from the RSA family.
+     *
+     * @param spec int id of specification for original algorithm
+     * @param alg string id of algorithm
+     * @return true if algorithm is RSA
+     * @throws NoSuchAlgorithmException if the original algorithm cannot be
+     * found
+     */
+    public static boolean isRsa(final int spec, final String alg) throws NoSuchAlgorithmException {
+        final String algFamily = algFamily(spec, alg);
+        return algFamily.compareToIgnoreCase("RSA") == 0;
+    }
+}

--- a/HIRS_Utils/src/main/java/hirs/utils/crypto/CryptoEngine.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/crypto/CryptoEngine.java
@@ -1,0 +1,71 @@
+package hirs.utils.crypto;
+
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+
+/**
+ * Interface to abstract a cryptographic implementation. Currently just supports
+ * digital signing.
+ */
+public interface CryptoEngine {
+    /**
+     * Loads a Private Key from the specified path.
+     *
+     * @param pathToKey a URI to the key
+     * @param cert X509Certificate certificate associated with the private key
+     * @param algorithm name of the IANA registerd COSE algorithm used to sign
+     * or verify a signature if not specified by the X509 certificate or public
+     * key
+     * @return true if the key was successfully loaded
+     * @throws Exception if an error occurred when loading or processing the key
+     */
+    boolean loadPrivateKey(String pathToKey, X509Certificate cert, String algorithm) throws Exception;
+
+    /**
+     * Method to digitally sign data.
+     *
+     * @param dataToSign data the specification is to sign
+     * @return byte array holing the signed data
+     * @throws Exception if an error with the signing of the data
+     */
+    byte[] sign(byte[] dataToSign) throws Exception;
+
+    /**
+     * Method to verify the signature on signed data using an X.509 Certificate.
+     * Either an X.509 or public key must be provided.
+     *
+     * @param signCert A valid x.509 certificate used to verify the signed data,
+     * can be null is publicKey is provided
+     * @param publicKey Optional public key used to verify the signed data, can
+     * be null is cert is provided
+     * @param algorithm optional string holding the COSE defined signature
+     * algorithm.
+     * @param data Message data to be verified (toBeSigned data from original
+     * msg)
+     * @param signatureData The signature data from the signed message
+     * @return True if data is valid , false if not
+     * @throws Exception if an error occurred when processing the with the
+     * certificate or signed data
+     */
+    boolean verify(X509Certificate signCert, PublicKey publicKey, String algorithm, byte[] data,
+                   byte[] signatureData) throws Exception;
+
+//    /**
+//     * Method to verify the signature on signed data using an X.509 Certificate.
+//     * @param publicKey Public Key used to verify the signed data
+//     * @param data message data to be verified (toBeSigned data from original msg)
+//     * @param signatureData The signature data from the signed message
+//     *
+//     * @return True if data is valid , false if not
+//     * @throws Exception if an error occurred when processing the with the certificate or signed data
+//     */
+//    public boolean verify(PublicKey publicKey, byte[] data, byte[] signatureData) throws Exception;
+
+    /**
+     * Retrieves Public Key from a KeyPair or Certificate. note that
+     * loadPrivateKey may load a public key as well.
+     *
+     * @return Java.Security.PublicKey object.
+     */
+    PublicKey getPublicKey();
+}

--- a/HIRS_Utils/src/main/java/hirs/utils/crypto/DefaultCrypto.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/crypto/DefaultCrypto.java
@@ -1,0 +1,498 @@
+package hirs.utils.crypto;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Security;
+import java.security.Signature;
+import java.security.cert.X509Certificate;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.PSSParameterSpec;
+import java.util.Arrays;
+
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.util.encoders.Base64;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+
+import hirs.utils.signature.cose.CoseAlgorithm;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Class that provides a default implementation of the {@link CryptoEngine}
+ * interface, offering support for cryptographic operations such as key loading,
+ * signature generation, and signature verification. Can handle cryptographic
+ * algorithms aligned with COSE standards and translate them into Java-supported
+ * cryptographic algorithms for interoperability.
+ */
+public class DefaultCrypto implements CryptoEngine {
+    private static final String X509 = "X.509";
+    private static final String PKCS1_HEADER = "-----BEGIN RSA PRIVATE KEY-----";
+    private static final String PKCS1_FOOTER = "-----END RSA PRIVATE KEY-----";
+    private static final String PKCS8_HEADER = "-----BEGIN PRIVATE KEY-----";
+    private static final String PKCS8_FOOTER = "-----END PRIVATE KEY-----";
+    private static final String CERTIFICATE_HEADER = "-----BEGIN CERTIFICATE-----";
+    private static final String CERTIFICATE_FOOTER = "-----END CERTIFICATE-----";
+    private static final String ECC_KEY_HEADER = "-----BEGIN EC PRIVATE KEY-----";
+    private static final String ECC_KEY_FOOTER = "-----END EC PRIVATE KEY-----";
+    private static final String ECC_PARAM_HEADER = "-----BEGIN EC PARAMETERS-----";
+    private static final String ECC_PARAM_FOOTER = "-----END EC PARAMETERS-----";
+    private static final String[] JSON_WEB_KEY_HEADER = {"keys", ":", "{", "}"};
+
+    private PrivateKey privateKey = null;
+    private KeyPair keyPair = null;
+    @Setter @Getter
+    private PublicKey publicKey = null;
+    @Setter @Getter
+    private String algorithm = "";
+    @Setter @Getter
+    private String kid = "";
+
+    /**
+     * Default Crypto Constructor. Used as a default mechanism for providing
+     * cryptographic operations.
+     */
+    public DefaultCrypto() {
+
+    }
+
+    /**
+     * This method extracts the private key from a  file.
+     * Supports PEM and JSon Web Keys.
+     * Json Web Keys are used to validate external test patterns.
+     * Json Web Keys are expected to have parameters for KID and Algorithm.
+     * Will load in a public key from a JSON Web key if present.
+     * Both PKCS1 and PSS formats are handled for RSA.
+     * ECDSA keys are supported.
+     * Algorithm argument is present to allow handling of multiple encryption algorithms,
+     * but for now it is always RSA.
+     * @param pathTokey full file path to the private key to be loaded
+     * @param cert a properly formatted x509 certificate
+     * @param sigHashAlg a string representing the signature hash algorithm to use if the certificate is null
+     * @return true if the private key was successfully loaded
+     */
+    @Override
+    public boolean loadPrivateKey(final String pathTokey, final X509Certificate cert,
+                                  final String sigHashAlg) throws Exception {
+        String alg = "";
+        String signAlg = "";
+        PrivateKeyInfo pkInfo = null;
+        if (cert != null) {
+            alg = getAlgorithmFromCert(cert);
+            algorithm = alg;
+            signAlg = coseAlgToJavaAlg(alg);
+        } else {
+            if (!sigHashAlg.isEmpty()) {
+                algorithm = sigHashAlg;
+                signAlg = coseAlgToJavaAlg(sigHashAlg);
+            }
+        }
+        try {
+            final File file = new File(pathTokey);
+            final byte[] keyBytes = Files.readAllBytes(file.toPath());
+            String privateKeyStr = new String(keyBytes, StandardCharsets.UTF_8);
+            if (privateKeyStr.contains(PKCS1_HEADER)) {
+                try (PEMParser pemParser = new PEMParser(
+                        new InputStreamReader(new FileInputStream(pathTokey), StandardCharsets.UTF_8))) {
+                    final JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+                    final KeyPair parsedKeyPair = converter.getKeyPair((PEMKeyPair) pemParser.readObject());
+                    privateKey = parsedKeyPair.getPrivate();
+                }
+            } else if (privateKeyStr.contains(PKCS8_HEADER)) {
+                privateKeyStr = privateKeyStr.replace(PKCS8_HEADER, "");
+                privateKeyStr = privateKeyStr.replace(PKCS8_FOOTER, "");
+                byte[] decodedKey = Base64.decode(privateKeyStr);
+                PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(decodedKey);
+                KeyFactory keyFactory = KeyFactory.getInstance(signAlg);
+                privateKey = keyFactory.generatePrivate(spec);
+            } else if (privateKeyStr.contains(ECC_KEY_HEADER)) {
+                try (
+                        ByteArrayInputStream kbs = new ByteArrayInputStream(keyBytes);
+                        InputStreamReader isr = new InputStreamReader(kbs, StandardCharsets.UTF_8);
+                        PEMParser p = new PEMParser(isr)
+                ) {
+                    Object readObject1 = p.readObject();   // Can contain key or parameters
+                    Object readObject2 = p.readObject();   // null if no parameters are in private key file
+                    if (readObject2 == null) {
+                        pkInfo = ((PEMKeyPair) readObject1).getPrivateKeyInfo();
+                    } else {
+                        pkInfo = ((PEMKeyPair) readObject2).getPrivateKeyInfo();
+                    }
+                    privateKey = new org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter()
+                            .getPrivateKey(pkInfo);
+                }
+            } else if (containsAll(privateKeyStr, JSON_WEB_KEY_HEADER)) {  // process Json Web Key
+                JWKSet jwkSet = JWKSet.load(new File(pathTokey));
+                JWK jwKey = jwkSet.getKeys().get(0);
+                com.nimbusds.jose.Algorithm  joseAlg = jwKey.getAlgorithm();
+                if (AlgorithmsIds.isEcc(AlgorithmsIds.SPEC_COSE_ALG, joseAlg.getName())) {
+                    privateKey = jwKey.toECKey().toPrivateKey();
+                    keyPair = jwKey.toECKey().toKeyPair();
+                    publicKey = jwKey.toECKey().toPublicKey();
+                    algorithm = joseAlg.getName();
+                    kid = jwKey.getKeyID();
+                } else if (AlgorithmsIds.isRsa(AlgorithmsIds.SPEC_COSE_ALG, joseAlg.getName())) {
+                    privateKey = jwKey.toRSAKey().toPrivateKey();
+                    keyPair = jwKey.toRSAKey().toKeyPair();
+                    publicKey = jwKey.toRSAKey().toPublicKey();
+                    algorithm = joseAlg.getName();
+                    kid = jwKey.getKeyID();
+                } else {
+                    throw new RuntimeException("Unknown JSON Web Key algorithm: + joseAlg");
+                }
+            } else {
+                throw new RuntimeException("Private Key Type not supported");
+            }
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException("Default Crypto: Unable to locate private key file: " + pathTokey);
+
+        } catch (IOException e) {
+            throw new RuntimeException("Default Crypto Error: " + e.getMessage());
+        }
+        return true;
+    }
+
+
+    /**
+     * Helper method to lookup a COSE algoritm used by this class from an x509
+     * certificate specified algorithm.
+     *
+     * @param cert a properly formatted x509 certificate
+     * @return A IANA published COSE algorithm description
+     * @throws NoSuchAlgorithmException if the algorithm is not found in the
+     * x509 certificate
+     */
+    private String getAlgorithmFromCert(final X509Certificate cert) throws NoSuchAlgorithmException {
+        final String x509Alg = cert.getSigAlgName();
+        final String alg = AlgorithmsIds.translateAlgId(AlgorithmsIds.ALG_TYPE_SIG,
+                AlgorithmsIds.SPEC_X509_ALG, x509Alg, AlgorithmsIds.SPEC_COSE_ALG);
+        return alg;
+    }
+
+    /**
+     * Convert COSE defined algorithm Name to a Java.Security equivalent
+     * algorithm string.
+     *
+     * @param coseAlg
+     * @return Java.Security equivalent algorithm string
+     * @throws RuntimeException
+     */
+    private String coseAlgToJavaAlg(final String coseAlg) throws RuntimeException {
+        String signAlg = "";
+        switch (coseAlg) {
+            case CoseAlgorithm.RSA_SHA512_PKCS1:
+                signAlg = "RSA";
+                break;
+            case CoseAlgorithm.RSA_SHA384_PKCS1:
+                signAlg = "RSA";
+                break;
+            case CoseAlgorithm.RSA_SHA256_PKCS1:
+                signAlg = "RSA";
+                break;
+            case CoseAlgorithm.RSA_SHA256_PSS:
+                signAlg = "RSA";
+                break;
+            case CoseAlgorithm.RSA_SHA384_PSS:
+                signAlg = "RSA";
+                break;
+            case CoseAlgorithm.RSA_SHA512_PSS:
+                signAlg = "RSA";
+                break;
+            case CoseAlgorithm.ECDSA_SHA256:
+                signAlg = "EC";
+                break;
+            case CoseAlgorithm.ECDSA_SHA384:
+                signAlg = "EC";
+                break;
+            case CoseAlgorithm.ECDSA_SHA512:
+                signAlg = "EC";
+                break;
+            default:
+                throw new RuntimeException("algorithm combination not supported: " + signAlg);
+        }
+        return signAlg;
+    }
+
+    /**
+     * This method reads a PKCS1 keypair from a PEM file.
+     *
+     * @param filename file holding the private key
+     * @return a Java Key Pair based upon the file
+     */
+    private KeyPair getPKCS1KeyPair(final String filename) throws IOException {
+        Security.addProvider(new BouncyCastleProvider());
+        try (
+                FileInputStream fis = new FileInputStream(filename);
+                InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);
+                PEMParser pemParser = new PEMParser(isr)
+        ) {
+            final JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+            keyPair = converter.getKeyPair((PEMKeyPair) pemParser.readObject());
+            return keyPair;
+        }
+    }
+
+    /**
+     * Checks whether the given text contains all specified substrings.
+     *
+     * @param text the string to search within
+     * @param substrings an array of substrings to check for presence in the
+     * text
+     * @return true if all substrings are found in the text; false otherwise
+     */
+    public static boolean containsAll(final String text, final String[] substrings) {
+        for (final String substring : substrings) {
+            if (!text.contains(substring)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Signs given data using the algorithm set in the constructor.
+     *
+     * @param dataToSign data to be hashed and signed.
+     * @return raw signature as a byte[]
+     */
+    @Override
+    public byte[] sign(final byte[] dataToSign) throws Exception {
+        Signature signature = null;
+        signature = loadSignatureInstance(algorithm);
+        signature.initSign(privateKey);
+        signature.update(dataToSign);
+        final byte[] derEncodedSignature = signature.sign();
+        return removeDerFromSignature(derEncodedSignature);
+    }
+
+    /**
+     * Verifies a signature on a COSE object using a public key vs an X.509
+     * certificate. Note that the signature is expected to be in raw (IEEE).
+     *
+     * @param cert a properly formatted x509 certificate
+     * @param pk Public Key used to verify the signed data
+     * @param sigAlgorithm optional signature algorithm name; may be empty
+     * @param data message data to be verified (toBeSigned data from original
+     * msg)
+     * @param signatureData The signature data from the signed message
+     * @return true if the signature is valid; false otherwise
+     */
+    @Override
+    public boolean verify(final X509Certificate cert, final PublicKey pk, final String sigAlgorithm,
+                          final byte[] data, final byte[] signatureData) throws Exception {
+        Signature signature = null;
+        String alg = algorithm;
+
+        if (!sigAlgorithm.isEmpty()) {
+            alg = sigAlgorithm;
+        }
+        if (alg.isEmpty()) {
+            if (cert != null) {
+                alg = cert.getSigAlgName();
+                // AlgorithmsIds algIds = new AlgorithmsIds();
+                alg = AlgorithmsIds.translateAlgId(AlgorithmsIds.ALG_TYPE_SIG, AlgorithmsIds.SPEC_X509_ALG,
+                        alg, AlgorithmsIds.SPEC_COSE_ALG);
+            } else if (pk != null) {
+                final String x509Alg = pk.getAlgorithm();
+                // AlgorithmsIds algIds = new AlgorithmsIds();
+                alg = AlgorithmsIds.translateAlgId(AlgorithmsIds.ALG_TYPE_SIG, AlgorithmsIds.SPEC_X509_ALG,
+                        x509Alg, AlgorithmsIds.SPEC_COSE_ALG);
+            }
+            if (alg.isEmpty()) {
+                alg = sigAlgorithm;
+            }
+        }
+        algorithm = alg;
+        // signature = loadSignatureInstance(alg);
+        signature = loadSignatureInstance(alg);
+        final byte[] derEncodedSignature = derEncodeRawSignature(signatureData);
+        signature.initVerify(pk);
+        signature.update(data);
+        return signature.verify(derEncodedSignature);
+    }
+
+    /**
+     * Helper method to load Java signature instances. Supports RSA PKCS1, RSA
+     * PSS, and ECDSA signatures.
+     *
+     * @param alg the algorithm name in COSE-compatible format
+     * @return a configured {@link Signature} instance
+     */
+    @SuppressWarnings("MagicNumber")
+    private Signature loadSignatureInstance(final String alg)
+            throws NoSuchAlgorithmException, InvalidAlgorithmParameterException {
+        Signature signature = null;
+        if (CoseAlgorithm.isRsaPssName(alg)) {
+            PSSParameterSpec pssParams = null;
+            if (alg.compareToIgnoreCase(CoseAlgorithm.RSA_SHA256_PSS) == 0) {
+                pssParams = new PSSParameterSpec("SHA-256", "MGF1", new MGF1ParameterSpec("SHA-256"), 32,
+                        1);
+            } else if (alg.compareToIgnoreCase(CoseAlgorithm.RSA_SHA384_PSS) == 0) {
+                pssParams = new PSSParameterSpec("SHA-384", "MGF1", new MGF1ParameterSpec("SHA-384"), 48,
+                        1);
+            } else if (alg.compareToIgnoreCase(CoseAlgorithm.RSA_SHA512_PSS) == 0) {
+                pssParams = new PSSParameterSpec("SHA-512", "MGF1", new MGF1ParameterSpec("SHA-512"), 64,
+                        1);
+            }
+            signature = Signature.getInstance("RSASSA-PSS");
+            signature.setParameter(pssParams);
+        } else {
+            switch (alg) {
+                case CoseAlgorithm.RSA_SHA512_PKCS1:
+                    signature = Signature.getInstance("SHA512withRSA");
+                    break;
+                case CoseAlgorithm.RSA_SHA384_PKCS1:
+                    signature = Signature.getInstance("SHA384withRSA");
+                    break;
+                case CoseAlgorithm.RSA_SHA256_PKCS1:
+                    signature = Signature.getInstance("SHA256withRSA");
+                    break;
+                case CoseAlgorithm.ECDSA_SHA256:
+                    signature = Signature.getInstance("SHA256withECDSA");
+                    break;
+                case CoseAlgorithm.ECDSA_SHA384:
+                    signature = Signature.getInstance("SHA384withECDSA");
+                    break;
+                case CoseAlgorithm.ECDSA_SHA512:
+                    signature = Signature.getInstance("SHA512withECDSA");
+                    break;
+                default:
+                    throw new RuntimeException("Algorithm combination not supported: " + algorithm);
+            }
+        }
+        return signature;
+    }
+
+    /**
+     * Converts the signature block (from COSE) to a DER encoded format used by
+     * Java.security.
+     *
+     * @param signature a COSE-compatible signature block
+     * @return the given signature block in DER encoded format
+     */
+    @SuppressWarnings("MagicNumber")
+    private byte[] derEncodeRawSignature(final byte[] signature) throws IOException {
+        int n = 32;
+        final int signum = 1;
+        // System.out.println("Signature Size is "+ signature.length);
+        if (CoseAlgorithm.isEcdsaName(algorithm)) {
+            if (signature.length >= 94 && signature.length <= 98) {
+                n = 48;
+            } else if (signature.length >= 130 && signature.length <= 134) {
+                n = 66;
+            }
+
+            final BigInteger r = new BigInteger(signum, Arrays.copyOfRange(signature, 0, n));
+            final BigInteger s = new BigInteger(signum, Arrays.copyOfRange(signature, n, n * 2));
+
+            final DERSequence sequence = new DERSequence(
+                    new ASN1Encodable[] {new ASN1Integer(r), new ASN1Integer(s)});
+            return sequence.getEncoded();
+        } else if (CoseAlgorithm.isRsaName(algorithm)) {
+            return signature;
+        }
+        throw new RuntimeException(
+                "Unknown Algorithm provided for COSE signature processing. COSE Algorithm ID = "
+                        + algorithm);
+    }
+
+    /**
+     * Removes the Der Encoding from the signature data to produce a "Raw"
+     * Signature. Result should be conformant with IEEE P1363.
+     *
+     * @param signatureBytes the DER-encoded signature bytes to process
+     * @return raw signature as a concatenation of r and s, or the input bytes
+     * if RSA
+     */
+    private byte[] removeDerFromSignature(final byte[] signatureBytes) throws IOException {
+        byte[] rawSignature = null;
+        int rOffset = 0;
+        int sOffset = 0;
+        // Strip off DER encoding left by Java.Security
+        if (CoseAlgorithm.isEcdsaName(algorithm)) {
+            try (ASN1InputStream asn1InputStream = new ASN1InputStream(signatureBytes)) {
+                final ASN1Sequence sequence = (ASN1Sequence) asn1InputStream.readObject();
+                final BigInteger r = ((ASN1Integer) sequence.getObjectAt(0)).getValue();
+                final BigInteger s = ((ASN1Integer) sequence.getObjectAt(1)).getValue();
+                byte[] rbytes = r.toByteArray();
+                byte[] sbytes = s.toByteArray();
+                int rLength = r.toByteArray().length;
+                int sLength = s.toByteArray().length;
+                // Copy individual components into the final array but account
+                // for missing leading 0's
+                if (((rLength % 2) != 0) && (rbytes[0] == 0)) {
+                    rbytes = removeLeadingByte(rbytes);
+                    rLength = rbytes.length;
+                } else if ((rLength % 2) != 0) {
+                    rOffset = 1; // make adjustments for odd length and non zero
+                    // first byte
+                }
+
+                if (((sLength % 2) != 0) && (sbytes[0] == 0)) {
+                    sbytes = removeLeadingByte(sbytes);
+                    sLength = sbytes.length;
+                } else if ((sLength % 2) != 0) {
+                    sOffset = 1; // make adjustments for odd length and non zero
+                    // first byte
+                }
+
+                rawSignature = new byte[rLength + rOffset + sLength + sOffset];
+                // If there was a leading zero then set the specific byte to 0
+                // in the output
+                if (rOffset == 1) {
+                    rawSignature[0] = 0;
+                }
+                if (sOffset == 1) {
+                    rawSignature[rLength + rOffset] = 0;
+                }
+
+                System.arraycopy(rbytes, 0, rawSignature, rOffset, rLength);
+                System.arraycopy(sbytes, 0, rawSignature, rLength + rOffset + sOffset, sLength);
+            }
+        } else if (CoseAlgorithm.isRsaName(algorithm)) {
+            return signatureBytes;
+        } else {
+            throw new RuntimeException(
+                    " Unknown or unsupported algorithm specified when processing signature by the "
+                            + "default cryptographic device");
+        }
+        return rawSignature;
+    }
+
+    /**
+     * Removes a leading byte from an array and resizes the array.
+     *
+     * @param byteArray the original byte array
+     * @return new array without leading byte
+     */
+    private byte[] removeLeadingByte(final byte[] byteArray) {
+        if (byteArray == null || byteArray.length == 0) {
+            return byteArray;
+        }
+        return Arrays.copyOfRange(byteArray, 1, byteArray.length);
+    }
+}

--- a/HIRS_Utils/src/main/java/hirs/utils/crypto/package-info.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/crypto/package-info.java
@@ -1,0 +1,2 @@
+/** Cryptographic support for creation and verification of digital signatures. */
+package hirs.utils.crypto;

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/cbor/ietfCoswid/CoswidItems.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/cbor/ietfCoswid/CoswidItems.java
@@ -1,0 +1,356 @@
+package hirs.utils.rim.unsignedRim.cbor.ietfCoswid;
+
+/**
+ * Class that provides support for table 9 of rfc 9393 (CoSWID Items Initial Registrations).
+ * The static fields are intended to be referenced the CoSWID parser and builder.
+ */
+public class CoswidItems {
+    // Constant Index values defined in RFC 9393 Table 9
+    // concise-swid-tag map
+    /** A 16-byte binary string, or a textual identifier, uniquely referencing a software component. */
+    public static final int TAG_ID_INT = 0;
+    /** Textual item that provides the software component's namee. */
+    public static final int SOFTWARE_NAME_INT = 1;
+    /** Provides information about one or more organizations responsible for producing the CoSWID tag. */
+    public static final int ENTITY_INT = 2;
+    /** Records the results of a software discovery process used to identify untagged software. */
+    public static final int EVIDENCE_INT = 3;
+    /** Provides a means to establish relationship arcs between the tag and another item. */
+    public static final int LINK_INT = 4;
+    /** An open-ended map of key/value data pairs. */
+    public static final int SOFTWARE_META_INT = 5;
+    /** Represents a collection of software artifacts that compose the target software. */
+    public static final int PAYLOAD_INT = 6;
+    /**  Value that provides a hash of a file. */
+    public static final int HASH_INT = 7;           // note: belongs to resource-collection group
+    /** A boolean value that indicates if software component is an installable software component. */
+    public static final int CORPUS_INT = 8;
+    /** Indicates that the software component is an incremental change installed on an endpoint. */
+    public static final int PATCH_INT = 9;
+    /** Media. */
+    public static final int MEDIA_INT = 10;
+    /** A boolean value that indicates if the tag is associated with another referenced SWID or CoSWID tag. */
+    public static final int SUPPLEMENTAL_INT = 11;
+    /** An integer value that indicates the specific release revision of the tag. */
+    public static final int TAG_VERSION_INT = 12;
+    /** A textual value representing the specific release or development version of the software component. */
+    public static final int SOFTWARE_VERSION_INT = 13;
+    /**  An integer or textual value representing the versioning scheme used for the software-version item. */
+    public static final int VERSION_SCHEME_INT = 14;
+    // global-attributes group
+    /** Language. */
+    public static final int LANG_INT = 15;
+    // resource-collection group
+    /** Item that allows child directory and file items to be defined within a directory hierarchy. */
+    public static final int DIRECTORY_INT = 16;
+    /** Item that allows details about a file to be provided for the software component. */
+    public static final int FILE_INT = 17;
+    /** Item that allows details to be provided about the runtime behavior of the software component. */
+    public static final int PROCESS_INT = 18;
+    /** Item that can be used to provide details about an artifact or capability. */
+    public static final int RESOURCE_INT = 19;
+    /** The file's size in bytes. */
+    public static final int SIZE_INT = 20;
+    /** The file's version as reported by querying information on the file from the operating system. */
+    public static final int FILE_VERSION_INT = 21;
+    /** A boolean value indicating if a file or directory is significant or required. */
+    public static final int KEY_INT = 22;
+    /** The filesystem path of the location of the CoSWID tag generated as evidence. */
+    public static final int LOCATION_INT = 23;
+    /** The name of the directory or file without any path informatio. */
+    public static final int FS_NAME_INT = 24;
+    /** A host-specific name for the root of the filesystem. */
+    public static final int ROOT_STR_INT = 25;
+    /** Group that allows a hierarchy of directory and file items to be defined in payload. */
+    public static final int PATH_ELEMENTS_INT = 26;
+    /** The software component's process name as it will appear in an endpoint's process list. */
+    public static final int PROCESS_NAME_INT = 27;
+    /** The process ID for a running instance of the software component in the endpoint's process list. */
+    public static final int PID_INT = 28;
+    /** A human-readable string indicating the type of resource. */
+    public static final int TYPE_INT = 29;
+    /** Name of the organizational entity claiming the roles for the CoSWID tag. */
+    public static final int UNASSIGNED_INT = 30;
+    /** entity-entry map. */
+    public static final int ENTITY_NAME_INT = 31;
+    /** Registration ID. */
+    public static final int REG_ID_INT = 32;
+    /** A textual value representing the relationship(s) between the entity and the software component. */
+    public static final int ROLE_INT = 33;
+    /** Value that provides a hash (i.e., the thumbprint) of the signing entity's public key certificate. */
+    public static final int THUMBPRINT_INT = 34;
+    // evidence-entry map
+    /** The date and time the information was collected. */
+    public static final int DATE_INT = 35;
+    /** The endpoint's string identifier from which the evidence was collected. */
+    public static final int DEVICE_INT = 36;
+    // link-entry map
+    /** Provides the absolute filesystem path to the installer executable. */
+    public static final int ARTIFACT_INT = 37;
+    /** A URI-reference for the referenced resource. */
+    public static final int HREF_INT = 38;
+    /** Indicates the degree of ownership between the software component and the referenced link. */
+    public static final int OWNERSHIP_INT = 39;
+    /** Relationship between this CoSWID and the target resource identified by the href item.. */
+    public static final int REL_INT = 40;
+    /** Supplies the resource consumer with a hint regarding what type of resource to expect. */
+    public static final int MEDIA_TYPE_INT = 41;
+    /** An integer or textual value used to determine if prerequisite software is required to be installed. */
+    public static final int USE_INT = 42;
+    // software-meta-entry map
+    /** A textual value that identifies how the software component has been activated. */
+    public static final int ACTIVATION_STATUS_INT = 43;
+    /** A textual value that identifies a sales, licensing, or marketing channel. */
+    public static final int CHANNEL_TYPE_INT = 44;
+    /** A textual value for the software component's informal or colloquial version. */
+    public static final int COLLOQUIAL_VERSION_INT = 45;
+    /** A textual value that provides a detailed description of the software componen. */
+    public static final int DESCRIPTION_INT = 46;
+    /** ext indicating a functional variation of the code base. */
+    public static final int EDITION_INT = 47;
+    /** A boolean value that can be used to determine if accompanying proof of entitlement is needed. */
+    public static final int ENTITLEMENT_DATA_REQUIRED_INT = 48;
+    /** vendor-specific key that can be used to identify an entitlement. */
+    public static final int ENTITLEMENT_KEY_INT = 49;
+    /** The name (or tag-id) of the software component that created the CoSWID tag. */
+    public static final int GENERATOR_INT = 50;
+    /** A globally unique identifier used to identify a set of software components that are related. */
+    public static final int PERSISTENT_ID_INT = 51;
+    /**  A basic name for the software component. */
+    public static final int PRODUCT_INT = 52;
+    /** A textual value indicating the software components' overall product family. */
+    public static final int PRODUCT_FAMILY_INT = 53;
+    /** A string value indicating an informal or colloquial release version of the software. */
+    public static final int REVISION_INT = 54;
+    /** A short description of the software component. */
+    public static final int SUMMARY_INT = 55;
+    /** United Nations Standard Products and Services Code. */
+    public static final int UNSPSC_CODE_INT = 56;
+    /** United Nations Standard Products and Services Code version. */
+    public static final int UNSPSC_VERSION_INT = 57;
+    // other
+    /** Unknown item id. */
+    public static final int UNKNOWN_INT = 99;
+
+    // Constant Item Names defined in RFC 9393 Table 9
+    // concise-swid-tag map
+    /** A 16-byte binary string, or a textual identifier, uniquely referencing a software component. */
+    public static final String TAG_ID_STR = "tag-id";
+    /** Textual item that provides the software component's name. */
+    public static final String SOFTWARE_NAME_STR = "software-name";
+    /** Provides information about one or more organizations responsible for producing the CoSWID tag. */
+    public static final String ENTITY_STR = "entity";
+    /** Records the results of a software discovery process used to identify untagged software. */
+    public static final String EVIDENCE_STR = "evidence";
+    /** Provides a means to establish relationship arcs between the tag and another item. */
+    public static final String LINK_STR = "link";
+    /** An open-ended map of key/value data pairs. */
+    public static final String SOFTWARE_META_STR = "software-meta";
+    /** Represents a collection of software artifacts that compose the target software. */
+    public static final String PAYLOAD_STR = "payload";
+    /** Value that provides a hash of a file. */
+    public static final String HASH_STR = "hash";           // belongs to resource-collection group
+    /** A boolean value that indicates if software component is an installable software component. */
+    public static final String CORPUS_STR = "corpus";
+    /** Indicates that the software component is an incremental change installed on an endpoint. */
+    public static final String PATCH_STR = "patch";
+    /** A boolean value that indicates if the tag is associated with another referenced SWID or CoSWID tag.*/
+    public static final String SUPPLEMENTAL_STR = "supplemental";
+    /** An integer value that indicates the specific release revision of the tag. */
+    public static final String TAG_VERSION_STR = "tag-version";
+    /** A textual value representing the specific release or development version of the software component. */
+    public static final String SOFTWARE_VERSION_STR = "software-version";
+    /** An integer or textual value representing the versioning scheme used for the software-version item. */
+    public static final String VERSION_SCHEME_STR = "version-scheme";
+    // global-attributes group
+    /** Language. */
+    public static final String LANG_STR = "lang";
+    // resource-collection group
+    /** Item that allows child directory and file items to be defined within a directory hierarchy. */
+    public static final String DIRECTORY_STR = "directory";
+    /** Item that allows details about a file to be provided for the software component. */
+    public static final String FILE_STR = "file";
+    /** Item that allows details to be provided about the runtime behavior of the software component. */
+    public static final String PROCESS_STR = "process";
+    /** Item that can be used to provide details about an artifact or capability. */
+    public static final String RESOURCE_STR = "resource";
+    /** The file's size in bytes. */
+    public static final String SIZE_STR = "size";
+    /** The file's version as reported by querying information on the file from the operating system. */
+    public static final String FILE_VERSION_STR = "file-version";
+    /** A boolean value indicating if a file or directory is significant or required. */
+    public static final String KEY_STR = "key";
+    /** The filesystem path of the location of the CoSWID tag generated as evidence. */
+    public static final String LOCATION_STR = "location";
+    /** The name of the directory or file without any path information. */
+    public static final String FS_NAME_STR = "fs-name";
+    /** A host-specific name for the root of the filesystem. */
+    public static final String ROOT_STR = "root";
+    /** Group that allows a hierarchy of directory and file items to be defined in payload. */
+    public static final String PATH_ELEMENTS_STR = "path-elements";
+    /** The software component's process name as it will appear in an endpoint's process list. */
+    public static final String PROCESS_NAME_STR = "process-name";
+    /** The process ID for a running instance of the software component in the endpoint's process list. */
+    public static final String PID_STR = "pid";
+    /** A human-readable string indicating the type of resource. */
+    public static final String TYPE_STR = "type";
+    // other
+    /** Not currently a valid rfc 9393 item. */
+    public static final String UNASSIGNED_STR = "Unassigned";
+    // entity-entry map
+    /** Name of the organizational entity claiming the roles for the CoSWID tag. */
+    public static final String ENTITY_NAME_STR = "entity-name";
+    /** Registration ID. */
+    public static final String REG_ID_STR = "reg-id";
+    /** A textual value representing the relationship(s) between the entity and the software component. */
+    public static final String ROLE_STR = "role";
+    /** Value that provides a hash (i.e., the thumbprint) of the signing entity's public key certificate. */
+    public static final String THUMBPRINT_STR = "thumbprint";
+    // evidence-entry map
+    /** The date and time the information was collected. */
+    public static final String DATE_STR = "date";
+    /** The endpoint's string identifier from which the evidence was collected. */
+    public static final String DEVICE_STR = "device";
+    // link-entry map
+    /** Item represents a query as defined by the W3C "Media Queries Level 3" Recommendation.  */
+    public static final String MEDIA_STR = "media";
+    /** Provides the absolute filesystem path to the installer executable. */
+    public static final String ARTIFACT_STR = "artifact";
+    /** A URI-reference for the referenced resource. */
+    public static final String HREF_STR = "href";
+    /** Indicates the degree of ownership between the software component and the referenced link. */
+    public static final String OWNERSHIP_STR = "ownership";
+    /** Relationship between this CoSWID and the target resource identified by the href item. */
+    public static final String REL_STR = "rel";
+    /** Supplies the resource consumer with a hint regarding what type of resource to expect. */
+    public static final String MEDIA_TYPE_STR = "media-type";
+    /** An integer or textual value used to determine if prerequisite software is required to be installed.*/
+    public static final String USE_STR = "use";
+    // software-meta-entry map
+    /** A textual value that identifies how the software component has been activated. */
+    public static final String ACTIVATION_STATUS_STR = "activation-status";
+    /** A textual value that identifies a sales, licensing, or marketing channel. */
+    public static final String CHANNEL_TYPE_STR = "channel-type";
+    /** A textual value for the software component's informal or colloquial version. */
+    public static final String COLLOQUIAL_VERSION_STR = "colloquial-version";
+    /**A textual value that provides a detailed description of the software component. */
+    public static final String DESCRIPTION_STR = "description";
+    /** Text indicating a functional variation of the code base. */
+    public static final String EDITION_STR = "edition";
+    /**A boolean value that can be used to determine if accompanying proof of entitlement is needed. */
+    public static final String ENTITLEMENT_DATA_REQUIRED_STR = "entitlement-data-required";
+    /** A vendor-specific key that can be used to identify an entitlement. */
+    public static final String ENTITLEMENT_KEY_STR = "entitlement-key";
+    /** The name (or tag-id) of the software component that created the CoSWID tag. */
+    public static final String GENERATOR_STR = "generator";
+    /** A globally unique identifier used to identify a set of software components that are related. */
+    public static final String PERSISTENT_ID_STR = "persistent-id";
+    /**A basic name for the software component. */
+    public static final String PRODUCT_STR = "product";
+    /** A textual value indicating the software components' overall product family. */
+    public static final String PRODUCT_FAMILY_STR = "product-family";
+    /** A string value indicating an informal or colloquial release version of the software. */
+    public static final String REVISION_STR = "revision";
+    /** A short description of the software component. */
+    public static final String SUMMARY_STR = "summary";
+    /** United Nations Standard Products and Services Code. */
+    public static final String UNSPSC_CODE_STR = "unspsc-code";
+    /** United Nations Standard Products and Services Code version. */
+    public static final String UNSPSC_VERSION_STR = "unspsc-version";
+    /** Unknown item name. */
+    public static final String UNKNOWN_STR = "unknown";
+    /** Array of valid Coswid index names. */
+    private static final String[][] INDEX_NAMES = {
+            {"0", "tag-id" },
+            {"1", "software-name" },
+            {"2", "entity" },
+            {"3", "evidence" },
+            {"4", "link" },
+            {"5", "software-meta" },
+            {"6", "payload" },
+            {"7", "hash" },
+            {"8", "corpus" },
+            {"9", "patch" },
+            {"10", "media" },
+            {"11", "supplemental" },
+            {"12", "tag-version" },
+            {"13", "software-version" },
+            {"14", "version-scheme" },
+            {"15", "lang" },
+            {"16", "directory" },
+            {"17", "file" },
+            {"18", "process" },
+            {"19", "resource" },
+            {"20", "size" },
+            {"21", "file-version" },
+            {"22", "key" },
+            {"23", "location" },
+            {"24", "fs-name" },
+            {"25", "root" },
+            {"26", "path-elements" },
+            {"27", "process-name" },
+            {"28", "pid" },
+            {"29", "type" },
+            {"30", "Unassigned" },
+            {"31", "entity-name" },
+            {"32", "reg-id" },
+            {"33", "role" },
+            {"34", "thumbprint" },
+            {"35", "date" },
+            {"36", "device-id" },
+            {"37", "artifact" },
+            {"38", "href" },
+            {"39", "ownership" },
+            {"40", "rel" },
+            {"41", "media-type" },
+            {"42", "use" },
+            {"43", "activation-status" },
+            {"44", "channel-type" },
+            {"45", "colloquial-version" },
+            {"46", "description" },
+            {"47", "edition" },
+            {"48", "entitlement-data-required" },
+            {"49", "entitlement-key" },
+            {"50", "generator" },
+            {"51", "persistent-id" },
+            {"52", "product" },
+            {"53", "product-family" },
+            {"54", "revision" },
+            {"55", "summary" },
+            {"56", "unspsc-code" },
+            {"57", "unspsc-version" }
+    };
+    /**
+     * Searches Rfc 9393 Items Names for match to a specified item name and returns the index.
+     * @param itemName  Iem Name specified in section 6.1 of rfc 9393
+     * @return int id of algorithm
+     */
+    public static int getIndex(final String itemName) {
+        for (int i = 0; i < INDEX_NAMES.length; i++) {
+            if (itemName.compareToIgnoreCase(INDEX_NAMES[i][1]) == 0) {
+                return i;
+            }
+        }
+        return UNKNOWN_INT;
+    }
+    /**
+     * Searches for an rfc 9393 specified index and returns the item name associated with the index.
+     * @param index int rfc 939 sepcified index value
+     * @return String item name associated with the index
+     */
+    public static String getItemName(final int index) {
+        for (int i = 0; i < INDEX_NAMES.length; i++) {
+            if (index == Integer.parseInt(INDEX_NAMES[i][0])) {
+                return INDEX_NAMES[i][1];
+            }
+        }
+        return UNKNOWN_STR;
+    }
+
+    /**
+     * Protected constructor.
+     */
+    protected CoswidItems() {
+
+    }
+}

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/cbor/ietfCoswid/package-info.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/cbor/ietfCoswid/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package that supports IETF 9393, "Coswid".
+ */
+package hirs.utils.rim.unsignedRim.cbor.ietfCoswid;

--- a/HIRS_Utils/src/main/java/hirs/utils/signature/cose/CoseAlgorithm.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/signature/cose/CoseAlgorithm.java
@@ -1,0 +1,169 @@
+package hirs.utils.signature.cose;
+
+import hirs.utils.rim.unsignedRim.cbor.ietfCoswid.CoswidItems;
+
+/**
+ * Class to handle COSE algorithms specified on https://www.iana.org/assignments/cose/cose.xhtml#algorithms.
+ * As specified by the COSE specification (rfc rfc8152) and constrained by the TCG Component Rim binding spec
+ * (for CoSwid).
+ * Processing is limited to the Algorithm Combinations suited to TCG registered signatures.
+ */
+public final class CoseAlgorithm {
+    /** IANA Registered COSE Algorithm. */
+    public static final int COSE_RSA_SHA_512 = -259;  // Uses PKCS-v1_5 padding
+    /** IANA Registered COSE Algorithm. */
+    public static final int COSE_RSA_SHA_384 = -258;
+    /** IANA Registered COSE Algorithm. */
+    public static final int COSE_RSA_SHA_256 = -257;
+    /** IANA Registered COSE Algorithm. */
+    public static final int COSE_ES_SHA_512 = -36;
+    /** IANA Registered COSE Algorithm. */
+    public static final int COSE_ES_SHA_384 = -35;
+    /** IANA Registered COSE Algorithm. */
+    public static final int COSE_ES_SHA_256 = -7;
+    /** IANA Registered COSE Algorithm. */
+    public static final int COSE_RSA_PSS_512 = -39;
+    /** IANA Registered COSE Algorithm. */
+    public static final int COSE_RSA_PSS_384 = -38;
+    /** IANA Registered COSE Algorithm. */
+    public static final int COSE_RSA_PSS_256 = -37;
+    /** IANA Registered COSE Algorithm. */
+    public static final int COSE_SHA_256 = -16;
+    /** IANA Registered COSE Algorithm Name. */
+    public static final String RSA_SHA512_PKCS1 = "RS512";
+    /** IANA Registered COSE Algorithm Name. */
+    public static final String RSA_SHA384_PKCS1 = "RS384";
+    /** IANA Registered COSE Algorithm Name. */
+    public static final String RSA_SHA256_PKCS1 = "RS256";
+    /** IANA Registered COSE Algorithm Name. */
+    public static final String RSA_SHA512_PSS = "PS512";
+    /** IANA Registered COSE Algorithm Name. */
+    public static final String RSA_SHA384_PSS = "PS384";
+    /** IANA Registered COSE Algorithm Name. */
+    public static final String RSA_SHA256_PSS = "PS256";
+    /** IANA Registered COSE Algorithm Name. */
+    public static final String ECDSA_SHA256 = "ES256";
+    /** IANA Registered COSE Algorithm Name. */
+    public static final String ECDSA_SHA384 = "ES384";
+    /** IANA Registered COSE Algorithm Name. */
+    public static final String ECDSA_SHA512 = "ES512";
+    /** IANA Registered COSE Algorithm Name. */
+    public static final String SHA256 = "SHA-256";
+
+    private static final String[][] ALG_NAMES = {
+            {"-259", "RS512"},     // RSASSA-PKCS1-v1_5 using SHA-512
+            {"-258", "RS384"},     // RSASSA-PKCS1-v1_5 using SHA-384
+            {"-257", "RS256"},     // RSASSA-PKCS1-v1_5 using SHA-256
+            {"-39", "PS512"},      // RSASSA-PSS w/ SHA-512
+            {"-38", "PS384"},      // RSASSA-PSS w/ SHA-384
+            {"-37", "PS256"},      // RSASSA-PSS w/ SHA-256
+            {"-36", "ES512"},      // ECDSA w/ SHA-512
+            {"-35", "ES384"},      // ECDSA w/ SHA-384
+            {"-16", "SHA-256"},     // SHA-2 256-bit Hash
+            {"-7", "ES256"}        // ECDSA w/ SHA-256
+    };
+
+    /**
+     * Default constructor for CoseAlgorithm.
+     */
+    private CoseAlgorithm() {
+    }
+    /**
+     * Searches Rfc 9393 Items Names for match to a specified item name and returns the index.
+     * @param coseAlg  Iem Name specified in rfc 8152
+     * @return int tag of the cose type
+     */
+    public static int getAlgId(final String coseAlg) {
+        int algId = 0;
+        for (int i = 0; i < ALG_NAMES.length; i++) {
+            if (coseAlg.compareToIgnoreCase(ALG_NAMES[i][1]) == 0) {
+                return (Integer.parseInt(ALG_NAMES[i][0]));
+            }
+        }
+        return CoswidItems.UNKNOWN_INT;
+    }
+    /**
+     * Searches for an Rfc 8152 specified index and returns the item name associated with the index.
+     * @param coseAlId IANA registered COSE Algorithm Value (ID)
+     * @return String Algorithm name associated with the Algorithm Value (ID)
+     */
+    public static String getAlgName(final int coseAlId) {
+        int algId = 0;
+        for (int i = 0; i < ALG_NAMES.length; i++) {
+            if (coseAlId == Integer.parseInt(ALG_NAMES[i][0])) {
+                return ALG_NAMES[i][1];
+            }
+        }
+        return CoswidItems.UNKNOWN_STR;
+    }
+    /**
+     * Returns true if the specified COSE algorithm identifier is a supported algorithm.
+     * from the ECDSA family of algorithms.
+     * @param cosAlId
+     * @return true if algorithm is COSE supported
+     */
+    public static boolean isEcdsa(final int cosAlId) {
+        if ((cosAlId == CoseAlgorithm.COSE_ES_SHA_256) || (cosAlId == CoseAlgorithm.COSE_ES_SHA_384)
+                || (cosAlId == CoseAlgorithm.COSE_ES_SHA_512)) {
+            return true;
+        }
+        return false;
+    }
+    /**
+     * Returns true of the specified COSE algorithm identifier is a supported algorithm
+     * from the ECDSA family of algorithms.
+     * @param coseAlgorithmName a IANA Registered COSE algorithm name
+     * @return true if algorithm is an ecdsa variant
+     */
+    public static boolean isEcdsaName(final String coseAlgorithmName) {
+        if ((coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.ECDSA_SHA256) == 0)
+                || (coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.ECDSA_SHA384) == 0)
+                || (coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.ECDSA_SHA512) == 0)) {
+            return true;
+        }
+        return false;
+    }
+    /**
+     * Returns true of the specified COSE algorithm identifier is a supported algorithm
+     * from the RSA family of algorithms.
+     * @param cosAlId cose registered algorithm id
+     * @return true if algorithm is a rsa variant
+     */
+    public static boolean isRsa(final int cosAlId) {
+        return cosAlId == CoseAlgorithm.COSE_RSA_PSS_256
+                || cosAlId == CoseAlgorithm.COSE_RSA_PSS_384
+                || cosAlId == CoseAlgorithm.COSE_RSA_SHA_256;
+    }
+
+    /**
+     * Returns true of the specified COSE algorithm identifier is a supported algorithm
+     * from the ECDSA family of algorithms.
+     * @param coseAlgorithmName a IANA Registered COSE algorithm name
+     * @return true if algorithm is a rsa variant
+     */
+    public static boolean isRsaName(final String coseAlgorithmName) {
+        if ((coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.RSA_SHA256_PKCS1) == 0)
+                || (coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.RSA_SHA384_PKCS1) == 0)
+                || (coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.RSA_SHA512_PKCS1) == 0)
+                || (coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.RSA_SHA256_PSS) == 0)
+                || (coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.RSA_SHA384_PSS) == 0)
+                || (coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.RSA_SHA512_PSS) == 0)) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Returns true of the specified COSE algorithm is an RSA PSS variant.
+     * @param coseAlgorithmName name of the algorithm
+     * @return true if algorithm is a rsa-pss variant
+     */
+    public static boolean isRsaPssName(final String coseAlgorithmName) {
+        if ((coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.RSA_SHA256_PSS) == 0)
+                || (coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.RSA_SHA384_PSS) == 0)
+                || (coseAlgorithmName.compareToIgnoreCase(CoseAlgorithm.RSA_SHA512_PSS) == 0)) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/HIRS_Utils/src/main/java/hirs/utils/signature/cose/package-info.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/signature/cose/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Package for support of rfc rfc9052 (CBOR Object Signing and Encryption - COSE) signatures.
+ * Provides limited support rfc 9360 in terms of embedding the signing certificate and thumbprint.
+ */
+package hirs.utils.signature.cose;

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -13,6 +13,7 @@
     <!-- This ignores checking all public variable for a javadoc -->
     <suppress files="SwidTagConstants.java" checks="LineLength"/>
     <suppress files="SwidTagConstants.java" checks="JavadocVariable"/>
+    <suppress files="DefaultCrypto.java" checks="MagicNumber"/>
 
     <!-- This ignores checking for public constructors in utility classes in certain files -->
     <suppress files="HIRSApplication.java" checks="HideUtilityClassConstructor"/>

--- a/gradle/versions.toml
+++ b/gradle/versions.toml
@@ -16,6 +16,7 @@ jcommanderVersion = "2.0"
 lombokVersion = "1.18.36"
 mariadbVersion = "3.5.1"
 minimalJsonVersion = "0.9.5"
+nimbusJwtVersion = "10.0.1"
 ospackageVersion = "11.2.0"
 pciVersion = "0.3"
 protobufJavaVersion = "4.28.3"
@@ -50,6 +51,7 @@ jcommander = { module = "org.jcommander:jcommander", version.ref = "jcommanderVe
 lombok = { module = "org.projectlombok:lombok", version.ref = "lombokVersion" }
 mariadb-java-client = { module = "org.mariadb.jdbc:mariadb-java-client", version.ref = "mariadbVersion" }
 minimal-json = { module = "com.eclipsesource.minimal-json:minimal-json", version.ref = "minimalJsonVersion" }
+nimbus-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbusJwtVersion" }
 pci = { module = "com.github.marandus:pci-ids", version.ref = "pciVersion" }
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobufJavaVersion" }
 snake-yaml = { module = "org.yaml:snakeyaml", version.ref = "snakeYamlVersion" }


### PR DESCRIPTION
This PR will resolve the migration of the CoSwid Project's `/rim/crypto` module into `HIRS_Utils`. A few classes outside of this module are included due to dependencies.

Much of CoSwid's code uses many "Magic Numbers" and protected variables that we currently flag in Checkstyle. For now, new classes that have too many of those instances will have those warnings supressed, such as `DefaultCrypto` here.

New classes:
- CoSwid classes to be moved into `HIRS_Utils/src/main/java/hirs/utils/crypto`:
  - `/rim/crypto/AlgorithmsIds.java`
  - `/rim/crypto/CryptoEngine.java`
  - `/rim/crypto/DefaultCrypto.java`
- CoSwid classes to be moved into `HIRS_Utils/src/main/java/hirs/utils/signature`:
  - `/rim/signature/cose/CoseAlgorithm.java`
- CoSwid classes to be moved into `HIRS_Utils/src/main/java/hirs/utils/rim`:
  - `/rim/unsignedRim/cbor/ietfCoswid/CoswidItems.java`

Resolves #954