### PR TITLE
[WIP] Added start up params for ecc options

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/resources/application.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.properties
@@ -25,16 +25,11 @@ server.port=8443
 server.ssl.enabled=true
 server.ssl.trust-store-type=JKS
 server.ssl.trust-store=/etc/hirs/certificates/HIRS/TrustStore.jks
-server.ssl.trust-alias=hirs_aca_tls_rsa_3k_sha384
 server.ssl.key-store-type=JKS
 server.ssl.key-store=/etc/hirs/certificates/HIRS/KeyStore.jks
-server.ssl.key-alias=hirs_aca_tls_rsa_3k_sha384
 server.ssl.enabled-protocols=TLSv1.2, TLSv1.3
-server.ssl.ciphers=TLS_AES_256_GCM_SHA384, ECDHE-ECDSA-AES256-GCM-SHA384, ECDHE-RSA-AES256-GCM-SHA384, DHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384
+server.ssl.ciphers=TLS_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA256 , TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE-RSA-AES256-GCM-SHA384, TLS_ECDHE-RSA-AES256-GCM-SHA384, AES256-GCM-SHA384
 # ACA specific default properties
-aca.certificates.leaf-three-key-alias=HIRS_leaf_ca3_rsa_3k_sha384
-aca.certificates.intermediate-key-alias=HIRS_intermediate_ca_rsa_3k_sha384
-aca.certificates.root-key-alias=HIRS_root_ca_rsa_3k_sha384
 aca.certificates.validity=3652
 # Compression settings
 server.compression.enabled=true
@@ -45,4 +40,3 @@ server.compression.min-response-size=2048
 #Spring Boot actuator
 management.endpoints.web.exposure.include=health,info,metrics,loggers,beans
 management.endpoint.health.show-details=always
-

--- a/package/linux/db/db_create.sh
+++ b/package/linux/db/db_create.sh
@@ -10,7 +10,8 @@
 LOG_FILE=$1
 DB_LOG_FILE="/var/log/mariadb/mariadb.log"
 PKI_PASS=$2
-UNATTENDED=$3
+DB_ALG=$3
+UNATTENDED=$4
 RSA_PATH=rsa_3k_sha384_certs
 ECC_PATH=ecc_512_sha384_certs
 # Capture location of the script to allow from invocation from any location
@@ -21,15 +22,26 @@ DB_ADMIN_PWD=""
 # Db Configuration fileis, use RHELpaths as default
 DB_SRV_CONF="/etc/my.cnf.d/mariadb-server.cnf"
 DB_CLIENT_CONF="/etc/my.cnf.d/client.cnf"
-# Default Server Side Certificates
-SSL_DB_SRV_CHAIN="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_rsa_3k_sha384_Cert_Chain.pem";
-SSL_DB_SRV_CERT="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_db_srv_rsa_3k_sha384.pem"; 
-SSL_DB_SRV_KEY="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_db_srv_rsa_3k_sha384.key";
-# Default Client Side Certificates
-SSL_DB_CLIENT_CHAIN="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_rsa_3k_sha384_Cert_Chain.pem";
-SSL_DB_CLIENT_CERT="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_db_client_rsa_3k_sha384.pem"; 
-SSL_DB_CLIENT_KEY="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_db_client_rsa_3k_sha384.key";
-
+# Default Certificates
+if [ "$DB_ALG" == "rsa" ]; then
+  # Default Server Side Certificates
+  SSL_DB_SRV_CHAIN="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_rsa_3k_sha384_Cert_Chain.pem";
+  SSL_DB_SRV_CERT="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_db_srv_rsa_3k_sha384.pem";
+  SSL_DB_SRV_KEY="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_db_srv_rsa_3k_sha384.key";
+  # Default Client Side Certificates
+  SSL_DB_CLIENT_CHAIN="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_rsa_3k_sha384_Cert_Chain.pem";
+  SSL_DB_CLIENT_CERT="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_db_client_rsa_3k_sha384.pem";
+  SSL_DB_CLIENT_KEY="/etc/hirs/certificates/HIRS/rsa_3k_sha384_certs/HIRS_db_client_rsa_3k_sha384.key";
+elif [ "$DB_ALG" == "ecc" ]; then
+  # Default Server Side Certificates
+  SSL_DB_SRV_CHAIN="/etc/hirs/certificates/HIRS/ecc_512_sha384_certs/HIRS_ecc_512_sha384_Cert_Chain.pem";
+  SSL_DB_SRV_CERT="/etc/hirs/certificates/HIRS/ecc_512_sha384_certs/HIRS_db_srv_ecc_512_sha384.pem";
+  SSL_DB_SRV_KEY="/etc/hirs/certificates/HIRS/ecc_512_sha384_certs/HIRS_db_srv_ecc_512_sha384.key";
+  # Default Client Side Certificates
+  SSL_DB_CLIENT_CHAIN="/etc/hirs/certificates/HIRS/ecc_512_sha384_certs/HIRS_ecc_512_sha384_Cert_Chain.pem";
+  SSL_DB_CLIENT_CERT="/etc/hirs/certificates/HIRS/ecc_512_sha384_certs/HIRS_db_client_ecc_512_sha384.pem";
+  SSL_DB_CLIENT_KEY="/etc/hirs/certificates/HIRS/ecc_512_sha384_certs/HIRS_db_client_ecc_512_sha384.key";
+fi
 # Make sure required paths exist
 mkdir -p /etc/hirs/aca/
 mkdir -p /var/log/hirs/
@@ -207,7 +219,7 @@ create_hibernate_url () {
  ALG=$1
  db_username=$2
 
-  if [ $ALG = "RSA" ]; then 
+  if [ $ALG = "rsa" ]; then
     CERT_PATH="/etc/hirs/certificates/HIRS/$RSA_PATH"
     CERT_CHAIN="$CERT_PATH/HIRS_rsa_3k_sha384_Cert_Chain.pem"
     CLIENT_DB_P12=$CERT_PATH/HIRS_db_client_rsa_3k_sha384.p12
@@ -243,5 +255,5 @@ set_hirs_db_pwd
 create_hirs_db_with_tls
 set_mysql_server_tls
 set_mysql_client_tls
-create_hibernate_url "RSA" "hirs_db"
+create_hibernate_url $DB_ALG "hirs_db"
 mysqld_reboot

--- a/package/linux/pki/pki_chain_gen.sh
+++ b/package/linux/pki/pki_chain_gen.sh
@@ -114,6 +114,7 @@ add_to_stores () {
    # Import the cert into a java trust store via keytool
    keytool -import -keystore $TRUSTSTORE -storepass $PASS -file "$CERT_PATH".pem  -noprompt -alias "$ALIAS" >> "$LOG_FILE" 2>&1
    # Remove the temp p1 file.
+   #echo "key with alias of $ALIAS stored"
    rm tmpkey.p12
 } 
 
@@ -178,6 +179,7 @@ create_cert () {
    # Import the cert into a java trust store via keytool
    keytool -import -keystore $TRUSTSTORE -storepass $PASS -file "$CERT_PATH".pem  -noprompt -alias "$ALIAS" >> "$LOG_FILE" 2>&1
    # Remove the temp p1 file.
+   #echo "Key with alias of $ALIAS stored in jks"
    rm -f tmpkey.p12 &>/dev/null
 }
 

--- a/package/linux/pki/pki_setup.sh
+++ b/package/linux/pki/pki_setup.sh
@@ -17,6 +17,7 @@ LOG_DIR="/var/log/hirs/"
 HIRS_DIR=/etc/hirs
 HIRS_CONF_DIR=/etc/hirs/aca
 HIRS_CERT_DIR=/etc/hirs/certificates
+
 # Capture location of the script to allow from invocation from any location 
 SCRIPT_DIR=$( dirname -- "$( readlink -f -- "$0"; )"; )
 
@@ -81,6 +82,7 @@ echo "Setting MYSQL permissions for DB TLS Certs..." | tee -a "$LOG_FILE"
   echo "hirs_pki_password="$PKI_PASS >>  $ACA_PROP
   echo "server.ssl.key-store-password="$PKI_PASS >> $SPRING_PROP_FILE
   echo "server.ssl.trust-store-password="$PKI_PASS >> $SPRING_PROP_FILE
+
 else 
   echo "/etc/hirs/certificates exists, skipping" | tee -a "$LOG_FILE"
 fi


### PR DESCRIPTION
Adds a set parameters to the aca_setup.sh script for selecting default algorithms:
``` 
 -aa | --aca-alg specify the ACA's default algorithm (rsa, ecc, or mldsa) for Attestation Certificates
 -ta | --tls-alg specify the ACA's default algorithm (rsa, ecc, or mldsa) for TLS on the ACA portal
 -da | --db-alg specify the ACA's default algorithm (rsa, ecc, or mldsa) for use with maraidb
```
The default is left at rsa (rsa 3072 with SHA384) to keep backward compatibility. Note that some algorithm choices (e.g. mldsa) may not be available on some systems or libraries (e.g. openssl).