### PR TITLE
[#1175] Remove TPM Specification from Issued Certs details page

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -699,11 +699,6 @@ public final class CertificateStringMapBuilder {
                 } else {
                     data.put("endorsementID", "0");
                 }
-                // Add hashmap with TPM information if available
-                if (ek.getTpmSpecification() != null) {
-                    data.putAll(
-                            convertStringToHash(ek.getTpmSpecification().toString()));
-                }
                 data.put("credentialType", IssuedAttestationCertificate.AIC_TYPE_LABEL);
             }
             // add platform credential IDs if not empty

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/certificate-details.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/certificate-details.html
@@ -1539,21 +1539,6 @@
                             [[${initialData.get('tcgMajorVersion')}]].[[${initialData.get('tcgMinorVersion')}]].[[${initialData.get('tcgRevisionLevel')}]]
                         </div>
                     </div>
-                    <div class="certrow">
-                        <div class="col-md-1 col-md-offset-1">
-                            <span class="colHeader">
-                                TPM Specification
-                            </span>
-                        </div>
-                        <div class="col col-md-8" id="tpmSpecification">
-                            <div class="card-body" id="tpmSpecificationInner">
-                                <div>Family:&nbsp;<span>[[${initialData.get('TPMSpecificationFamily')}]]</span></div>
-                                <div>Level:&nbsp;<span>[[${initialData.get('TPMSpecificationLevel')}]]</span></div>
-                                <div>Revision:&nbsp;<span>[[${initialData.get('TPMSpecificationRevision')}]]</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
                 </th:block> <!-- Close certificate of type 'issued' -->
 
                 <!-- If this is a certificate of type 'idevid' -->


### PR DESCRIPTION
The TPM Specification field(s) on Issued Certs details page, for both ACs and LDevIDs, does not belong there. It only belongs on EK Credential page, which is already linked to the Issued Cert on the details page. This PR removes it from Issued Certs page.

To test, spin up a local ACA from this branch and go to Issued Certs details page to confirm that TPM Specification is not at the bottom.

Resolves #1175 