### PR TITLE
[#1014] Add AKI check for verifying EK Certs, Add missing info to EK Cert Details page

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/EndorsementCredential.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/EndorsementCredential.java
@@ -311,7 +311,12 @@ public class EndorsementCredential extends DeviceAssociatedCertificate {
                     parseSingle((ASN1Primitive) obj2, false, null);
                 }
             }
-
+            else {
+                // parse the elements of the sequence individually
+                for (ASN1Encodable component : seq) {
+                    parseSingle((ASN1Primitive) component, false, null);
+                }
+            }
             // The next two are special sequences that have already been matched with an OID.
         } else if (addToMapping && key.equals(TPM_SPECIFICATION)
                 && seq.size() == ASN1_SEQ_KNOWN_SIZE) {

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/certificate-details.jsp
@@ -216,7 +216,7 @@
                                 aria-labelledby="headingOne" aria-expanded="false">
                                 <div>
                                     <span class="fieldValue">
-                                        ${initialData.signatureAlgorithm} / ${initialData.signatureSize}
+                                        ${initialData.signatureAlgorithm}
                                     </span>
                                 </div>
                             </div>
@@ -406,16 +406,16 @@
                         <div id="tpmSecurityAssertion" class="col col-md-8">
                             <div id="tpmSecurityAssertionInner" class="panel-body collapse" role="tabpanel"
                                 aria-expanded="false">
-                                <div>Version:&nbsp;<span>${initialData.TPMSecurityAssertionsVersion}</span></div>
+                                <div>Version:&nbsp;<span>${initialData.TPMSecurityAssertionsTpmSecAssertsVersion}</span></div>
                                 <div>Field
                                     Upgradeable:&nbsp;<span>${initialData.TPMSecurityAssertionsFieldUpgradeable}</span>
                                 </div>
                                 <div>ek Generation Type:&nbsp;<span>${initialData.TPMSecurityAssertionsEkGenType}</span>
                                 </div>
                                 <div>ek Generation
-                                    Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkGenLoc}</span></div>
+                                    Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkGenerationLocation}</span></div>
                                 <div>ek Certificate Generation
-                                    Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkCertGenLoc}</span></div>
+                                    Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkCertificateGenerationLocation}</span></div>
                             </div>
                         </div>
                     </div>
@@ -1047,14 +1047,14 @@
                 <div id="tpmSecurityAssertion" class="col col-md-8">
                     <div id="tpmSecurityAssertionInner" class="panel-body collapse" role="tabpanel"
                         aria-expanded="false">
-                        <div>Version:&nbsp;<span>${initialData.TPMSecurityAssertionsVersion}</span></div>
+                        <div>Version:&nbsp;<span>${initialData.TPMSecurityAssertionsTpmSecAssertsVersion}</span></div>
                         <div>Field Upgradeable:&nbsp;<span>${initialData.TPMSecurityAssertionsFieldUpgradeable}</span>
                         </div>
                         <div>ek Generation Type:&nbsp;<span>${initialData.TPMSecurityAssertionsEkGenType}</span></div>
-                        <div>ek Generation Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkGenLoc}</span>
+                        <div>ek Generation Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkGenerationLocation}</span>
                         </div>
                         <div>ek Certificate Generation
-                            Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkCertGenLoc}</span></div>
+                            Location:&nbsp;<span>${initialData.TPMSecurityAssertionsEkCertificateGenerationLocation}</span></div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This PR addresses several fixes on the Details pages for Endorsement Key Credentials uploaded to the ACA.

- Updated EK certificate verification to prioritize `Authority Key Identifier`/`Subject Key Identifier` matching, with a fallback to `Distinguished Name` matching if no AKI/SKI match is found. Previously, only DN matching was being done.
- Removed display of signature size, which just measured the entire DER-encoded signature in bits. Confusing and not useful.
- Added display of public key size for EC algorithm. Previously was working for RSA but not EC.
- Added display of TPM Specification and TPM Security Assertions. Previously was missing.

Test Instructions:
1. [To test AKI/SKI matching] Upon starting an ACA, upload two different certificate chains from the same issuer.
  - Upload respective certificates to Endorsement Key Credentials page that are from the same issuer but use different algorithms.
  - Ensure on Details page for Endorsement Certificates that they each have green check for verification. This is evident that the certificates are being verified by first checking the AKI against SKI. IF it were checking the DN, the 2nd certificate would fail verification due to having the same DN from the same issuer. This was the issue up until now.

2. [To view public key size] On Endorsement Certificate Details page, drop down "Public Key" > "Algorithm". It will now display the size for EC public keys (i.e. "EC / 256"), which was previously missing. RSA keys are same as is.
3. [To view TPM Specification and TPM Security Assertions] On Endorsement Certificate Details page **for a certificate that contains said fields**, they are now displayed in dropdowns at the bottom of page.

Resolves: #1014 