### PR TITLE
[#1102] Update ACA to trim out extra text in PEM uploads

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/CredentialHelper.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/CredentialHelper.java
@@ -4,7 +4,6 @@ import hirs.attestationca.persist.entity.userdefined.certificate.CertificateVari
 import lombok.extern.log4j.Log4j2;
 import org.bouncycastle.util.encoders.Base64;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;


### PR DESCRIPTION
Some PEM-formatted certificates including CAs and EKs have extra text above the `-----BEGIN CERTIFICATE-----` line. Currently, the ACA does not know what to do with it and throws an error when encountering it. This PR adds functionality so the ACA can trim out the extra text and proceed with normal byte parsing.

Test Instructions:
1. Pull down this branch and spin up an ACA from it.
2. Upload a cert chain to the Trust Chain page in PEM formatting that has extra text. Ensure that it is successful and the details are properly displayed. Note that the extra text can be anything, including gibberish, and can be added to the PEM in a text editor for testing purposes.
3. Upload an EK to the Endorsement Credential page in PEM formatting that has extra text. Ensure that it is successful and the details are properly displayed.

Resolves #1102 