### PR TITLE
[#1013] Improved error messaging for base RIM payload hash mismatch

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/rim-details.jsp
@@ -489,6 +489,7 @@
                                                                         </c:when>
                                                                         <c:otherwise>
                                                                             ${resource.getName()}
+                                                                            <img src="${failIcon}" title="${supportRimHashInvalidText}"/>
                                                                         </c:otherwise>
                                                                     </c:choose>
                                                                 </span>
@@ -540,7 +541,7 @@
                                                                 </c:when>
                                                                 <c:otherwise>
                                                                 <c:if test="${not initialData.swidPatch and not initialData.swidSupplemental}">
-                                                                    <div class="component col col-md-10" style="color: red; padding-left: 20px">Support RIM file named ${resource.getName()} was not imported via the Reference Integrity Manifest page.</div>
+                                                                    <div class="component col col-md-10" style="color: red; padding-left: 20px">Support RIM file with hash ${resource.getHashValue()} was not found.</div>
                                                                 </c:if>
                                                                 </c:otherwise>
                                                             </c:choose>

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -275,7 +275,7 @@ public class ReferenceManifestValidator {
         String calculatedHash = getHashValue(input, SHA256);
         supportRimValid = calculatedHash.equals(expected);
         if (!supportRimValid) {
-            log.info("Unmatched support RIM hash! Expected: {}, actual: {}", expected, calculatedHash);
+            log.warn("Unmatched support RIM hash! Expected: {}, actual: {}", expected, calculatedHash);
         }
     }
 
@@ -404,9 +404,9 @@ public class ReferenceManifestValidator {
             throws XMLSignatureException {
         boolean cryptoValidity = signature.getSignatureValue().validate(context);
         if (cryptoValidity) {
-            log.error("Signature value is valid.");
+            log.info("Signature block validated.");
         } else {
-            log.error("Signature value is invalid!");
+            log.error("Signature block not valid, <SignedInfo> should be compared to <SignatureValue>.");
         }
         Iterator itr = signature.getSignedInfo().getReferences().iterator();
         while (itr.hasNext()) {
@@ -414,12 +414,13 @@ public class ReferenceManifestValidator {
             boolean refValidity = reference.validate(context);
             String refUri = reference.getURI();
             if (refUri.isEmpty()) {
-                refUri = "whole document";
+                refUri = "<SoftwareIdentity>";
             }
             if (refValidity) {
-                log.error("Reference for {} is valid.", refUri);
+                log.info("Reference for {} is valid.", refUri);
             } else {
-                log.error("Reference for {} is invalid!", refUri);
+                log.error("Reference for {} is invalid, its <DigestValue> should be inspected.",
+                        refUri);
             }
         }
     }


### PR DESCRIPTION
If a provision fails because a corrupted payload hash caused a support RIM to be not found, the ACA front end and logs now show the following:

Frontend:
<img width="1536" height="718" alt="image" src="https://github.com/user-attachments/assets/f96998b6-6830-4482-9969-f26aacb3a916" />
<img width="934" height="332" alt="image" src="https://github.com/user-attachments/assets/0b49e942-8a79-48a0-b3c8-3290edba093c" />
<br/>
Portal console:
`[hirs.utils.rim.ReferenceManifestValidator.whySignatureInvalid] ERROR : Reference for <SoftwareIdentity> is invalid, its <DigestValue> should be inspected.`
<br/>
ACA log:
`[hirs.attestationca.persist.provision.IdentityClaimProcessor.parseDeviceInfo] WARN  : Could not locate support RIM with hash cf8ab8eefa8bd5e0b83e18132a17065f322a8c17b1e1e773b68a61cdb2415e90
[hirs.attestationca.persist.provision.IdentityClaimProcessor.parseDeviceInfo] WARN  : Could not locate support RIM associated with base RIM 7a836704-d4b8-4906-a788-7a4fbfb112ef
[hirs.utils.rim.ReferenceManifestValidator.whySignatureInvalid] ERROR : Reference for <SoftwareIdentity> is invalid, its <DigestValue> should be inspected.
[hirs.attestationca.persist.validation.FirmwareScvValidator.validateFirmware] WARN  : RIM signature validation failed: Support Reference Integrity Manifest can not be found`