### PR TITLE
Openssl link update

### DIFF
--- a/.ci/docker/Dockerfile.aca-windows
+++ b/.ci/docker/Dockerfile.aca-windows
@@ -70,7 +70,7 @@ RUN Start-Process -FilePath 'C:/vs_buildtools.exe' -ArgumentList \"--quiet --wai
 RUN Write-Host "Finished installing Visual Studio Build Tools."
 
 # Download and extract pre-built openssl
-RUN ((New-Object System.Net.WebClient).DownloadFile('https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.3.1.zip', 'C:/openssl-3.zip'))
+RUN ((New-Object System.Net.WebClient).DownloadFile('https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.3.zip', 'C:/openssl-3.zip'))
 RUN Expand-Archive C:/openssl-3.zip -DestinationPath C:/openssl_files
 WORKDIR C:/openssl_files/openssl-3
 RUN cp -Recurse -Force C:/openssl_files/openssl-3/x64 'C:/Program Files/openssl'


### PR DESCRIPTION
The previous link to download openssl 3 was removed.