### PR TITLE
[#996] Add test resources inclusion in building of HIRS Utils jar

### DIFF
--- a/HIRS_Utils/build.gradle
+++ b/HIRS_Utils/build.gradle
@@ -55,6 +55,10 @@ jar {
     }
     //jar name format: [archiveBaseName]-[archiveAppendix]-[archiveVersion]-[archiveClassifier].[archiveExtension]
     archiveVersion = jarVersion
+
+    from(sourceSets.test.resources.srcDirs) {
+        into('/')
+    }
 }
 
 //task generateXjcLibrary(type:Exec) {


### PR DESCRIPTION
This PR is meant to include said resources in the HIRS_Utils jar file, as they are not currently included.

Rim-Tool is currently using HIRS as a submodule in order to access source code in HIRS_Utils, and thus grabs the HIRS_Utils jar file to depend on it. HIRS_Utils' test directory contains resources that Rim-Tool tests use.

Resolves #996 