### PR TITLE
Update combo of EV_EFI_VARIABLE_AUTHORITY/EFI_IMAGE_SECURITY_DATABASE_GUID to be a UefiSignatureData

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -153,11 +153,11 @@ public class ReferenceManifestDetailsPageService {
                 coveredEvents.put("gptTable", true);
             } else if (contentStr.contains("BootOrder")) {
                 coveredEvents.put("bootOrder", true);
-            } else if (contentStr.contains(UefiConstants.UEFI_VARIABLE_LABEL + ": PK")) {
+            } else if (contentStr.contains(UefiConstants.UEFI_VARIABLE_UNICODE_NAME + ": PK")) {
                 coveredEvents.put("pk", true);
-            } else if (contentStr.contains(UefiConstants.UEFI_VARIABLE_LABEL + ": KEK")) {
+            } else if (contentStr.contains(UefiConstants.UEFI_VARIABLE_UNICODE_NAME + ": KEK")) {
                 coveredEvents.put("kek", true);
-            } else if (contentStr.contains(UefiConstants.UEFI_VARIABLE_LABEL + ": db")) {
+            } else if (contentStr.contains(UefiConstants.UEFI_VARIABLE_UNICODE_NAME + ": db")) {
                 if (contentStr.contains("dbx")) {
                     coveredEvents.put("forbiddenDbx", true);
                 } else {

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
@@ -233,6 +233,9 @@ public final class TCGEventLog {
             // put the remaining events into the event list
             while (is.available() > 0) {
                 if (bCryptoAgile) {
+                    if(eventNumber == 32) {
+                        String stop = "stop";
+                    }
                     TpmPcrEvent2 event2 = new TpmPcrEvent2(is, eventNumber, strongestEvLogHashAlgName);
                     eventList.put(eventNumber++, event2);
                     if (event2.isStartupLocalityEvent()) {
@@ -277,19 +280,19 @@ public final class TCGEventLog {
                 }
             }
         } catch (IOException i) {
-            String error = "IO error parsing event log at Event #" + (eventNumber - 1);
+            String error = "IO error parsing event log at Event #" + (eventNumber);
             log.error(error + ": " + i);
             throw new IOException(error);
         } catch (CertificateException c) {
-            String error = "Certificate error parsing event log at Event#" + (eventNumber - 1);
+            String error = "Certificate error parsing event log at Event#" + (eventNumber);
             log.error(error + ": " + c);
             throw new CertificateException(error);
         } catch (NoSuchAlgorithmException a) {
-            String error = "Algorithm error parsing event log at Event #" + (eventNumber - 1);
+            String error = "Algorithm error parsing event log at Event #" + (eventNumber);
             log.error(error + ": " + a);
             throw new NoSuchAlgorithmException(error);
         } catch (RuntimeException r) {
-            String error = "Error parsing event log at Event #" + (eventNumber - 1);
+            String error = "Error parsing event log at Event #" + (eventNumber);
             log.error(error + ": " + r);
             throw new RuntimeException(error);
         }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
@@ -233,9 +233,6 @@ public final class TCGEventLog {
             // put the remaining events into the event list
             while (is.available() > 0) {
                 if (bCryptoAgile) {
-                    if(eventNumber == 35) {
-                        String stop = "stop";
-                    }
                     TpmPcrEvent2 event2 = new TpmPcrEvent2(is, eventNumber, strongestEvLogHashAlgName);
                     eventList.put(eventNumber++, event2);
                     if (event2.isStartupLocalityEvent()) {

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
@@ -233,7 +233,7 @@ public final class TCGEventLog {
             // put the remaining events into the event list
             while (is.available() > 0) {
                 if (bCryptoAgile) {
-                    if(eventNumber == 32) {
+                    if(eventNumber == 35) {
                         String stop = "stop";
                     }
                     TpmPcrEvent2 event2 = new TpmPcrEvent2(is, eventNumber, strongestEvLogHashAlgName);

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
@@ -427,7 +427,7 @@ public class TpmPcrEvent {
             case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
             case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
                 try {
-                    sb.append(new UefiVariable((int)eventType, eventContent));
+                    sb.append(new UefiVariable((int) eventType, eventContent));
                 } catch (NoSuchAlgorithmException | IOException exception) {
                     log.error(exception);
                     sb.append(exception);

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
@@ -427,7 +427,7 @@ public class TpmPcrEvent {
             case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
             case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
                 try {
-                    sb.append(new UefiVariable(eventContent));
+                    sb.append(new UefiVariable((int)eventType, eventContent));
                 } catch (NoSuchAlgorithmException | IOException exception) {
                     log.error(exception);
                     sb.append(exception);
@@ -567,7 +567,7 @@ public class TpmPcrEvent {
             case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
             case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
             case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
-                UefiVariable efiVar = new UefiVariable(content);
+                UefiVariable efiVar = new UefiVariable(eventID, content);
                 description += "Event Content:\n" + efiVar;
 //                guidTableFileStatus = efiVar.getGuidTableFileStatus();
                 break;

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiConstants.java
@@ -286,7 +286,7 @@ public final class UefiConstants {
     /**
      * This string is used to assemble strings for output and also to search for events.
      */
-    public static final String UEFI_VARIABLE_LABEL = "UEFI Variable Name";
+    public static final String UEFI_VARIABLE_UNICODE_NAME = "UEFI Unicode Name";
 
     /**
      * This string is used to assemble strings for output and also to search for events.

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -181,7 +181,14 @@ public class UefiVariable {
                 break;
             case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
             case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
-                processSigDataX509(uefiVariableData);
+//                if(!(unicodeName.contains("MokList"))) {
+
+                if(!(unicodeName.contains("MokList") || unicodeName.contains("SbatLevel"))) {
+                    processSigDataX509(uefiVariableData);
+                }
+                else {
+                    String temph = "temph";
+                }
                 break;
             case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
                 processSigList(uefiVariableData);
@@ -248,7 +255,7 @@ public class UefiVariable {
         sigDataInfo += "";
 
         // for now, hard-code the signature type for X509
-        // in future with more test data, update this (potentially need to look at previous SPDM event)
+        // in future with more test data, update this (for SPDM potentially need to look at previous SPDM event)
         byte[] guid = HexUtils.hexStringToByteArray("A159C0A5E494A74A87B5AB155C2BF072");
         UefiGuid signatureType = new UefiGuid(guid);
 
@@ -306,14 +313,14 @@ public class UefiVariable {
                     efiVariable.append(booto.toString());
                 }
                 break;
+            case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
+                if(unicodeName.contains("MokList") || unicodeName.contains("SbatLevel")) {
+                    efiVariable.append(printCert(uefiVariableData, 0));
+                }
+                break;
             default:
                 efiVariable.append(String.format("      Code does not yet process this Uefi Variable"));
         }
-
-//            case "Shim":
-//            case "MokList":
-//                efiVariable.append(printCert(uefiVariableData, 0));
-//                break;
 
         // Signature List output (if there are any Signature Lists)
         if (certSuperList.size() > 0) {

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -12,8 +12,6 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.bouncycastle.oer.its.template.ieee1609dot2.basetypes.Ieee1609Dot2BaseTypes.UINT64;
-
 /**
  * Class to process a UEFI variable within a TPM Event.
  * <pre>
@@ -105,6 +103,7 @@ public class UefiVariable {
      * The UEFI_VARIABLE_DATA contains a "VariableName" field which is used to determine
      * the class used to parse the data within the "VariableData".
      *
+     * @param eventTypeIn the event type
      * @param variableData byte array holding the UEFI Variable.
      * @throws java.security.NoSuchAlgorithmException if there's a problem
      *                                                hashing the certificate.
@@ -169,13 +168,13 @@ public class UefiVariable {
                     case "dbx":
                         processSigList(uefiVariableData);
                         break;
+                    default:
                 }
                 break;
             case EvConstants.EV_EFI_VARIABLE_BOOT:
                 if (unicodeName.contains("Boot00")) {
                     bootv = new UefiBootVariable(uefiVariableData);
-                }
-                else if (unicodeName.equals("BootOrder")) {
+                } else if (unicodeName.equals("BootOrder")) {
                     booto = new UefiBootOrder(uefiVariableData);
                 }
                 break;
@@ -305,6 +304,9 @@ public class UefiVariable {
                     if (unicodeName.equals("SecureBoot")) {
                         efiVariable.append(sb.toString());
                     }
+                    else {
+                        efiVariable.append("      Code does not yet process this Uefi Variable\n");
+                    }
                     break;
                 case EvConstants.EV_EFI_VARIABLE_BOOT:
                     if (unicodeName.contains("Boot00")) {
@@ -312,13 +314,20 @@ public class UefiVariable {
                     } else if (unicodeName.equals("BootOrder")) {
                         efiVariable.append(booto.toString());
                     }
+                    else {
+                        efiVariable.append("      Code does not yet process this Uefi Variable\n");
+                    }
                     break;
                 case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
+                    if (!variableNameGuid.getVendorTableReference().equals("EFI_IMAGE_SECURITY_DATABASE_GUID")) {
+                        efiVariable.append("      Code does not yet process this Uefi Variable\n");
+                    }
+                    break;
                 case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
                 case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
                     break;
                 default:
-                    efiVariable.append(String.format("      Code does not yet process this Uefi Variable\n"));
+                    efiVariable.append("      Code does not yet process this Uefi Variable\n");
             }
         }
 

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -1,6 +1,7 @@
 package hirs.utils.tpm.eventlog.uefi;
 
 import hirs.utils.HexUtils;
+import hirs.utils.tpm.eventlog.events.EvConstants;
 import lombok.Getter;
 
 import java.io.ByteArrayInputStream;
@@ -17,28 +18,44 @@ import static org.bouncycastle.oer.its.template.ieee1609dot2.basetypes.Ieee1609D
  * Class to process a UEFI variable within a TPM Event.
  * <pre>
  * typedef struct tdUEFI_VARIABLE_DATA{
- * <pre>    UEFI_GUID VariableName;     (16 bytes)</pre>
- * <pre>    UINT64 UnicodeNameLength;   (8 bytes)</pre>
- * <pre>    UINT64 VariableDataLength;  (8 bytes)</pre>
- * <pre>    CHAR16 UnicodeName[];</pre>
- * <pre>    INT8 VariableData[];</pre>
- * } UEFI_VARIABLE_DATA
- * </pre>
- * <pre>
+ * &emsp;UEFI_GUID VariableName;     (16 bytes)
+ * &emsp;UINT64 UnicodeNameLength;   (8 bytes)
+ * &emsp;UINT64 VariableDataLength;  (8 bytes)
+ * &emsp;CHAR16 UnicodeName[];
+ * &emsp;INT8 VariableData[];
+ * } UEFI_VARIABLE_DATA<br>
  *
  * Example:
  *
  * UEFI_VARIABLE_DATA example{
- * <pre>    "8be4df61-93ca-11d2-aa0d-00e098032b8c : EFI_Global_Variable"</pre>
- * <pre>    2</pre>
- * <pre>    973</pre>
- * <pre>    PK</pre>
- * <pre>    < UefiSignatureList > </pre>
+ * &emsp;"8be4df61-93ca-11d2-aa0d-00e098032b8c : EFI_Global_Variable"
+ * &emsp;2
+ * &emsp;973
+ * &emsp;PK
+ * &emsp;< UefiSignatureList >
  * }
- * </pre>
+ * </pre><br>
+ * PFP 1.06 Revision 52:<br>
+ * <ul>
+ * <li>For Event Type EV_EFI_VARIABLE_DRIVER_CONFIG: The event field MUST contain a
+ * UEFI_VARIABLE_DATA structure, including
+ * the variable data, the GUID and the Unicode
+ * string.</li>
+ * <li>For Event Type EV_EFI_VARIABLE_AUTHORITY: The event field MUST contain a
+ * UEFI_VARIABLE_DATA structure where the
+ * VariableData field contains the
+ * EFI_SIGNATURE_DATA value from the
+ * EFI_SIGNATURE_LIST used to validate the
+ * loaded image</li>
+ * </ul>
  */
 public class UefiVariable {
 
+    /**
+     * Event Type.
+     */
+    @Getter
+    private int eventType = 0;
     /**
      * UEFI defined variable identifier GUID.
      */
@@ -80,7 +97,8 @@ public class UefiVariable {
     /**
      * Human-readable description of the data within the SPDM devdc (to be updated with more test data).
      */
-    private String spdmDevdcInfo = "";
+//    private String spdmDevdcInfo = "";
+    private String sigDataInfo = "";
 
     /**
      * EFIVariable constructor.
@@ -93,9 +111,10 @@ public class UefiVariable {
      * @throws java.io.IOException                    If there's a problem
      *                                                parsing the signature data.
      */
-    public UefiVariable(final int eventType, final byte[] variableData)
+    public UefiVariable(final int eventTypeIn, final byte[] variableData)
             throws NoSuchAlgorithmException, IOException {
 
+        eventType = eventTypeIn;
         certSuperList = new ArrayList<>();
 
         byte[] variableNameGuidBytes = new byte[UefiConstants.SIZE_16];
@@ -138,31 +157,34 @@ public class UefiVariable {
         System.arraycopy(variableData, UefiConstants.OFFSET_32
                 + unicodeNameLength * UefiConstants.SIZE_2, uefiVariableData, 0, variableDataLength);
 
-        switch (unicodeNameAdjusted) {
-            case "PK":
-            case "KEK":
-            case "db":
-            case "dbx":
-                processSigList(uefiVariableData);
+        switch (eventType) {
+            case EvConstants.EV_EFI_VARIABLE_DRIVER_CONFIG:
+                switch (unicodeName) {
+                    case "SecureBoot":
+                        sb = new UefiSecureBoot(uefiVariableData);
+                        break;
+                    case "PK":
+                    case "KEK":
+                    case "db":
+                    case "dbx":
+                        processSigList(uefiVariableData);
+                        break;
+                }
                 break;
-            case "devdb":
-                processSigList(uefiVariableData);
-                break;      // Update when test patterns exist
-            // PFP v1.06 Rev 52, Sec 3.3.4.8
-            // EV_EFI_SPDM_DEVICE_POLICY: EFI_SIGNATURE_LIST
-            // EV_EFI_SPDM_DEVICE_AUTHORITY: EFI_SIGNATURE_DATA
-            // for now, differentiate them by using devdc for ..DEVICE_AUTHORITY
-            case "devdc":
+            case EvConstants.EV_EFI_VARIABLE_BOOT:
+                if (unicodeName.contains("Boot00")) {
+                    bootv = new UefiBootVariable(uefiVariableData);
+                }
+                else if (unicodeName.equals("BootOrder")) {
+                    booto = new UefiBootOrder(uefiVariableData);
+                }
+                break;
+            case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
+            case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
                 processSigDataX509(uefiVariableData);
                 break;
-            case "Boot00":
-                bootv = new UefiBootVariable(uefiVariableData);
-                break;
-            case "BootOrder":
-                booto = new UefiBootOrder(uefiVariableData);
-                break;
-            case "SecureBoot":
-                sb = new UefiSecureBoot(uefiVariableData);
+            case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
+                processSigList(uefiVariableData);
                 break;
             default:
         }
@@ -201,7 +223,6 @@ public class UefiVariable {
 //                guidTableFileStatus = list.getGuidTableFileStatus();
 //            }
 
-//            efiVariableSigListContents += list.toString();
             if (!list.isSignatureTypeValid()) {
                 invalidSignatureListEncountered = true;
                 invalidSignatureListStatus = list.toString();
@@ -224,7 +245,7 @@ public class UefiVariable {
 
         ByteArrayInputStream efiSigDataIS = new ByteArrayInputStream(efiSigData);
         ArrayList<UefiSignatureData> sigList = new ArrayList<UefiSignatureData>();
-        spdmDevdcInfo += "";
+        sigDataInfo += "";
 
         // for now, hard-code the signature type for X509
         // in future with more test data, update this (potentially need to look at previous SPDM event)
@@ -244,16 +265,16 @@ public class UefiVariable {
             sigList.add(tmpSigData);
             numberOfCerts++;
         }
-        spdmDevdcInfo += "   Number of X509 Certs in UEFI Signature Data = " + numberOfCerts + "\n";
+        sigDataInfo += "   Number of X509 Certs in UEFI Signature Data = " + numberOfCerts + "\n";
         int certCnt = 0;
         for (int i = 0; i < sigList.size(); i++) {
             certCnt++;
-            spdmDevdcInfo += "   Cert # " + certCnt + " of " + numberOfCerts + ": ------------------\n";
+            sigDataInfo += "   Cert # " + certCnt + " of " + numberOfCerts + ": ------------------\n";
             UefiSignatureData certData = sigList.get(i);
-            spdmDevdcInfo += certData.toString();
+            sigDataInfo += certData.toString();
         }
         if (!dataValid) {
-            spdmDevdcInfo += "   *** Invalid UEFI Signature data encountered: " + dataInvalidStatus + "\n";
+            sigDataInfo += "   *** Invalid UEFI Signature data encountered: " + dataInvalidStatus + "\n";
         }
     }
 
@@ -265,47 +286,34 @@ public class UefiVariable {
     public String toString() {
         StringBuilder efiVariable = new StringBuilder();
 
-        efiVariable.append(String.format("   %s: %s%n", UefiConstants.UEFI_VARIABLE_LABEL, unicodeName));
         efiVariable.append("   UEFI Variable Name GUID: " + variableNameGuid.toString() + "\n");
+        efiVariable.append(String.format("   %s: %s%n", UefiConstants.UEFI_VARIABLE_UNICODE_NAME, unicodeName));
         if (unicodeName != "") {
-            efiVariable.append("   UEFI Variable Contents => " + "\n");
+            efiVariable.append("   UEFI Variable Data => " + "\n");
         }
-        String tmpName = "";
-        if (unicodeName.contains("Boot00")) {
-            tmpName = "Boot00";
-        } else {
-            tmpName = unicodeName;
-        }
-        switch (tmpName) {
-            case "Shim":
-            case "MokList":
-                efiVariable.append(printCert(uefiVariableData, 0));
+
+        switch (eventType) {
+            case EvConstants.EV_EFI_VARIABLE_DRIVER_CONFIG:
+                if (unicodeName.equals("SecureBoot")) {
+                    efiVariable.append(sb.toString());
+                }
                 break;
-            case "PK":
-            case "KEK":
-            case "db":
-            case "dbx":
-            case "devdb":           // SPDM_DEVICE_POLICY and SPDM_DEVICE_AUTHORITY
-            case "devdc":           // for now use devdb and devdc respectively
-                // (update when more test patterns exist)
-                break;
-            case "Boot00":
-                efiVariable.append(bootv.toString());
-                break;
-            case "BootOrder":
-                efiVariable.append(booto.toString());
-                break;
-            case "SecureBoot":
-                efiVariable.append(sb.toString());
+            case EvConstants.EV_EFI_VARIABLE_BOOT:
+                if (unicodeName.contains("Boot00")) {
+                    efiVariable.append(bootv.toString());
+                }
+                else if (unicodeName.equals("BootOrder")) {
+                    efiVariable.append(booto.toString());
+                }
                 break;
             default:
-                if (!tmpName.isEmpty()) {
-                    efiVariable.append(String.format("      Data not provided for "
-                            + "UEFI variable named %s   ", tmpName));
-                } else {
-                    efiVariable.append("      Data not provided   ");
-                }
+                efiVariable.append(String.format("      Code does not yet process this Uefi Variable"));
         }
+
+//            case "Shim":
+//            case "MokList":
+//                efiVariable.append(printCert(uefiVariableData, 0));
+//                break;
 
         // Signature List output (if there are any Signature Lists)
         if (certSuperList.size() > 0) {
@@ -324,8 +332,8 @@ public class UefiVariable {
         }
 
         // Signature Data output (if there is a Signature Data)
-        if (!spdmDevdcInfo.isEmpty()) {
-            efiVariable.append(spdmDevdcInfo);
+        if (!sigDataInfo.isEmpty()) {
+            efiVariable.append(sigDataInfo);
         }
 
         return efiVariable.toString();

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -180,18 +180,15 @@ public class UefiVariable {
                 }
                 break;
             case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
-            case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
-//                if(!(unicodeName.contains("MokList"))) {
-
-                if(!(unicodeName.contains("MokList") || unicodeName.contains("SbatLevel"))) {
+                if (variableNameGuid.getVendorTableReference().equals("EFI_IMAGE_SECURITY_DATABASE_GUID")) {
                     processSigDataX509(uefiVariableData);
-                }
-                else {
-                    String temph = "temph";
                 }
                 break;
             case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
                 processSigList(uefiVariableData);
+                break;
+            case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
+                processSigDataX509(uefiVariableData);
                 break;
             default:
         }
@@ -299,27 +296,30 @@ public class UefiVariable {
             efiVariable.append("   UEFI Variable Data => " + "\n");
         }
 
-        switch (eventType) {
-            case EvConstants.EV_EFI_VARIABLE_DRIVER_CONFIG:
-                if (unicodeName.equals("SecureBoot")) {
-                    efiVariable.append(sb.toString());
-                }
-                break;
-            case EvConstants.EV_EFI_VARIABLE_BOOT:
-                if (unicodeName.contains("Boot00")) {
-                    efiVariable.append(bootv.toString());
-                }
-                else if (unicodeName.equals("BootOrder")) {
-                    efiVariable.append(booto.toString());
-                }
-                break;
-            case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
-                if(unicodeName.contains("MokList") || unicodeName.contains("SbatLevel")) {
-                    efiVariable.append(printCert(uefiVariableData, 0));
-                }
-                break;
-            default:
-                efiVariable.append(String.format("      Code does not yet process this Uefi Variable"));
+        // fix shim & moklist once come across an example:
+        if (unicodeName.equals("Shim") || unicodeName.equals("MokList")) {
+            efiVariable.append(printCert(uefiVariableData, 0));
+        } else {
+            switch (eventType) {
+                case EvConstants.EV_EFI_VARIABLE_DRIVER_CONFIG:
+                    if (unicodeName.equals("SecureBoot")) {
+                        efiVariable.append(sb.toString());
+                    }
+                    break;
+                case EvConstants.EV_EFI_VARIABLE_BOOT:
+                    if (unicodeName.contains("Boot00")) {
+                        efiVariable.append(bootv.toString());
+                    } else if (unicodeName.equals("BootOrder")) {
+                        efiVariable.append(booto.toString());
+                    }
+                    break;
+                case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
+                case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
+                case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
+                    break;
+                default:
+                    efiVariable.append(String.format("      Code does not yet process this Uefi Variable\n"));
+            }
         }
 
         // Signature List output (if there are any Signature Lists)

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -11,6 +11,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.bouncycastle.oer.its.template.ieee1609dot2.basetypes.Ieee1609Dot2BaseTypes.UINT64;
+
 /**
  * Class to process a UEFI variable within a TPM Event.
  * <pre>
@@ -22,23 +24,39 @@ import java.util.List;
  * <pre>    INT8 VariableData[];</pre>
  * } UEFI_VARIABLE_DATA
  * </pre>
+ * <pre>
+ *
+ * Example:
+ *
+ * UEFI_VARIABLE_DATA example{
+ * <pre>    "8be4df61-93ca-11d2-aa0d-00e098032b8c : EFI_Global_Variable"</pre>
+ * <pre>    2</pre>
+ * <pre>    973</pre>
+ * <pre>    PK</pre>
+ * <pre>    < UefiSignatureList > </pre>
+ * }
+ * </pre>
  */
 public class UefiVariable {
 
     /**
-     * List of Signature lists.
-     */
-    private final List<UefiSignatureList> certSuperList;
-    /**
      * UEFI defined variable identifier GUID.
      */
     @Getter
-    private UefiGuid uefiVarGuid = null;
+    private UefiGuid variableNameGuid = null;
     /**
      * Name of the UEFI variable.
      */
     @Getter
-    private String efiVarName = "";
+    private String unicodeName = "";
+    /**
+     * UEFI variable data.
+     */
+    private byte[] uefiVariableData = null;
+    /**
+     * List of Signature lists.
+     */
+    private final List<UefiSignatureList> certSuperList;
     /**
      * Encountered invalid UEFI Signature List.
      */
@@ -60,20 +78,6 @@ public class UefiVariable {
      */
     private UefiSecureBoot sb = null;
     /**
-     * UEFI variable data.
-     */
-    private byte[] uefiVariableData = null;
-
-//    /**
-//     * Track status of vendor-table.json file.
-//     * The default here is that each list correctly grabbed the file from file system.
-//     * If any one list has issues, this overall status will change to reflect the
-//     * problematic list's status.
-//     */
-//    @Getter
-//    private String guidTableFileStatus = FILESTATUS_FROM_FILESYSTEM;
-
-    /**
      * Human-readable description of the data within the SPDM devdc (to be updated with more test data).
      */
     private String spdmDevdcInfo = "";
@@ -89,19 +93,22 @@ public class UefiVariable {
      * @throws java.io.IOException                    If there's a problem
      *                                                parsing the signature data.
      */
-    public UefiVariable(final byte[] variableData)
+    public UefiVariable(final int eventType, final byte[] variableData)
             throws NoSuchAlgorithmException, IOException {
+
         certSuperList = new ArrayList<>();
+
         byte[] variableNameGuidBytes = new byte[UefiConstants.SIZE_16];
         byte[] unicodeNameLengthBytes = new byte[UefiConstants.SIZE_8];
-        byte[] unicodeNameCharBytes = null;
         byte[] variableDataLengthBytes = new byte[UefiConstants.SIZE_8];
-        byte[] unicodeName = null;
-        int variableLength = 0;
+        int variableDataLength = 0;
+        byte[] unicodeNameCharBytes = null;
+        byte[] unicodeNameWithZerosBytes = null;
+        byte[] unicodeNameBytes = null;
 
         // VariableName (GUID)
         System.arraycopy(variableData, 0, variableNameGuidBytes, 0, UefiConstants.SIZE_16);
-        uefiVarGuid = new UefiGuid(variableNameGuidBytes);
+        variableNameGuid = new UefiGuid(variableNameGuidBytes);
 
         // UnicodeNameLength
         System.arraycopy(variableData, UefiConstants.SIZE_16, unicodeNameLengthBytes,
@@ -111,27 +118,27 @@ public class UefiVariable {
         // VariableDataLength
         System.arraycopy(variableData, UefiConstants.OFFSET_24, variableDataLengthBytes,
                 0, UefiConstants.SIZE_8);
-        variableLength = HexUtils.leReverseInt(variableDataLengthBytes);
+        variableDataLength = HexUtils.leReverseInt(variableDataLengthBytes);
 
         // UnicodeName
         unicodeNameCharBytes = new byte[unicodeNameLength * UefiConstants.SIZE_2];
         System.arraycopy(variableData, UefiConstants.OFFSET_32,
                 unicodeNameCharBytes, 0, unicodeNameLength * UefiConstants.SIZE_2);
-        byte[] unicodeNameBytes = UefiDevicePath.convertChar16tobyteArray(unicodeNameCharBytes);
-        unicodeName = new byte[unicodeNameLength];
-        System.arraycopy(unicodeNameBytes, 0, unicodeName, 0, unicodeNameLength);
-        efiVarName = new String(unicodeName, StandardCharsets.UTF_8);
-        String efiVarNameAdjusted = efiVarName;
-        if (efiVarName.contains("Boot00")) {
-            efiVarNameAdjusted = "Boot00";
+        unicodeNameWithZerosBytes = UefiDevicePath.convertChar16tobyteArray(unicodeNameCharBytes);
+        unicodeNameBytes = new byte[unicodeNameLength];
+        System.arraycopy(unicodeNameWithZerosBytes, 0, unicodeNameBytes, 0, unicodeNameLength);
+        unicodeName = new String(unicodeNameBytes, StandardCharsets.UTF_8);
+        String unicodeNameAdjusted = unicodeName;
+        if (unicodeName.contains("Boot00")) {
+            unicodeNameAdjusted = "Boot00";
         }
 
         // VariableData
-        uefiVariableData = new byte[variableLength];
+        uefiVariableData = new byte[variableDataLength];
         System.arraycopy(variableData, UefiConstants.OFFSET_32
-                + unicodeNameLength * UefiConstants.SIZE_2, uefiVariableData, 0, variableLength);
+                + unicodeNameLength * UefiConstants.SIZE_2, uefiVariableData, 0, variableDataLength);
 
-        switch (efiVarNameAdjusted) {
+        switch (unicodeNameAdjusted) {
             case "PK":
             case "KEK":
             case "db":
@@ -258,16 +265,16 @@ public class UefiVariable {
     public String toString() {
         StringBuilder efiVariable = new StringBuilder();
 
-        efiVariable.append(String.format("   %s: %s%n", UefiConstants.UEFI_VARIABLE_LABEL, efiVarName));
-        efiVariable.append("   UEFI Variable GUID: " + uefiVarGuid.toString() + "\n");
-        if (efiVarName != "") {
+        efiVariable.append(String.format("   %s: %s%n", UefiConstants.UEFI_VARIABLE_LABEL, unicodeName));
+        efiVariable.append("   UEFI Variable Name GUID: " + variableNameGuid.toString() + "\n");
+        if (unicodeName != "") {
             efiVariable.append("   UEFI Variable Contents => " + "\n");
         }
         String tmpName = "";
-        if (efiVarName.contains("Boot00")) {
+        if (unicodeName.contains("Boot00")) {
             tmpName = "Boot00";
         } else {
-            tmpName = efiVarName;
+            tmpName = unicodeName;
         }
         switch (tmpName) {
             case "Shim":

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -73,6 +73,10 @@ public class UefiVariable {
      */
     private final List<UefiSignatureList> certSuperList;
     /**
+     * Was able to process the Variable Data.
+     */
+    private boolean uefiVariableDataProcessed = false;
+    /**
      * Encountered invalid UEFI Signature List.
      */
     private boolean invalidSignatureListEncountered = false;
@@ -161,12 +165,14 @@ public class UefiVariable {
                 switch (unicodeName) {
                     case "SecureBoot":
                         sb = new UefiSecureBoot(uefiVariableData);
+                        uefiVariableDataProcessed = true;
                         break;
                     case "PK":
                     case "KEK":
                     case "db":
                     case "dbx":
                         processSigList(uefiVariableData);
+                        uefiVariableDataProcessed = true;
                         break;
                     default:
                 }
@@ -174,20 +180,25 @@ public class UefiVariable {
             case EvConstants.EV_EFI_VARIABLE_BOOT:
                 if (unicodeName.contains("Boot00")) {
                     bootv = new UefiBootVariable(uefiVariableData);
+                    uefiVariableDataProcessed = true;
                 } else if (unicodeName.equals("BootOrder")) {
                     booto = new UefiBootOrder(uefiVariableData);
+                    uefiVariableDataProcessed = true;
                 }
                 break;
             case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
                 if (variableNameGuid.getVendorTableReference().equals("EFI_IMAGE_SECURITY_DATABASE_GUID")) {
                     processSigDataX509(uefiVariableData);
+                    uefiVariableDataProcessed = true;
                 }
                 break;
             case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
                 processSigList(uefiVariableData);
+                uefiVariableDataProcessed = true;
                 break;
             case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
                 processSigDataX509(uefiVariableData);
+                uefiVariableDataProcessed = true;
                 break;
             default:
         }
@@ -304,9 +315,6 @@ public class UefiVariable {
                     if (unicodeName.equals("SecureBoot")) {
                         efiVariable.append(sb.toString());
                     }
-                    else {
-                        efiVariable.append("      Code does not yet process this Uefi Variable\n");
-                    }
                     break;
                 case EvConstants.EV_EFI_VARIABLE_BOOT:
                     if (unicodeName.contains("Boot00")) {
@@ -314,21 +322,17 @@ public class UefiVariable {
                     } else if (unicodeName.equals("BootOrder")) {
                         efiVariable.append(booto.toString());
                     }
-                    else {
-                        efiVariable.append("      Code does not yet process this Uefi Variable\n");
-                    }
                     break;
                 case EvConstants.EV_EFI_VARIABLE_AUTHORITY:
-                    if (!variableNameGuid.getVendorTableReference().equals("EFI_IMAGE_SECURITY_DATABASE_GUID")) {
-                        efiVariable.append("      Code does not yet process this Uefi Variable\n");
-                    }
-                    break;
                 case EvConstants.EV_EFI_SPDM_DEVICE_POLICY:
                 case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
                     break;
                 default:
-                    efiVariable.append("      Code does not yet process this Uefi Variable\n");
             }
+        }
+
+        if(!uefiVariableDataProcessed) {
+            efiVariable.append("      Code does not yet process this Uefi Variable\n");
         }
 
         // Signature List output (if there are any Signature Lists)

--- a/HIRS_Utils/src/test/java/hirs/tpm/eventlog/uefi/UefiProcessingTest.java
+++ b/HIRS_Utils/src/test/java/hirs/tpm/eventlog/uefi/UefiProcessingTest.java
@@ -3,6 +3,7 @@ package hirs.tpm.eventlog.uefi;
 import com.eclipsesource.json.JsonObject;
 import hirs.utils.HexUtils;
 import hirs.utils.JsonUtils;
+import hirs.utils.tpm.eventlog.events.EvConstants;
 import hirs.utils.tpm.eventlog.uefi.UefiDevicePath;
 import hirs.utils.tpm.eventlog.uefi.UefiFirmware;
 import hirs.utils.tpm.eventlog.uefi.UefiGuid;
@@ -76,9 +77,9 @@ public class UefiProcessingTest {
         String uefiTxt = IOUtils.toString(this.getClass().getResourceAsStream(UEFI_VARIABLE_BOOT),
                 StandardCharsets.UTF_8);
         byte[] uefiVariableBytes = HexUtils.hexStringToByteArray(uefiTxt);
-        UefiVariable uefiVariable = new UefiVariable(uefiVariableBytes);
-        UefiGuid guid = uefiVariable.getUefiVarGuid();
-        String varName = uefiVariable.getEfiVarName();
+        UefiVariable uefiVariable = new UefiVariable(EvConstants.EV_EFI_VARIABLE_BOOT, uefiVariableBytes);
+        UefiGuid guid = uefiVariable.getVariableNameGuid();
+        String varName = uefiVariable.getUnicodeName();
         JsonObject jsonObject = JsonUtils.getSpecificJsonObject(jsonPath, "VendorTable");
         String guidStr = jsonObject.getString(
                 guid.toStringNoLookup().toLowerCase(), "Unknown GUID reference");
@@ -89,9 +90,9 @@ public class UefiProcessingTest {
                         .getResourceAsStream(UEFI_VARIABLE_BOOT_SECURE_BOOT),
                 StandardCharsets.UTF_8);
         uefiVariableBytes = HexUtils.hexStringToByteArray(uefiTxt);
-        uefiVariable = new UefiVariable(uefiVariableBytes);
-        guid = uefiVariable.getUefiVarGuid();
-        varName = uefiVariable.getEfiVarName();
+        uefiVariable = new UefiVariable(EvConstants.EV_EFI_VARIABLE_DRIVER_CONFIG, uefiVariableBytes);
+        guid = uefiVariable.getVariableNameGuid();
+        varName = uefiVariable.getUnicodeName();
         guidStr = jsonObject.getString(
                 guid.toStringNoLookup().toLowerCase(), "Unknown GUID reference");
         Assertions.assertEquals("EFI_Global_Variable", guidStr);
@@ -100,8 +101,8 @@ public class UefiProcessingTest {
         uefiTxt = IOUtils.toString(this.getClass().getResourceAsStream(
                 UEFI_VARIABLE_BOOT_DRIVER_CONFIG_KEK), StandardCharsets.UTF_8);
         uefiVariableBytes = HexUtils.hexStringToByteArray(uefiTxt);
-        uefiVariable = new UefiVariable(uefiVariableBytes);
-        varName = uefiVariable.getEfiVarName();
+        uefiVariable = new UefiVariable(EvConstants.EV_EFI_VARIABLE_DRIVER_CONFIG, uefiVariableBytes);
+        varName = uefiVariable.getUnicodeName();
         Assertions.assertEquals("KEK", varName);
     }
 


### PR DESCRIPTION
Closes #1170 

This PR updates the UefiVariable class to better reflect the PFP, and fixes the combo of EV_EFI_VARIABLE_AUTHORITY/EFI_IMAGE_SECURITY_DATABASE_GUID to be processed as a UefiSignatureData.

Test with a variety of event logs. Include an event log that includes an event with EV_EFI_VARIABLE_AUTHORITY/EFI_IMAGE_SECURITY_DATABASE_GUID.