### PR TITLE
[#984] Updated ACA Test pseudo random source

### DIFF
--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/AttestationCertificateAuthorityTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/AttestationCertificateAuthorityTest.java
@@ -239,7 +239,7 @@ public class AttestationCertificateAuthorityTest {
         byte[] randomBytes = new byte[ENCRYPTION_IV_LEN];
 
         // generate the random bytes
-        SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
+        SecureRandom random = SecureRandom.getInstance("NativePRNG");
         random.nextBytes(randomBytes);
 
         // the shared secret
@@ -289,7 +289,7 @@ public class AttestationCertificateAuthorityTest {
 
         // generate a random session key to be used for encryption and decryption
         byte[] sessionKey = new byte[ENCRYPTION_IV_LEN];
-        SecureRandom random = SecureRandom.getInstance("SHA1PRNG");
+        SecureRandom random = SecureRandom.getInstance("NativePRNG");
         random.nextBytes(sessionKey);
 
         // perform the test

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/AttestationCertificateAuthorityTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/AttestationCertificateAuthorityTest.java
@@ -51,7 +51,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
-import java.security.SecureRandom;
+import java.util.Random;
 import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
@@ -126,6 +126,7 @@ public class AttestationCertificateAuthorityTest {
     private AccessAbstractProcessor abstractProcessor;
     // test key pair
     private KeyPair keyPair;
+    private  Random random = new Random();
 
     /**
      * Registers bouncy castle as a security provider. Normally the JEE container will handle this,
@@ -239,7 +240,6 @@ public class AttestationCertificateAuthorityTest {
         byte[] randomBytes = new byte[ENCRYPTION_IV_LEN];
 
         // generate the random bytes
-        SecureRandom random = SecureRandom.getInstance("NativePRNG");
         random.nextBytes(randomBytes);
 
         // the shared secret
@@ -289,9 +289,9 @@ public class AttestationCertificateAuthorityTest {
 
         // generate a random session key to be used for encryption and decryption
         byte[] sessionKey = new byte[ENCRYPTION_IV_LEN];
-        SecureRandom random = SecureRandom.getInstance("NativePRNG");
-        random.nextBytes(sessionKey);
 
+        random.nextBytes(sessionKey);
+        
         // perform the test
         byte[] result = ProvisionUtils.generateAsymmetricContents(identityProofEncoded,
                 sessionKey, keyPair.getPublic());


### PR DESCRIPTION
Use of SHA1PRNG is prevented when the RHEL device has FIPS mode enabled. ~~Switching to NativePRNG should allow the device to pull from sources (e.g. /dev/random) that are not disabled when FIPS mode is enabled~~. Had to move to java.util.random for the test to avoid issues with Java.security.SecureRandom in FIPS mode. This fix will build on FIPS enabled devices.


closes #984 