### PR TITLE
[RIM-Tool #41]: Modify CoRIM signing for RIM-Tool bugfix

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/cbor/ietfCorim/CoRimBuilder.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/cbor/ietfCorim/CoRimBuilder.java
@@ -32,10 +32,8 @@ import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 import hirs.utils.crypto.DefaultCrypto;
-import hirs.utils.signature.SignatureHelper;
 import hirs.utils.signature.cose.CoseAlgorithm;
 import hirs.utils.signature.cose.CoseSignature;
-import hirs.utils.rim.unsignedRim.GenericRim;
 
 /**
  * Class containing the logic used to build out a CoRIM from user input.
@@ -128,14 +126,8 @@ public final class CoRimBuilder {
         // Add payload
         coseSign1Items.add(new CBORByteArray(unsignedCorim));
         // Add signature
-        // Create signature block (Sig_structure) and ToBeSigned
         try {
-            // byte[] toBeSigned = new CoseSignature().createToBeSigned(cert,
-            // unsignedCorim, protectedHeader);
-            final byte[] toBeSigned = new CoseSignature().createToBeSigned(
-                    SignatureHelper.getCoseAlgFromCert(cert), SignatureHelper.getKidFromCert(cert),
-                    unsignedCorim, cert, false, false,
-                    GenericRim.RIMTYPE_CORIM_COMID); // need protectedHeader
+            final byte[] toBeSigned = new CoseSignature().createToBeSigned(unsignedCorim, protectedHeader);
             final byte[] signature = cryptoProvider.sign(toBeSigned);
             coseSign1Items.add(new CBORByteArray(signature));
         } catch (final Exception e) {

--- a/HIRS_Utils/src/main/java/hirs/utils/signature/cose/CoseSignature.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/signature/cose/CoseSignature.java
@@ -148,6 +148,35 @@ public class CoseSignature implements SignatureFormat {
     }
 
     /**
+     * Create toBeSigned using an already-constructed protected header.
+     * This ensures that all fields (including corim-meta, etc.)
+     * are preserved exactly as encoded.
+     * This method should be used for CoRIM signing where the protected header
+     * is constructed externally (e.g., via CoRimBuilder).
+     *
+     * @param payload the payload to sign
+     * @param protectedHeader the fully constructed COSE protected header
+     * @return the encoded Sig_structure
+     */
+    public byte[] createToBeSigned(final byte[] payload,
+                                   final COSEProtectedHeader protectedHeader) {
+        if (coseBuilder == null) {
+            coseBuilder = new COSESign1Builder();
+        }
+        CBORByteArray encodedPayload = new CBORByteArray(payload);
+        SigStructure structure = new SigStructureBuilder()
+                .signature1()
+                .bodyAttributes(protectedHeader)
+                .payload(encodedPayload)
+                .build();
+        this.toBeSigned = structure.encode();
+        coseBuilder.payload(encodedPayload);
+        coseBuilder.protectedHeader(protectedHeader);
+        this.payload = payload.clone();
+        return this.toBeSigned.clone();
+    }
+
+    /**
      * Follows the "The steps for verifying a signature are" of section 4.4. of rfc9052 Signing
      * and Verification Process.
      * <a href="https://datatracker.ietf.org/doc/html/rfc9052#section-4.4">rfc9052 Signing


### PR DESCRIPTION
This PR is intended to modify CoRIM structure building and signing in order to fix functionality and maintain consistency in the RIM-Tool. It creates an overloaded `createToBeSigned()` method that allows CoRIM structures (which contain additional fields in the protected header, such as `corim-meta-map`) to be used in signing and properly verified.

Intended to be merged into HIRS before merging nsacyber/RIM-Tool#43 into RIM-Tool. After merging this PR, nsacyber/RIM-Tool#43 should add a new pointer to the updated `main` HIRS branch to use as submodule.

Resolves HIRS changes for nsacyber/Rim-Tool#41