### PR TITLE
Update Provisioner Pcie, Smbios component dependencies

### DIFF
--- a/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
+++ b/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
@@ -36,10 +36,10 @@
     <PackageReference Include="paccor.HardwareManifestPlugin" Version="2.0.5" />
     <PackageReference Include="paccor.HardwareManifestPluginManager" Version="2.0.5" />
     <PackageReference Include="paccor.paccor_scripts" Version="2.2.0" />
-    <PackageReference Include="paccor.pcie" Version="0.7.6" />
-    <PackageReference Include="paccor.smbios" Version="0.7.6" />
+    <PackageReference Include="paccor.pcie" Version="0.8.0" />
+    <PackageReference Include="paccor.smbios" Version="0.8.1" />
     <PackageReference Include="paccor.storage" Version="0.7.6" />
-    <PackageReference Include="Packaging.Targets" Version="0.1.226">
+    <PackageReference Include="Packaging.Targets" Version="0.1.232">
       <PrivateAssets>all</PrivateAssets> <!-- These assets will be consumed but won't flow to the parent project -->
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -104,3 +104,4 @@
     </ItemGroup>
   </Target>
 </Project>
+


### PR DESCRIPTION
Updates the provisioner to use newer SMBIOS and PCIE component class registry dependencies.

Smbios registry program won't collect SMBIOS RAM information when memory device (type 17) size field is 0.
The PCIe registry program should be able to validate the VPD-R checksum.