### PR TITLE
[#1070] Throw an error if base RIM is not found during provisioning

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/IdentityClaimProcessor.java
@@ -673,8 +673,8 @@ public class IdentityClaimProcessor extends AbstractProcessor {
                             referenceManifestRepository.save(bRim);
                             referenceManifestRepository.save(sBaseRim);
                         } else {
-                            log.warn("Could not locate support RIM associated with " +
-                                    "base RIM " + bRim.getId());
+                            log.warn("Could not locate support RIM associated with "
+                                    + "base RIM " + bRim.getId());
                         }
                     }
                 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -511,8 +511,8 @@ public class ReferenceManifestDetailsPageService {
             for (TpmPcrEvent attestationEvent : unmatchedAttestationEvents) {
                 matchedEvents = new ArrayList<>();
                 for (TpmPcrEvent referenceEvent : referenceEventValues) {
-                    if ((referenceEvent.getEventType() == attestationEvent.getEventType()) &&
-                            (referenceEvent.getPcrIndex() == attestationEvent.getPcrIndex())) {
+                    if ((referenceEvent.getEventType() == attestationEvent.getEventType())
+                            && (referenceEvent.getPcrIndex() == attestationEvent.getPcrIndex())) {
                         if (eventIsType(attestationEvent.getEventType())) {
                             matcher = variableName.matcher(attestationEvent.getEventContentStr());
                             if (matcher.find()) {
@@ -547,7 +547,7 @@ public class ReferenceManifestDetailsPageService {
      * @param eventType to check for event type
      * @return true if the below types are matched, otherwise false
      */
-    private boolean eventIsType(long eventType) {
+    private boolean eventIsType(final long eventType) {
         return eventType == EvConstants.EV_EFI_VARIABLE_AUTHORITY
                 || eventType == EvConstants.EV_EFI_VARIABLE_BOOT
                 || eventType == EvConstants.EV_EFI_VARIABLE_DRIVER_CONFIG

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
@@ -31,6 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import static hirs.attestationca.persist.enums.AppraisalStatus.Status.ERROR;
 import static hirs.attestationca.persist.enums.AppraisalStatus.Status.FAIL;
 import static hirs.attestationca.persist.enums.AppraisalStatus.Status.PASS;
 
@@ -88,6 +89,7 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
         if (baseReferenceManifest == null) {
             failedString = "Base Reference Integrity Manifest not found for " + hostName + "\n";
             passed = false;
+            fwStatus = new AppraisalStatus(ERROR, failedString);
         } else if (measurement == null) {
             measurement = (EventLogMeasurements) referenceManifestRepository
                     .findByHexDecHashAndRimTypeUnarchived(baseReferenceManifest.getEventLogHash(),

--- a/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/validation-reports.jsp
+++ b/HIRS_AttestationCAPortal/src/main/webapp/WEB-INF/jsp/validation-reports.jsp
@@ -251,13 +251,15 @@
                 }
               }
 
-              switch (validation_type) {
-                case "FIRMWARE":
-                  html +=
-                    '<a href="${portal}/rim-details?id=' +
-                    curValidation.rimId +
-                    '">';
-                  break;
+              if (curValidation.rimId !== "") {
+                  switch (validation_type) {
+                    case "FIRMWARE":
+                      html +=
+                        '<a href="${portal}/rim-details?id=' +
+                        curValidation.rimId +
+                        '">';
+                      break;
+                  }
               }
 
               switch (curResult) {


### PR DESCRIPTION
### These changes include the following:
1. Set an ERROR status if a base RIM is not sent for provisioning (or otherwise cannot be found for validation).
2. ERROR icons on the Validation Reports page do not link in the absence of a RIM ID.
3. Minor checkstyle changes.

### Test instructions:
1. Build and deploy an ACA instance from this branch.
2. Provision without a base RIM (e.g. delete it from the expected directory).
3. Confirm that the provision fails and that the following are observed:


#### Frontend:
<img width="1920" height="1023" alt="v3_issue-1070" src="https://github.com/user-attachments/assets/305369e0-1af4-48b8-9102-7ef9bd9e96e9" />


#### Console:
`[hirs.attestationca.persist.service.ValidationService.buildValidationRecord] ERROR : Base Reference Integrity Manifest not found for [hostname]`
`[hirs.attestationca.persist.provision.IdentityClaimProcessor.processIdentityClaimTpm2] ERROR : Supply chain validation did not succeed. Result is: ERROR`

#### Log:
`[hirs.attestationca.persist.validation.FirmwareScvValidator.validateFirmware] INFO  : Validating firmware...`
`[hirs.attestationca.persist.service.ValidationService.buildValidationRecord] ERROR : Base Reference Integrity Manifest not found for [hostname]
`

Closes #1070 