### PR TITLE
3.1.0 fix cert parsing

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/ReferenceManifestPageController.java
@@ -608,7 +608,8 @@ public class ReferenceManifestPageController extends PageController<NoPageParams
                             this.referenceDigestValueRepository.save(newRdv);
                         }
                     } catch (CertificateException e) {
-                        throw new CertificateException(e.getMessage());
+                        throw new CertificateException("Error processing support RIM "
+                                + dbSupport.getId() + ": " + e.getMessage());
                     } catch (NoSuchAlgorithmException | IOException e) {
                         e.printStackTrace();
                     }


### PR DESCRIPTION
This change is related to #1135.  Any errors that are encountered during RIM upload and subsequent parsing are displayed on the front end.  This may cause improper upload of RIM files.