### PR TITLE
[#1083] Update Gradle's OWASP Dependency Check Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'application'
     id 'checkstyle'
     id 'com.github.spotbugs' version '6.0.13' apply false
-    id 'org.owasp.dependencycheck' version '11.1.1'
+    id 'org.owasp.dependencycheck' version '12.1.9'
     id 'java'
     id 'jacoco'
 }
@@ -77,6 +77,12 @@ subprojects {
     }
 }
 
+dependencyCheck {
+    nvd {
+        // Read API key from a system property 'nvd.apiKey'
+        apiKey = System.getProperty("nvd.apiKey")
+    }
+}
 dependencies {
     repositories {
         // Use Maven Central for resolving dependencies.


### PR DESCRIPTION
Updated org.owasp.dependencycheck to version 12.1.9

closes #1083