### PR TITLE
[#1116] Update to fix Java pathing on Windows for the ACA image workflow

### DIFF
--- a/.ci/docker/Dockerfile.aca-windows
+++ b/.ci/docker/Dockerfile.aca-windows
@@ -33,13 +33,12 @@ RUN ((New-Object System.Net.WebClient).DownloadFile('https://download.oracle.com
 
 # Install JDK 25
 RUN Write-Host "Installing JDK 25..."
-RUN Start-Process -filepath 'C:/jdk-25_windows-x64_bin.exe' -Wait -PassThru -ArgumentList "/s"
+RUN Start-Process -filepath 'C:/jdk-25_windows-x64_bin.exe' -Wait -PassThru -ArgumentList "/s", "INSTALLDIR=C:\Java\jdk25"
 RUN Write-Host "Finished installing JDK 25."
 
 # Verify installation by listing directories
-RUN ls 'C:\Program Files'
-RUN ls 'C:\Program Files\Java'
-RUN ls 'C:\Program Files\Java\latest\'
+RUN ls 'C:\Java'
+RUN ls 'C:\Java\jdk25\'
 
 # Download and install Mariadb as a service
 RUN ((New-Object System.Net.WebClient).DownloadFile('https://archive.mariadb.org/mariadb-11.1.2/winx64-packages/mariadb-11.1.2-winx64.msi', 'C:/mariadb-11.1.2-winx64.msi'))
@@ -59,19 +58,6 @@ RUN Start-Process -FilePath 'C:/Git-2.42.0.2-64-bit.exe' -ArgumentList \"/VERYSI
 RUN [Environment]::SetEnvironmentVariable('GCM_INTERACTIVE', 'Never', [System.EnvironmentVariableTarget]::Machine)
 RUN Write-Host "Finished installing Git."
 
-# Download and install .NET SDK 10
-RUN ((New-Object System.Net.WebClient).DownloadFile('https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1', 'C:/dotnet-install.ps1'))
-RUN Write-Host "Installing .NET SDK..."
-RUN pwsh -ExecutionPolicy Bypass C:/dotnet-install.ps1 --channel 10.0
-RUN Write-Host "Finished installing .NET SDK."
-
-# Download and install VS Build Tools from Microsoft
-RUN ((New-Object System.Net.WebClient).DownloadFile('https://aka.ms/vs/17/release/vs_buildtools.exe', 'C:/vs_buildtools.exe'))
-RUN ((New-Object System.Net.WebClient).DownloadFile('https://aka.ms/vs/17/release/channel', 'C:/vs_channel.chman'))
-RUN Write-Host "Installing Visual Studio Build Tools..."
-RUN Start-Process -FilePath 'C:/vs_buildtools.exe' -ArgumentList \"--quiet --wait --norestart --nocache --channelUri C:/vs_channel.chman --installChannelUri C:/vs_channel.chman --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended --installPath C:/vsbuildtools\" -Wait -PassThru
-RUN Write-Host "Finished installing Visual Studio Build Tools."
-
 # Download and extract pre-built openssl
 RUN ((New-Object System.Net.WebClient).DownloadFile('https://download.firedaemon.com/FireDaemon-OpenSSL/openssl-3.5.3.zip', 'C:/openssl-3.zip'))
 RUN Expand-Archive C:/openssl-3.zip -DestinationPath C:/openssl_files/
@@ -84,42 +70,14 @@ RUN ls 'C:\Program Files\openssl'
 EXPOSE 8443
 
 # Set Environment Variables
-RUN setx JAVA_HOME 'C:\Program Files\Java\latest'
+RUN setx JAVA_HOME 'C:\Java\jdk25'
 RUN setx GIT_HOME 'C:\Program Files\Git'
-RUN setx PATH '%JAVA_HOME%\bin;C:\Program Files\MariaDB 11.1\bin;%GIT_HOME%\bin;C:\vsbuildtools\MSBuild\Current\Bin;%LOCALAPPDATA%\Microsoft\dotnet;%PATH%'
+RUN setx PATH '%JAVA_HOME%\bin;C:\Program Files\MariaDB 11.1\bin;%GIT_HOME%\bin;%PATH%'
 
 # Echo System Variables
 RUN echo $Env:PATH
 RUN echo $Env:GIT_HOME
 RUN echo $Env:JAVA_HOME
-
-# Clone ibmswtpm2 and build
-RUN git clone https://github.com/kgoldman/ibmswtpm2.git C:/ibmswtpm2
-## tpm_server.sln is looking for the openssl crypto lib in a fixed location
-## Copying twice because sometimes it references either filename
-RUN cp 'C:/Program Files/openssl/lib/libcrypto.lib' 'C:/ibmswtpm2/tpmvstudio/tpm_server/libcrypto64md.lib'
-RUN cp 'C:/Program Files/openssl/lib/libcrypto.lib' 'C:/ibmswtpm2/tpmvstudio/tpm_server/libcrypto.lib'
-## Assume compatibility with any version of openssl3
-RUN (Get-Content C:/ibmswtpm2/src/BnToOsslMath.h) -replace '0x30200ff0L', '0x40200ff0L' | Out-File C:/ibmswtpm2/src/BnToOsslMath.h
-WORKDIR C:/ibmswtpm2/tpmvstudio/tpm_server
-#IF MSBUILD NOT ON PATH: RUN /vsbuildtools/MSBuild/Current/Bin/MSBuild.exe .\tpm_server.sln -t:Build -p:Configuration=Release -p:Platform=x64
-RUN MSBuild.exe .\tpm_server.sln -t:Build -p:Configuration=Release -p:Platform=x64
-# RUN Start-Process "C:/ibmswtpm2/tpmvstudio/tpm_server/x64/Release/tpm_server.exe" -WindowStyle Hidden
-
-# Clone ibmtss and build
-RUN git clone https://github.com/kgoldman/ibmtss.git C:/ibmtss
-## Again, This VS project is looking for the openssl crypto library in a fixed location. The paths are imported into multiple subprojects. Easier to edit the paths than attempt to copy the library everywhere.
-RUN ((Get-Content C:/ibmtss/tpmutils/CommonPropertiesx64.props) -replace 'libcrypto','C:/program files/openssl/lib/libcrypto') | Set-Content C:/ibmtss/tpmutils/CommonPropertiesx64.props
-RUN ((Get-Content C:/ibmtss/tpmutils/CommonPropertiesx64Release.props) -replace 'libcrypto','C:/program files/openssl/lib/libcrypto') | Set-Content C:/ibmtss/tpmutils/CommonPropertiesx64Release.props
-WORKDIR C:/ibmtss/tpmutils
-# IF MSBUILD NOT ON PATH: RUN /vsbuildtools/MSBuild/Current/Bin/MSBuild.exe .\tpmutils.sln -t:Build -p:Configuration=Release -p:Platform=x64
-RUN MSBuild.exe .\tpmutils.sln -t:Build -p:Configuration=Release -p:Platform=x64
-
-# Update path with the ibmtss utilities; Have to include previous additions as well
-RUN setx PATH '%JAVA_HOME%\bin;C:\Program Files\MariaDB 11.1\bin;%GIT_HOME%\bin;C:\vsbuildtools\MSBuild\Current\Bin;%LOCALAPPDATA%\Microsoft\dotnet;C:\ibmswtpm2\tpmvstudio\tpm_server\x64\Release;C:\ibmtss\tpmutils\x64\Release;%PATH%'
-
-# Echo PATH after update
-RUN echo $Env:PATH
 
 # Clone HIRS main (or REF)
 WORKDIR C:/


### PR DESCRIPTION
Oracle changed the default directory Java installs into on Windows for JDK 25 to include the minor revision. 

This update specifies the install directory.

I also removed dotnet, VSC++, and tpm server steps from the dockerfile to speed up the ACA Windows image build.