### PR TITLE
[#980] Remove -p command line requirement for embedded certs

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
@@ -181,7 +181,7 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
             try {
                 if (referenceManifestValidator.validateXmlSignature(
                         signingCert.getX509Certificate().getPublicKey(),
-                        signingCert.getSubjectKeyIdString(), signingCert.getEncodedPublicKey())) {
+                        signingCert.getSubjectKeyIdString())) {
                     try {
                         if (!SupplyChainCredentialValidator.verifyCertificate(
                                 signingCert.getX509Certificate(), keyStore)) {

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestDetailsPageController.java
@@ -262,7 +262,7 @@ public class ReferenceManifestDetailsPageController
                         + e.getMessage());
             }
             if (RIM_VALIDATOR.validateXmlSignature(caCert.getX509Certificate().getPublicKey(),
-                    caCert.getSubjectKeyIdString(), caCert.getEncodedPublicKey())) {
+                    caCert.getSubjectKeyIdString())) {
                 try {
                     if (SupplyChainCredentialValidator.verifyCertificate(
                             caCert.getX509Certificate(), keystore)) {

--- a/tools/tcg_rim_tool/gradle/wrapper/gradle-wrapper.properties
+++ b/tools/tcg_rim_tool/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/VerifyArgumentValidator.java
+++ b/tools/tcg_rim_tool/src/main/java/hirs/swid/utils/VerifyArgumentValidator.java
@@ -13,7 +13,7 @@ import java.util.Map;
  */
 @Log4j2
 public class VerifyArgumentValidator implements IParametersValidator {
-    String[] requiredArgs = {"--rimel", "--publicCertificate", "--truststore"};
+    String[] requiredArgs = {"--rimel", "--truststore"};
     String errorMessage = "";
 
     /**


### PR DESCRIPTION
This PR comprises the following changes:
- remove -p requirement for validating a base RIM with an embedded cert
- refactor the method signature for ReferenceManifestValidator.validateXmlSignature() to remove byte[] encodedPublicKey, which was never used.

Test instructions:
**Command arguments used below are found in HIRS/tools/tcg_rim_tool/src/test/resources/.
1. Build the rimtool from main branch.  Run the following command:
`java -jar <tcg_rim_tool.jar> -v generated_user_cert_embed.swidtag -l TpmLog.bin -t RimCertChain.pem`
and confirm that the results is 
`[main] ERROR hirs.swid.Main - --publicCertificate is required to verify a base RIM.`
2. Build the rimtool from this branch.  Run the following command:
`java -jar <tcg_rim_tool.jar> -v generated_user_cert_embed.swidtag -l TpmLog.bin -t RimCertChain.pem`
and confirm that the result is 
`Successfully verified generated_user_cert_embed.swidtag`.
3. Build the rimtool from this branch.  Run the following command:
`java -jar <tcg_rim_tool.jar> -v generated_user_cert.swidtag -l TpmLog.bin -t RimCertChain.pem`
and confirm that the result is 
`A public signing certificate (-p) is required to verify this base RIM.`
`[main] ERROR hirs.swid.Main - Failed to verify src/test/resources/generated_user_cert.swidtag`


Closes #980 