### PR TITLE
[#1134] Fix Provisioning Failure On Windows

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/resources/application.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.properties
@@ -29,7 +29,7 @@ server.ssl.key-store-type=JKS
 server.ssl.key-store=/etc/hirs/certificates/HIRS/KeyStore.jks
 server.ssl.key-alias=hirs_aca_tls_rsa_3k_sha384
 server.ssl.enabled-protocols=TLSv1.3,TLSv1.2
-server.ssl.ciphers=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+server.ssl.ciphers=TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_128_CCM_SHA256,TLS_AES_128_CCM_8_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 # ACA specific default properties
 aca.certificates.leaf-three-key-alias=HIRS_leaf_ca3_rsa_3k_sha384
 aca.certificates.intermediate-key-alias=HIRS_intermediate_ca_rsa_3k_sha384

--- a/HIRS_AttestationCAPortal/src/main/resources/application.win.properties
+++ b/HIRS_AttestationCAPortal/src/main/resources/application.win.properties
@@ -32,7 +32,7 @@ server.ssl.key-store-type=JKS
 server.ssl.key-store=C:/ProgramData/hirs/certificates/HIRS/KeyStore.jks
 server.ssl.key-alias=hirs_aca_tls_rsa_3k_sha384
 server.ssl.enabled-protocols=TLSv1.3,TLSv1.2
-server.ssl.ciphers=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+server.ssl.ciphers=TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_128_CCM_SHA256,TLS_AES_128_CCM_8_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
 # ACA specific default properties
 aca.certificates.leaf-three-key-alias=HIRS_leaf_ca3_rsa_3k_sha384
 aca.certificates.intermediate-key-alias=HIRS_intermediate_ca_rsa_3k_sha384


### PR DESCRIPTION
### Description
Fixes the SSL handshake errors that appears when provisioning against the ACA.

### Test Instructions:
1. If you have the ACA setup on your device, remove the setup and reset it using the setup scripts. After that, run the ACA.
2. Run the latest version of the Provisioner against the ACA.
3. Verify that no SSL handshake issues pop up in the provisioner log file.
4. Verify that the ACA produces two issued certificates and the device page shows your device.

### Issues This PR Addresses:
Closes #1137  