### PR TITLE
[#971] Fix 3 Missing Jar Files Warning

### DIFF
--- a/HIRS_Utils/build.gradle
+++ b/HIRS_Utils/build.gradle
@@ -50,7 +50,7 @@ jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     manifest {
         attributes(
-                'Class-Path': configurations.runtimeClasspath.files.collect { it.getName() }.join(' ')
+                'Class-Path': configurations.runtimeClasspath.files.collect { it.toURI().toString() }.join(' ')
         )
     }
     //jar name format: [archiveBaseName]-[archiveAppendix]-[archiveVersion]-[archiveClassifier].[archiveExtension]


### PR DESCRIPTION
### Description
The ACA displays warnings for three different "missing jar" files on both Windows and Linux. This issue focuses on resolving these warnings.


### Test Instructions
1. Setup your ACA using this local branch and verify via the log file and the terminal window that the ACA no longer warns the users about missing jar files.


### Issues This PR Addresses:
Closes #971 