### PR TITLE
[#1017]  Fix Pathing issue in Corim Unit tests on Windows

### DIFF
--- a/HIRS_Utils/src/test/java/hirs/utils/rim/unsignedRim/cbor/ietfCorim/CorimBuilderTest.java
+++ b/HIRS_Utils/src/test/java/hirs/utils/rim/unsignedRim/cbor/ietfCorim/CorimBuilderTest.java
@@ -1,11 +1,14 @@
 package hirs.utils.rim.unsignedRim.cbor.ietfCorim;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
@@ -15,23 +18,28 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 public class CorimBuilderTest {
     /**
      * Tests basic attributes of a CoRIM object without an included CoMID.
+     *
+     * @throws IOException        if there are any issues trying to read the provided files
+     * @throws URISyntaxException if there are any issues interpreting the provided paths
      */
     @Test
-    public final void buildCorimWithoutComid() throws IOException {
-        String corimConfigFile = "corim/config/corim_fields_without_comid.json";
-        String expectedCborFile = "corim/corim_expected_without_comid.cbor";
+    public final void buildCorimWithoutComid() throws IOException, URISyntaxException {
+        final String corimConfigFile = "corim/config/corim_fields_without_comid.json";
+        final String expectedCborFile = "corim/corim_expected_without_comid.cbor";
 
-        ClassLoader classLoader = getClass().getClassLoader();
-        URL resourceUrl = classLoader.getResource(corimConfigFile);
+        final ClassLoader classLoader = getClass().getClassLoader();
+        final URL resourceUrl = classLoader.getResource(corimConfigFile);
 
         // Create unsigned CoRIM using configuration file
         assert resourceUrl != null;
-        byte[] outputCorim = CoRimBuilder.build(resourceUrl.getPath());
+        final String resourceUrlPath = Paths.get(resourceUrl.toURI()).toString();
+        final byte[] outputCorim = CoRimBuilder.build(resourceUrlPath);
 
         // Read expected CoRIM bytes from file
-        URL expectedResourceUrl = classLoader.getResource(expectedCborFile);
+        final URL expectedResourceUrl = classLoader.getResource(expectedCborFile);
         assert expectedResourceUrl != null;
-        byte[] expectedCorim = Files.readAllBytes(Path.of(expectedResourceUrl.getPath()));
+        final Path expectedResourceUrlPath = Paths.get(expectedResourceUrl.toURI());
+        final byte[] expectedCorim = Files.readAllBytes(expectedResourceUrlPath);
 
         // Verify that output matches expected CBOR
         assertArrayEquals(outputCorim, expectedCorim);
@@ -39,23 +47,28 @@ public class CorimBuilderTest {
 
     /**
      * Tests basic attributes of a CoRIM object with an included CoMID.
+     *
+     * @throws IOException        if there are any issues trying to read the provided files
+     * @throws URISyntaxException if there are any issues interpreting the provided paths
      */
     @Test
-    public final void buildCorimWithComid() throws IOException {
-        String corimConfigFile = "corim/config/corim_fields_with_comid.json";
-        String expectedCborFile = "corim/corim_expected_with_comid.cbor";
+    public final void buildCorimWithComid() throws IOException, URISyntaxException {
+        final String corimConfigFile = "corim/config/corim_fields_with_comid.json";
+        final String expectedCborFile = "corim/corim_expected_with_comid.cbor";
 
-        ClassLoader classLoader = getClass().getClassLoader();
-        URL resourceUrl = classLoader.getResource(corimConfigFile);
+        final ClassLoader classLoader = getClass().getClassLoader();
+        final URL resourceUrl = classLoader.getResource(corimConfigFile);
 
         // Create unsigned CoRIM using configuration file
         assert resourceUrl != null;
-        byte[] outputCorim = CoRimBuilder.build(resourceUrl.getPath());
+        final String resourceUrlPath = Paths.get(resourceUrl.toURI()).toString();
+        final byte[] outputCorim = CoRimBuilder.build(resourceUrlPath);
 
         // Read expected CoRIM bytes from file
-        URL expectedResourceUrl = classLoader.getResource(expectedCborFile);
+        final URL expectedResourceUrl = classLoader.getResource(expectedCborFile);
         assert expectedResourceUrl != null;
-        byte[] expectedCorim = Files.readAllBytes(Path.of(expectedResourceUrl.getPath()));
+        final Path expectedResourceUrlPath = Paths.get(expectedResourceUrl.toURI());
+        final byte[] expectedCorim = Files.readAllBytes(expectedResourceUrlPath);
 
         // Verify that output matches expected CBOR
         assertArrayEquals(outputCorim, expectedCorim);

--- a/HIRS_Utils/src/test/java/hirs/utils/rim/unsignedRim/cbor/ietfCorim/CorimParserTest.java
+++ b/HIRS_Utils/src/test/java/hirs/utils/rim/unsignedRim/cbor/ietfCorim/CorimParserTest.java
@@ -8,9 +8,11 @@ import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -24,64 +26,72 @@ public class CorimParserTest {
     /**
      * Tests the ability of the CoRIM parser to correctly parse an unsigned CoRIM
      * that does not include a CoMID tag.
+     *
+     * @throws IOException        if there are any issues trying to read the provided files
+     * @throws URISyntaxException if there are any issues interpreting the provided paths
      */
     @Test
-    public final void parseCoRIMWithoutCoMID() throws IOException {
+    public final void parseCoRIMWithoutCoMID() throws IOException, URISyntaxException {
         // Read CoRIM from file
-        String corimFile = "corim/corim_expected_without_comid.cbor";
-        ClassLoader classLoader = getClass().getClassLoader();
-        URL corimUrl = classLoader.getResource(corimFile);
+        final String corimFile = "corim/corim_expected_without_comid.cbor";
+        final ClassLoader classLoader = getClass().getClassLoader();
+        final URL corimUrl = classLoader.getResource(corimFile);
         assert corimUrl != null;
-        byte[] expectedCorim = Files.readAllBytes(Path.of(corimUrl.getPath()));
+        final Path corimUrlPath = Paths.get(corimUrl.toURI());
+        final byte[] actualCoRIM = Files.readAllBytes(corimUrlPath);
 
         // Parse CoRIM (remove tag first)
-        CBORDecoder decoder = new CBORDecoder(expectedCorim, 0, expectedCorim.length);
+        CBORDecoder decoder = new CBORDecoder(actualCoRIM, 0, actualCoRIM.length);
         CBORTaggedItem taggedUnsignedCorim = (CBORTaggedItem) decoder.next();
         CoRimParser corimParser = new CoRimParser(taggedUnsignedCorim.getTagContent().encode());
 
         // Check select attributes
-        assertEquals(corimParser.id, "Test CoRIM 1");
+        assertEquals("Test CoRIM 1", corimParser.id);
         Object[] testDependentRim = corimParser.dependentRims.get(1);
-        assertEquals(testDependentRim[0], "https://testURI1");
+        assertEquals("https://testURI1", testDependentRim[0]);
         assertEquals(testDependentRim[1], IanaHashAlg.SHA_256.getAlgId());
         String testThumbprint = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
         assertArrayEquals((byte[]) testDependentRim[2], Hex.decode(testThumbprint));
-        assertEquals(corimParser.profile, "https://testprofile");
+        assertEquals("https://testprofile", corimParser.profile);
         final long notAfterTimestamp = 1749227400L;
-        assertEquals(corimParser.notAfter, notAfterTimestamp);
-        assertEquals(corimParser.entityName, "Test Inc.");
-        assertEquals(corimParser.entityRegId, "https://testing");
-        assertEquals(corimParser.entityRole, "tag-creator");
+        assertEquals(notAfterTimestamp, corimParser.notAfter);
+        assertEquals("Test Inc.", corimParser.entityName);
+        assertEquals("https://testing", corimParser.entityRegId);
+        assertEquals("tag-creator", corimParser.entityRole);
     }
 
     /**
      * Tests the ability of the CoRIM parser to correctly parse an unsigned CoRIM
      * that includes a CoMID tag.
+     *
+     * @throws IOException        if there are any issues trying to read the provided files
+     * @throws URISyntaxException if there are any issues interpreting the provided paths
      */
     @Test
-    public final void parseCoRIMWithCoMID() throws IOException {
+    public final void parseCoRIMWithCoMID() throws IOException, URISyntaxException {
         // Read CoRIM from file
-        String corimFile = "corim/corim_expected_with_comid.cbor";
-        ClassLoader classLoader = getClass().getClassLoader();
-        URL corimUrl = classLoader.getResource(corimFile);
+        final String corimFile = "corim/corim_expected_with_comid.cbor";
+        final ClassLoader classLoader = getClass().getClassLoader();
+        final URL corimUrl = classLoader.getResource(corimFile);
         assert corimUrl != null;
-        byte[] expectedCorim = Files.readAllBytes(Path.of(corimUrl.getPath()));
+        final Path corimUrlPath = Paths.get(corimUrl.toURI());
+        final byte[] actualCoRIM = Files.readAllBytes(corimUrlPath);
 
         // Parse CoRIM (remove tag first)
-        CBORDecoder decoder = new CBORDecoder(expectedCorim, 0, expectedCorim.length);
+        CBORDecoder decoder = new CBORDecoder(actualCoRIM, 0, actualCoRIM.length);
         CBORTaggedItem taggedUnsignedCorim = (CBORTaggedItem) decoder.next();
         CoRimParser corimParser = new CoRimParser(taggedUnsignedCorim.getTagContent().encode());
 
         // Check select attributes
-        assertEquals(corimParser.id, "Test CoRIM 2");
+        assertEquals("Test CoRIM 2", corimParser.id);
         Object[] testDependentRim = corimParser.dependentRims.get(0);
-        assertEquals(testDependentRim[0], "[https://testURI1, https://testURI2, https://testURI3]");
-        assertEquals(corimParser.profile, "https://testprofile");
+        assertEquals("[https://testURI1, https://testURI2, https://testURI3]", testDependentRim[0]);
+        assertEquals("https://testprofile", corimParser.profile);
         final long notAfterTimestamp = 1751376600L;
-        assertEquals(corimParser.notAfter, notAfterTimestamp);
-        assertEquals(corimParser.entityName, "ACME Inc.");
-        assertEquals(corimParser.entityRegId, "https://testing");
-        assertEquals(corimParser.entityRole, "tag-creator");
+        assertEquals(notAfterTimestamp, corimParser.notAfter);
+        assertEquals("ACME Inc.", corimParser.entityName);
+        assertEquals("https://testing", corimParser.entityRegId);
+        assertEquals("tag-creator", corimParser.entityRole);
 
         // Check select CoMID attributes
         checkCoMIDAttributes(corimParser.comidList.get(0));
@@ -93,24 +103,30 @@ public class CorimParserTest {
      *
      * @param comid The CoMID object to validate.
      */
-    public static void checkCoMIDAttributes(final Comid comid) {
-        assertEquals(comid.getLanguage(), Locale.US);
-        String testUUID = "742429b4-22ea-4d3b-baca-1e46fffa7379";
+    private void checkCoMIDAttributes(final Comid comid) {
+        assertEquals(Locale.US, comid.getLanguage());
+
+        final String testUUID = "742429b4-22ea-4d3b-baca-1e46fffa7379";
         assertEquals(comid.getTagIdentity().getTagIdUUID(), UUID.fromString(testUUID));
-        String testVendor = comid.getTriples().getReferenceTriples().get(0).getRefEnv().getComidClass()
+
+        final String testVendor = comid.getTriples().getReferenceTriples().get(0).getRefEnv().getComidClass()
                 .getVendor();
-        assertEquals(testVendor, "ACME Inc.");
-        String testModel = comid.getTriples().getReferenceTriples().get(0).getRefEnv().getComidClass()
+        assertEquals("ACME Inc.", testVendor);
+
+        final String testModel = comid.getTriples().getReferenceTriples().get(0).getRefEnv().getComidClass()
                 .getModel();
-        assertEquals(testModel, "ACME 9000");
-        int testMkey = comid.getTriples().getReferenceTriples().get(0).getRefClaims().get(1).getMkeyInt();
-        assertEquals(testMkey, 2);
-        IanaHashAlg testDigestAlg = comid.getTriples().getReferenceTriples().get(0).getRefClaims().get(1)
+        assertEquals("ACME 9000", testModel);
+
+        final int testMkey = comid.getTriples().getReferenceTriples().get(0).getRefClaims().get(1).getMkeyInt();
+        assertEquals(2, testMkey);
+
+        final IanaHashAlg testDigestAlg = comid.getTriples().getReferenceTriples().get(0).getRefClaims().get(1)
                 .getMval().getDigests().get(0).getAlg();
-        assertEquals(testDigestAlg, IanaHashAlg.SHA_256);
-        byte[] testDigestVal = comid.getTriples().getReferenceTriples().get(0).getRefClaims().get(1).getMval()
+        assertEquals(IanaHashAlg.SHA_256, testDigestAlg);
+
+        final byte[] testDigestVal = comid.getTriples().getReferenceTriples().get(0).getRefClaims().get(1).getMval()
                 .getDigests().get(0).getVal();
-        String expectedDigestVal = "17b66b2c3ae27ec5b0d20ae4987dadff4d1b81941c010c94675a60fb97b4e700";
+        final String expectedDigestVal = "17b66b2c3ae27ec5b0d20ae4987dadff4d1b81941c010c94675a60fb97b4e700";
         assertArrayEquals(testDigestVal, Hex.decode(expectedDigestVal));
     }
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -73,7 +73,7 @@
     </module>
     <module name="LineLength">
         <property name="fileExtensions" value="java"/>
-        <property name="max" value="110"/>
+        <property name="max" value="120"/>
     </module>
 
     <!-- Checks for whitespace                               -->


### PR DESCRIPTION
### Description
4 Junit tests under HIRS_UTILS fail when the application is run on a Windows machine. The goal of this issue is to address the failed tests under the HIRS_UTILS module so that they pass on both Linux and Windows environments.

### Test Instructions:
1. Pull this branch and run the `./gradlew clean test --rerun-tasks` command on a Windows machine and verify that there are no failed tests.

### Issues This PR Addresses:
Closes #1017 