### PR TITLE
[#1085] Resolve bug preventing ecc EK certs from being uploaded

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/EndorsementCredential.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/EndorsementCredential.java
@@ -310,11 +310,6 @@ public class EndorsementCredential extends DeviceAssociatedCertificate {
                     // there may be subfields that are expected, so continue parsing
                     parseSingle((ASN1Primitive) obj2, false, null);
                 }
-            } else {
-                // parse the elements of the sequence individually
-                for (ASN1Encodable component : seq) {
-                    parseSingle((ASN1Primitive) component, false, null);
-                }
             }
             // The next two are special sequences that have already been matched with an OID.
         } else if (addToMapping && key.equals(TPM_SPECIFICATION)


### PR DESCRIPTION
This pull request is meant to resolve a bug that was preventing ecc EK certs from being uploaded to the ACA. In PR #1015 , a block of code in `EndorsementCredential.java` was pushed, and seems to have been a mistake. This was not caught in testing because testing was done with already existing EK certs in the ACA, meaning no actual uploading of new EK certs was tested.

By removing this block of code, all EK certs are able to be uploaded again, while not interfering with the original intentions of PR #1015 .

Test instructions: Spin up ACA, upload EK cert that uses ECC (as opposed to RSA).

Resolves: #1085 