### PR TITLE
[#979]: Lengthen Certificate Bytes Column Definition

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/Certificate.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/Certificate.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Lob;
 import jakarta.persistence.Transient;
 import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
@@ -176,7 +177,7 @@ public abstract class Certificate extends ArchivableEntity {
     // We're currently seeing 2048-bit keys, which is 512 hex digits.
     // Using a max length of 1024 for future-proofing.
     @Getter
-    @Column(length = CertificateVariables.MAX_PUB_KEY_MODULUS_HEX_LENGTH, nullable = true)
+    @Column(length = CertificateVariables.MAX_PUB_KEY_MODULUS_HEX_LENGTH)
     private final String publicKeyModulusHexValue;
 
     @Column(length = CertificateVariables.MAX_CERT_LENGTH_BYTES, nullable = false)
@@ -210,13 +211,14 @@ public abstract class Certificate extends ArchivableEntity {
     @Column(precision = CertificateVariables.MAX_NUMERIC_PRECISION)
     private final BigInteger authoritySerialNumber;
 
-    @Column(length = CertificateVariables.MAX_CERT_LENGTH_BYTES * CertificateVariables.KEY_USAGE_BIT4,
-            nullable = false)
+    @Lob
+    @Column(nullable = false, columnDefinition = "BLOB")
     @JsonIgnore
     private byte[] certificateBytes;
 
     @Getter
     private String holderIssuer;
+
     // we don't need to persist this, but we don't want to unpack this cert multiple times
     @Transient
     private X509Certificate parsedX509Cert = null;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/CertificateVariables.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/CertificateVariables.java
@@ -23,7 +23,7 @@ public final class CertificateVariables {
      */
     public static final String MALFORMED_CERT_MESSAGE = "Malformed certificate detected.";
     /**
-     *
+     * Maximum certificate length in bytes.
      */
     public static final int MAX_CERT_LENGTH_BYTES = 2048;
     /**


### PR DESCRIPTION
### Description
Increase the length of the Certificate Bytes column definition to ensure that large Certificates can be uploaded to the ACA.

### Test Instructions
1. Download the latest and greatest version of paccor (vbeta3) https://github.com/nsacyber/paccor/releases/tag/v1.5.0beta3 to your Linux device.
2. If you're using a tar file, extract the tar file and head over to the scripts directory and find the pc_certgen.sh script. (If you decided to take the install rpm or debian file route, head over to the `/opt/paccor/scripts`.
3. Once you find the script,  run the `pc_certgen.sh`  script in sudo mode: 
   ```
   sudo ./pc_certgen.sh
   ```
4. Make sure that you find an endorsement credential and a newly minted platform certificate in the pc_testgen directory. I would highly suggest copying the certs over to your home directory and changing the read privileges for those certs so that you can upload the certs without any hitches: 
    ```
    sudo cp platform*crt ~/Downloads
    cd ~/Downloads
    sudo chmod a+r platform*.crt
    ```
5. Run the ACA using your preferred method and upload the newly minted Platform Certificate to the Platform Certificate page of the ACA.
6. Verify that you can do not get back a 404 error and that you can see the Platform Certificate's details (including the list of components)


### Issues This PR Addresses:
Closes #979 