### PR TITLE
[#1133] Fix for MSI build on FIPS-Enabled Systems and Better Version Reporting

### DIFF
--- a/HIRS_Provisioner.NET/hirs/Directory.Build.targets
+++ b/HIRS_Provisioner.NET/hirs/Directory.Build.targets
@@ -18,12 +18,30 @@
   </Target>
   <Target Name="SetWixPath" BeforeTargets="Msi">
     <PropertyGroup>
+      <_WindowsFipsEnabled>false</_WindowsFipsEnabled>
+      <!--Test if FIPS is enabled on Windows-->
+      <_WindowsFipsEnabled Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' And '$([MSBuild]::GetRegistryValue(`HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy`,`Enabled`,`0`))' == '1'">true</_WindowsFipsEnabled>
+
+      <EnableFipsCompliantWix Condition="'$(EnableFipsCompliantWix)'==''">$(_WindowsFipsEnabled)</EnableFipsCompliantWix>
+        
       <ProductSourceFilePath>$(MSBuildThisFileDirectory)\Resources\Product.wxs</ProductSourceFilePath>
       <WixInstallPath>$(NuGetPackageRoot)wix\3.14.1\tools\</WixInstallPath>
       <Heat>$(WixInstallPath)heat.exe</Heat>
       <Candle>$(WixInstallPath)candle.exe</Candle>
       <Light>$(WixInstallPath)light.exe</Light>
+      <SetupFilePath>$(TargetDir)$(AssemblyName).$(PackageVersion).msi</SetupFilePath>
+      <WixFipsArg Condition="'$(EnableFipsCompliantWix)'=='true'">-fips</WixFipsArg>
     </PropertyGroup>
+  </Target>
+  <Target Name="Msi" DependsOnTargets="Publish">
+    <PropertyGroup>
+      <WixArguments>-nologo -dPublishDir="$(PublishDir)\" -dSetupProductName="$(SetupProductName)" -dSetupProductManufacturer="HIRS" -dSetupFeatureId="$(SetupFeatureId)" -dSetupFeatureName="$(SetupFeatureName)" -dSetupInstallFolderName="$(SetupInstallFolderName)" -dSetupProductVersion="$(Version)" -dSetupProductLanguage="$(SetupProductLanguage)"</WixArguments>
+    </PropertyGroup>
+    <Message Text="Creating msi package $(SetupFilePath)" Importance="high"/>
+    <Exec Command='"$(Heat)" dir "$(PublishDir)\" -nologo -scom -sreg -sfrag -srd -gg -dr INSTALLFOLDER -cg SourceComponentGroup -var var.PublishDir $(WixFipsArg) -o $(HarvestSourceFilePath)'/>
+    <Exec Command='"$(Candle)" $(WixArguments) $(WixFipsArg) "$(HarvestSourceFilePath)" -o "$(HarvestObjectFilePath)"'/>
+    <Exec Command='"$(Candle)" $(WixArguments) $(WixFipsArg) "$(ProductSourceFilePath)" -o "$(ProductObjectFilePath)"'/>
+    <Exec Command='"$(Light)" $(WixArguments) "$(HarvestObjectFilePath)" "$(ProductObjectFilePath)" -o "$(SetupFilePath)"'/>
   </Target>
   <Target Name="DeletePDB" AfterTargets="RenameBeforePublishLinux;RenameBeforePublishWindows">
     <ItemGroup>

--- a/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
+++ b/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
@@ -9,8 +9,10 @@
     <SelfContained>true</SelfContained>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <PackageVersion>3.1.0</PackageVersion>
-    <Release></Release> 
+    <Version>3.2.0</Version>
+    <PackageVersion>$(Version)</PackageVersion>
+    <Release></Release>
+    <IncludeSourceRevisionInInformationalVersion>true</IncludeSourceRevisionInInformationalVersion>
 </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -30,6 +32,7 @@
         <PrivateAssets>all</PrivateAssets> <!-- These assets will be consumed but won't flow to the parent project -->
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All"/>
     <PackageReference Include="Microsoft.TSS" Version="2.1.1" />
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/HIRS_Provisioner.NET/hirs/src/Program.cs
+++ b/HIRS_Provisioner.NET/hirs/src/Program.cs
@@ -2,13 +2,16 @@
 using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Threading.Tasks;
 
 namespace hirs {
     class Program {
-        public static readonly string VERSION = "17";
+        public static readonly string VERSION = typeof(Program).Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
 
         static async Task<int> Main(string[] args) {
             ClientExitCodes result = 0;


### PR DESCRIPTION
MSI should now build as expected on fips-enabled Windows systems.  The MSBUILD command is the same. 

Also added the package version to the MSI filename, as well as hooked it into the version saved to the log.

Closes #1133 