### PR TITLE
[#1162] Remove EK's CRL and PolicyReference overrides for Issued Certs

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -708,8 +708,6 @@ public final class CertificateStringMapBuilder {
                     data.putAll(
                             convertStringToHash(ek.getTpmSecurityAssertions().toString()));
                 }
-
-                data.put("policyReference", ek.getPolicyReference());
                 data.put("credentialType", IssuedAttestationCertificate.AIC_TYPE_LABEL);
             }
             // add platform credential IDs if not empty


### PR DESCRIPTION
Previously, the back-end behavior of ACA would overwrite Issued Certificates' `Revocation Locator` and `Policy Reference` with that of the EK certificate. Reason it was written this way (if it was intentional) is still ambiguous/unknown.

This PR is intended to remove this overwrite so that the ACA will properly display the Issued Certificates' respective `Revocation Locator` (CRL) and `Policy Reference` fields. Note that if `Revocation Locator` is empty or null, it will be hidden entirely on the ACA portal.

Resolves #1162 