### PR TITLE
[#956] ACA Properties Not Initialized In Window Docker Containers

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/resources/application.win.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.win.properties
@@ -11,7 +11,6 @@ jakarta.persistence.sharedCache.mode=UNSPECIFIED
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 #spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 #spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
-aca.certificates.validity=3652
 # Tomcat Config
 server.tomcat.additional-tld-skip-patterns=jakarta.persistence-api*.jar, jakarta.xml.bind-api*.jar, txw2*.jar, *commons*.jar,  *annotations*.jar, *checker*.jar, *lombok*.jar, *jsr*.jar, *guava*.jar, *access*.jar, *activation*.jar, *bcprov*.jar, *bcmail*.jar, *bcutil*.jar, *bcpkix*.jar, *json*.jar 
 server.tomcat.basedir=C:/ProgramData/hirs/embeddedtomcat
@@ -35,6 +34,20 @@ server.ssl.key-store=C:/ProgramData/hirs/certificates/HIRS/KeyStore.jks
 server.ssl.key-alias=hirs_aca_tls_rsa_3k_sha384
 server.ssl.enabled-protocols=TLSv1.2, TLSv1.3
 server.ssl.ciphers=TLS_AES_256_GCM_SHA384, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384
+# ACA specific default properties
+aca.certificates.leaf-three-key-alias=HIRS_leaf_ca3_rsa_3k_sha384
+aca.certificates.intermediate-key-alias=HIRS_intermediate_ca_rsa_3k_sha384
+aca.certificates.root-key-alias=HIRS_root_ca_rsa_3k_sha384
+aca.certificates.validity=3652
+# Compression settings
+server.compression.enabled=true
+# Compression content types
+server.compression.mime-types=application/javascript,application/json,application/xml,text/css,text/html,text/plain,text/xml
+# Minimum response size for compression
+server.compression.min-response-size=2048
+#Spring Boot actuator
+management.endpoints.web.exposure.include=health,info,metrics,loggers,beans
+management.endpoint.health.show-details=always
 #--server.ssl.key-store-password=123456
 #--server.ssl.trust-store-password=123456
 #jdbc.driverClassName = com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
### Description
The logs from some of the Windows-based Docker containers indicate that certain newly created properties from PR https://github.com/nsacyber/HIRS/pull/931 are not being properly initialized, preventing the containers from functioning as expected.

### Test Instructions:


### Issues This PR Addresses:
Closes #956 