### PR TITLE
[#1002]  Add Ability To Download Multiple HIRS Log Files

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/CertificateService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/CertificateService.java
@@ -291,7 +291,7 @@ public class CertificateService {
     /**
      * Packages a collection of certificates into a zip file.
      *
-     * @param zipOut          zip outputs streams
+     * @param zipOut          zip outputs stream
      * @param singleFileName  zip file name
      * @param certificateType certificate type
      * @throws IOException if there are any issues packaging or downloading the zip file

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/HelpPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/HelpPageService.java
@@ -61,13 +61,29 @@ public class HelpPageService {
         try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(logDirectory)) {
             // Loop through each entry in the directory
             for (Path filePath : directoryStream) {
-                // Process only regular files (skip subdirectories, links, etc.)
+                // Skip if not a regular file
+                if (!Files.isRegularFile(filePath)) {
+                    log.error("Unable to process the following path [{}] since the provided file "
+                            + "path is not a regular file", filePath);
+                    continue;
+                }
+
+                Path fileNamePath = filePath.getFileName();
+
+                // Skip if the filename is null
+                if (fileNamePath == null) {
+                    log.error("Unable to process the following path [{}] since the provided file "
+                            + "path is null", filePath);
+                    continue;
+                }
+
+                final String fileName = fileNamePath.toString();
+
                 // and is a HIRS Attestation CA log file
-                if (Files.isRegularFile(filePath)
-                        && filePath.getFileName().toString().startsWith(HIRS_ATTESTATION_CA_PORTAL_LOG_NAME)
-                        && filePath.getFileName().toString().endsWith(".log")) {
+                if (fileName.startsWith(HIRS_ATTESTATION_CA_PORTAL_LOG_NAME)
+                        && fileName.endsWith(".log")) {
                     // Create a new zip entry with the file's name
-                    ZipEntry zipEntry = new ZipEntry(filePath.getFileName().toString());
+                    ZipEntry zipEntry = new ZipEntry(fileName);
                     zipEntry.setTime(System.currentTimeMillis());
                     zipOut.putNextEntry(zipEntry);
 
@@ -81,7 +97,6 @@ public class HelpPageService {
                 }
             }
         }
-
         zipOut.finish();
     }
 

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/EndorsementCredentialPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/EndorsementCredentialPageController.java
@@ -180,7 +180,6 @@ public class EndorsementCredentialPageController extends PageController<NoPagePa
                     + endorsementCredential.getSerialNumber()
                     + ".cer\"";
 
-            // Set filename for download.
             response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;" + fileName);
             response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
 
@@ -190,9 +189,6 @@ public class EndorsementCredentialPageController extends PageController<NoPagePa
         } catch (Exception exception) {
             log.error("An exception was thrown while attempting to download the"
                     + " specified endorsement credential", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // specified endorsement credential
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }
@@ -212,7 +208,6 @@ public class EndorsementCredentialPageController extends PageController<NoPagePa
         final String fileName = "endorsement_certificates.zip";
         final String singleFileName = "Endorsement_Certificates";
 
-        // Set filename for download.
         response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName);
         response.setContentType("application/zip");
 
@@ -221,11 +216,8 @@ public class EndorsementCredentialPageController extends PageController<NoPagePa
             this.certificateService.bulkDownloadCertificates(zipOut, CertificateType.ENDORSEMENT_CREDENTIALS,
                     singleFileName);
         } catch (Exception exception) {
-            log.error("An exception was thrown while attempting to bulk download all the"
+            log.error("An exception was thrown while attempting to bulk download all the "
                     + "endorsement credentials", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // endorsement credentials
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/HelpPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/HelpPageController.java
@@ -8,13 +8,10 @@ import hirs.attestationca.portal.datatables.DataTableResponse;
 import hirs.attestationca.portal.page.Page;
 import hirs.attestationca.portal.page.PageController;
 import hirs.attestationca.portal.page.params.NoPageParams;
-import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.FileSystemResource;
-import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -29,6 +26,7 @@ import org.springframework.web.servlet.view.RedirectView;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.zip.ZipOutputStream;
 
 /**
  * Controller for the Help page.
@@ -39,14 +37,6 @@ import java.io.IOException;
 public class HelpPageController extends PageController<NoPageParams> {
     private final HelpPageService helpPageService;
 
-    private String fullLogFilePath;
-
-    @Value("${logging.file.path}")
-    private String logFilePath;
-
-    @Value("${logging.file.name}")
-    private String logFileName;
-
     /**
      * Constructor providing the Help Page's display and routing specification.
      *
@@ -56,15 +46,6 @@ public class HelpPageController extends PageController<NoPageParams> {
     public HelpPageController(final HelpPageService helpPageService) {
         super(Page.HELP);
         this.helpPageService = helpPageService;
-    }
-
-    /**
-     * After this component has been created, combine the two application property values together
-     * to create the log file's full path.
-     */
-    @PostConstruct
-    public void initialize() {
-        this.fullLogFilePath = this.logFilePath + "/" + this.logFileName;
     }
 
     /**
@@ -80,39 +61,26 @@ public class HelpPageController extends PageController<NoPageParams> {
     }
 
     /**
-     * Processes the request to download the HIRS application's log file.
+     * Processes the request to download a zip file of the HIRS application's log files.
      *
      * @param response response that will be sent out after processing download request
      * @throws IOException when writing to response output stream
      */
-    @GetMapping("/hirs-log-download")
-    public void downloadHIRSLog(final HttpServletResponse response) throws IOException {
+    @GetMapping("/hirs-logs-download")
+    public void downloadHIRSLogs(final HttpServletResponse response) throws IOException {
+        log.info("Received request to download a zip file of all the"
+                + " HIRS Attestation application's log files");
 
-        try {
-            log.info("Received request to download the HIRS Attestation application's log file");
-            final File logFile = new File(this.fullLogFilePath);
+        final String fileName = "HIRS_AttestationCAPortal_Logs.zip";
 
-            if (!logFile.exists()) {
-                log.error("The log file cannot be downloaded because it does not exist");
-                response.sendError(HttpServletResponse.SC_NOT_FOUND);
-            }
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName);
+        response.setContentType("application/zip");
 
-            Resource resource = new FileSystemResource(logFile);
-
-            // Set the response headers for file download
-            response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + logFile.getName());
-            response.setContentType(
-                    MediaType.APPLICATION_OCTET_STREAM_VALUE);
-
-            // Copy the file content to the response output stream
-            org.apache.commons.io.IOUtils.copy(resource.getInputStream(), response.getOutputStream());
-
+        try (ZipOutputStream zipOut = new ZipOutputStream(response.getOutputStream())) {
+            this.helpPageService.bulkDownloadHIRSLogFiles(zipOut);
         } catch (Exception exception) {
-            log.error("An exception was thrown while attempting to download the"
-                    + " HIRS Application log file", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // HIRS log file
+            log.error("An exception was thrown while attempting to bulk download all the "
+                    + "HIRS Attestation Logs", exception);
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }
@@ -147,7 +115,6 @@ public class HelpPageController extends PageController<NoPageParams> {
         return new DataTableResponse<>(mainHIRSLoggersFilteredRecordsList, input);
     }
 
-
     /**
      * Processes the request that sets the log level of the selected logger.
      *
@@ -170,8 +137,6 @@ public class HelpPageController extends PageController<NoPageParams> {
         } catch (Exception exception) {
             log.error("An exception was thrown while attempting to set the logging level for the"
                     + " selected logger", exception);
-
-            // send a 404 error when an exception is thrown while attempting to set the logger's log level
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
 

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/HelpPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/HelpPageController.java
@@ -11,7 +11,6 @@ import hirs.attestationca.portal.page.params.NoPageParams;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -24,7 +23,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.zip.ZipOutputStream;
 

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/IDevIdCertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/IDevIdCertificatePageController.java
@@ -178,7 +178,6 @@ public class IDevIdCertificatePageController extends PageController<NoPageParams
                     + iDevIDCertificate.getSerialNumber()
                     + ".cer\"";
 
-            // Set filename for download.
             response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;" + fileName);
             response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
 
@@ -187,9 +186,6 @@ public class IDevIdCertificatePageController extends PageController<NoPageParams
         } catch (Exception exception) {
             log.error("An exception was thrown while attempting to download the"
                     + " specified idevid certificate", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // specified idevid certificate
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }
@@ -209,7 +205,6 @@ public class IDevIdCertificatePageController extends PageController<NoPageParams
         final String fileName = "idevid_certificates.zip";
         final String singleFileName = "IDevID_Certificates";
 
-        // Set filename for download.
         response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName);
         response.setContentType("application/zip");
 
@@ -220,9 +215,6 @@ public class IDevIdCertificatePageController extends PageController<NoPageParams
         } catch (Exception exception) {
             log.error("An exception was thrown while attempting to bulk download all the"
                     + "idevid certificates", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // specified idevid certificates
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/IssuedCertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/IssuedCertificatePageController.java
@@ -180,7 +180,6 @@ public class IssuedCertificatePageController extends PageController<NoPageParams
                     + issuedAttestationCertificate.getSerialNumber()
                     + ".cer\"";
 
-            // Set filename for download.
             response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;" + fileName);
             response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
 
@@ -188,11 +187,8 @@ public class IssuedCertificatePageController extends PageController<NoPageParams
             response.getOutputStream().write(certificate.getRawBytes());
 
         } catch (Exception exception) {
-            log.error("An exception was thrown while attempting to download the"
-                    + " specified issued attestation certificate", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // specified issued attestation certificate
+            log.error("An exception was thrown while attempting to download the "
+                    + "specified issued attestation certificate", exception);
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }
@@ -212,7 +208,7 @@ public class IssuedCertificatePageController extends PageController<NoPageParams
         final String singleFileName = "Issued_Certificate";
         final String fileName = "issued_certificates.zip";
 
-        // Set filename for download.
+
         response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName);
         response.setContentType("application/zip");
 
@@ -221,11 +217,8 @@ public class IssuedCertificatePageController extends PageController<NoPageParams
             this.certificateService.bulkDownloadCertificates(zipOut, CertificateType.ISSUED_CERTIFICATES,
                     singleFileName);
         } catch (Exception exception) {
-            log.error("An exception was thrown while attempting to bulk download all the"
+            log.error("An exception was thrown while attempting to bulk download all the "
                     + "issued attestation certificates", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // issued attestation certificates
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PlatformCredentialPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PlatformCredentialPageController.java
@@ -204,7 +204,6 @@ public class PlatformCredentialPageController extends PageController<NoPageParam
                     + platformCredential.getSerialNumber()
                     + ".cer\"";
 
-            // Set filename for download.
             response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;" + fileName);
             response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
 
@@ -212,11 +211,8 @@ public class PlatformCredentialPageController extends PageController<NoPageParam
             response.getOutputStream().write(certificate.getRawBytes());
 
         } catch (Exception exception) {
-            log.error("An exception was thrown while attempting to download the"
-                    + " specified platform credential", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // specified platform credential
+            log.error("An exception was thrown while attempting to download the "
+                    + "specified platform credential", exception);
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }
@@ -236,7 +232,6 @@ public class PlatformCredentialPageController extends PageController<NoPageParam
         final String fileName = "platform_certificates.zip";
         final String singleFileName = "Platform_Certificate";
 
-        // Set filename for download.
         response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName);
         response.setContentType("application/zip");
 
@@ -245,11 +240,9 @@ public class PlatformCredentialPageController extends PageController<NoPageParam
             this.certificateService.bulkDownloadCertificates(zipOut, CertificateType.PLATFORM_CREDENTIALS,
                     singleFileName);
         } catch (Exception exception) {
-            log.error("An exception was thrown while attempting to bulk download all the"
+            log.error("An exception was thrown while attempting to bulk download all the "
                     + "platform credentials", exception);
 
-            // send a 404 error when an exception is thrown while attempting to download the
-            //platform credentials
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
@@ -256,7 +256,6 @@ public class ReferenceManifestPageController extends PageController<NoPageParams
                 throw new EntityNotFoundException(notFoundMessage);
             }
 
-            // Set filename for download.
             response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
                     "attachment;" + "filename=\"" + referenceManifest.getFileName()
             );
@@ -266,11 +265,8 @@ public class ReferenceManifestPageController extends PageController<NoPageParams
             response.getOutputStream().write(referenceManifest.getRimBytes());
 
         } catch (Exception exception) {
-            log.error("An exception was thrown while attempting to download the"
+            log.error("An exception was thrown while attempting to download the "
                     + " specified RIM", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // specified RIM
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }
@@ -288,20 +284,14 @@ public class ReferenceManifestPageController extends PageController<NoPageParams
         log.info("Handling request to download all Reference Integrity Manifests");
         String fileName = "rims.zip";
 
-
-        // Set filename for download.
         response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName);
         response.setContentType("application/zip");
 
-        // write cert to output stream
         try (ZipOutputStream zipOut = new ZipOutputStream(response.getOutputStream())) {
             bulkDownloadRIMS(zipOut);
         } catch (Exception exception) {
             log.error("An exception was thrown while attempting to bulk download all the"
                     + "reference integrity manifests", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // reference manifests
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/TrustChainCertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/TrustChainCertificatePageController.java
@@ -87,8 +87,7 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
     public TrustChainCertificatePageController(final CertificateRepository certificateRepository,
                                                final CACredentialRepository caCredentialRepository,
                                                final CertificateService certificateService,
-                                               @Qualifier("acaTrustChainCerts")
-                                               final X509Certificate[] acaTrustChainCertificates) {
+                                               @Qualifier("acaTrustChainCerts") final X509Certificate[] acaTrustChainCertificates) {
         super(Page.TRUST_CHAIN);
         this.certificateRepository = certificateRepository;
         this.caCredentialRepository = caCredentialRepository;
@@ -227,7 +226,6 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
                     + trustChainCertificate.getSerialNumber()
                     + ".cer\"";
 
-            // Set filename for download.
             response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment;" + fileName);
             response.setContentType(MediaType.APPLICATION_OCTET_STREAM_VALUE);
 
@@ -237,9 +235,6 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
         } catch (Exception exception) {
             log.error("An exception was thrown while attempting to download the"
                     + " specified trust chain certificate", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // specified trust chain certificate
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }
@@ -263,7 +258,7 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
             // PEM file of the leaf certificate, intermediate certificate and root certificate (in that order)
             final String fullChainPEM =
                     ControllerPagesUtils.convertCertificateArrayToPem(
-                            new CertificateAuthorityCredential[] {certificateAuthorityCredentials.get(0),
+                            new CertificateAuthorityCredential[]{certificateAuthorityCredentials.get(0),
                                     certificateAuthorityCredentials.get(1),
                                     certificateAuthorityCredentials.get(2)});
 
@@ -281,9 +276,6 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
         } catch (Exception exception) {
             log.error("An exception was thrown while attempting to download the"
                     + "aca trust chain", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // aca certificates
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }
@@ -302,7 +294,6 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
         final String fileName = "trust-chain.zip";
         final String singleFileName = "ca-certificates";
 
-        // Set filename for download.
         response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + fileName);
         response.setContentType("application/zip");
 
@@ -313,9 +304,6 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
         } catch (Exception exception) {
             log.error("An exception was thrown while attempting to bulk download all the"
                     + "trust chain certificates", exception);
-
-            // send a 404 error when an exception is thrown while attempting to download the
-            // trust chain certificates
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
         }
     }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/TrustChainCertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/TrustChainCertificatePageController.java
@@ -87,7 +87,8 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
     public TrustChainCertificatePageController(final CertificateRepository certificateRepository,
                                                final CACredentialRepository caCredentialRepository,
                                                final CertificateService certificateService,
-                                               @Qualifier("acaTrustChainCerts") final X509Certificate[] acaTrustChainCertificates) {
+                                               @Qualifier("acaTrustChainCerts") final
+                                               X509Certificate[] acaTrustChainCertificates) {
         super(Page.TRUST_CHAIN);
         this.certificateRepository = certificateRepository;
         this.caCredentialRepository = caCredentialRepository;

--- a/HIRS_AttestationCAPortal/src/main/resources/application.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.properties
@@ -3,21 +3,19 @@ logging.level.org.springframework=ERROR
 logging.level.org.apache.catalina=ERROR
 logging.level.org.springframework.web=ERROR
 logging.level.org.hibernate=ERROR
-logging.file.path=C:/ProgramData/hirs/log
+logging.file.path=/var/log/hirs
 # Database Config
 spring.jpa.hibernate.ddl-auto=update
 jakarta.persistence.sharedCache.mode=UNSPECIFIED
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
-#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-#spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 # Tomcat Config
 server.tomcat.additional-tld-skip-patterns=jakarta.persistence-api*.jar, jakarta.xml.bind-api*.jar, txw2*.jar, *commons*.jar,  *annotations*.jar, *checker*.jar, *lombok*.jar, *jsr*.jar, *guava*.jar, *access*.jar, *activation*.jar, *bcprov*.jar, *bcmail*.jar, *bcutil*.jar, *bcpkix*.jar, *json*.jar 
-server.tomcat.basedir=C:/ProgramData/hirs/embeddedtomcat
+server.tomcat.basedir=/opt/embeddedtomcat
 server.servlet.register-default-servlet=true
 server.servlet.context-path=/
 spring.mvc.servlet.path=/
 server.tomcat.accesslog.enabled=true
-server.tomcat.accesslog.directory=C:/ProgramData/hirs/log
+server.tomcat.accesslog.directory=/var/log/hirs
 server.tomcat.accesslog.file-date-format=yyyy-MM-dd
 server.tomcat.accesslog.prefix=Tomcat_accesslog_
 server.tomcat.accesslog.suffix=.log
@@ -26,10 +24,10 @@ server.tomcat.accesslog.rotate=true
 server.port=8443
 server.ssl.enabled=true
 server.ssl.trust-store-type=JKS
-server.ssl.trust-store=C:/ProgramData/hirs/certificates/HIRS/TrustStore.jks
+server.ssl.trust-store=/etc/hirs/certificates/HIRS/TrustStore.jks
 server.ssl.trust-alias=hirs_aca_tls_rsa_3k_sha384
 server.ssl.key-store-type=JKS
-server.ssl.key-store=C:/ProgramData/hirs/certificates/HIRS/KeyStore.jks
+server.ssl.key-store=/etc/hirs/certificates/HIRS/KeyStore.jks
 server.ssl.key-alias=hirs_aca_tls_rsa_3k_sha384
 server.ssl.enabled-protocols=TLSv1.2, TLSv1.3
 server.ssl.ciphers=TLS_AES_256_GCM_SHA384, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384
@@ -47,14 +45,4 @@ server.compression.min-response-size=2048
 #Spring Boot actuator
 management.endpoints.web.exposure.include=health,info,metrics,loggers,beans
 management.endpoint.health.show-details=always
-#--server.ssl.key-store-password=123456
-#--server.ssl.trust-store-password=123456
-#jdbc.driverClassName = com.mysql.cj.jdbc.Driver
-#jdbc.url = jdbc:mysql://localhost:3306/hirs_db?autoReconnect=true&useSSL=false
-#jdbc.username = root
-#jdbc.password = hirspass
-#entitymanager.packagesToScan: hirs.attestationca.portal.page.controllers
-#spring.jpa.hibernate.ddl-auto=update
-#spring.jpa.show-sql=true
-# DB dfault password.
-#spring.datasource.password=hirs_db
+

--- a/HIRS_AttestationCAPortal/src/main/resources/application.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.properties
@@ -3,20 +3,21 @@ logging.level.org.springframework=ERROR
 logging.level.org.apache.catalina=ERROR
 logging.level.org.springframework.web=ERROR
 logging.level.org.hibernate=ERROR
-logging.file.path=/var/log/hirs
-logging.file.name=HIRS_AttestationCA_Portal.log
+logging.file.path=C:/ProgramData/hirs/log
 # Database Config
 spring.jpa.hibernate.ddl-auto=update
 jakarta.persistence.sharedCache.mode=UNSPECIFIED
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 # Tomcat Config
 server.tomcat.additional-tld-skip-patterns=jakarta.persistence-api*.jar, jakarta.xml.bind-api*.jar, txw2*.jar, *commons*.jar,  *annotations*.jar, *checker*.jar, *lombok*.jar, *jsr*.jar, *guava*.jar, *access*.jar, *activation*.jar, *bcprov*.jar, *bcmail*.jar, *bcutil*.jar, *bcpkix*.jar, *json*.jar 
-server.tomcat.basedir=/opt/embeddedtomcat
+server.tomcat.basedir=C:/ProgramData/hirs/embeddedtomcat
 server.servlet.register-default-servlet=true
 server.servlet.context-path=/
 spring.mvc.servlet.path=/
 server.tomcat.accesslog.enabled=true
-server.tomcat.accesslog.directory=/var/log/hirs
+server.tomcat.accesslog.directory=C:/ProgramData/hirs/log
 server.tomcat.accesslog.file-date-format=yyyy-MM-dd
 server.tomcat.accesslog.prefix=Tomcat_accesslog_
 server.tomcat.accesslog.suffix=.log
@@ -25,10 +26,10 @@ server.tomcat.accesslog.rotate=true
 server.port=8443
 server.ssl.enabled=true
 server.ssl.trust-store-type=JKS
-server.ssl.trust-store=/etc/hirs/certificates/HIRS/TrustStore.jks
+server.ssl.trust-store=C:/ProgramData/hirs/certificates/HIRS/TrustStore.jks
 server.ssl.trust-alias=hirs_aca_tls_rsa_3k_sha384
 server.ssl.key-store-type=JKS
-server.ssl.key-store=/etc/hirs/certificates/HIRS/KeyStore.jks
+server.ssl.key-store=C:/ProgramData/hirs/certificates/HIRS/KeyStore.jks
 server.ssl.key-alias=hirs_aca_tls_rsa_3k_sha384
 server.ssl.enabled-protocols=TLSv1.2, TLSv1.3
 server.ssl.ciphers=TLS_AES_256_GCM_SHA384, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384
@@ -46,4 +47,14 @@ server.compression.min-response-size=2048
 #Spring Boot actuator
 management.endpoints.web.exposure.include=health,info,metrics,loggers,beans
 management.endpoint.health.show-details=always
-
+#--server.ssl.key-store-password=123456
+#--server.ssl.trust-store-password=123456
+#jdbc.driverClassName = com.mysql.cj.jdbc.Driver
+#jdbc.url = jdbc:mysql://localhost:3306/hirs_db?autoReconnect=true&useSSL=false
+#jdbc.username = root
+#jdbc.password = hirspass
+#entitymanager.packagesToScan: hirs.attestationca.portal.page.controllers
+#spring.jpa.hibernate.ddl-auto=update
+#spring.jpa.show-sql=true
+# DB dfault password.
+#spring.datasource.password=hirs_db

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/help.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/help.jsp
@@ -29,8 +29,8 @@
     <div class="aca-data-table">
       <h2>Main HIRS Logger Management</h2>
       <div class="download-header">
-        <h3>Download HIRS Attestation Log File</h3>
-        <a href="${portal}/help/hirs-log-download">
+        <h3>Download All HIRS Attestation Log Files</h3>
+        <a href="${portal}/help/hirs-logs-download">
           <img src="${icons}/ic_file_download_black_24dp.png" title="Download HIRS Log">
         </a>
       </div>


### PR DESCRIPTION
### Description

This issue aims to enhance the functionality of the download button on the help page by enabling users to download a single ZIP archive containing all HIRS Attestation log files available in the logs directory. This improvement will provide users with easier access to historical log data directly from the GUI.

### Test Instructions:
1. Run the ACA using your preferred method.
2. Head over to the Help page and click on the download icon next to where it says **Download All HIRS Logs**.
3. Verify that the browser downloads a zip file that contains one or more HIRS Attestation log files.
4. Verify that you can open each file and you can read each file's content.

### Issues This PR Addresses:
Closes #1002