### PR TITLE
Update exception handling in TCG Event Log when event log can't parse

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/EventLogMeasurements.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/EventLogMeasurements.java
@@ -14,8 +14,6 @@ import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -84,7 +82,7 @@ public class EventLogMeasurements extends SupportReferenceManifest {
             TCGEventLog logProcessor = new TCGEventLog(this.getRimBytes());
             this.pcrHash = Arrays.hashCode(logProcessor.getExpectedPCRValues());
             return logProcessor.getExpectedPCRValues();
-        } catch (CertificateException | NoSuchAlgorithmException | IOException exception) {
+        } catch (IOException exception) {
             log.error(exception);
         }
 
@@ -101,7 +99,7 @@ public class EventLogMeasurements extends SupportReferenceManifest {
         try {
             logProcessor = new TCGEventLog(this.getRimBytes());
             return logProcessor.getEventList();
-        } catch (CertificateException | NoSuchAlgorithmException | IOException exception) {
+        } catch (IOException exception) {
             log.error(exception);
         }
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/SupportReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/SupportReferenceManifest.java
@@ -12,8 +12,6 @@ import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -81,7 +79,7 @@ public class SupportReferenceManifest extends ReferenceManifest {
             TCGEventLog logProcessor = new TCGEventLog(this.getRimBytes());
             this.pcrHash = Arrays.hashCode(logProcessor.getExpectedPCRValues());
             return logProcessor.getExpectedPCRValues();
-        } catch (CertificateException | NoSuchAlgorithmException | IOException exception) {
+        } catch (IOException exception) {
             log.error(exception);
         }
 
@@ -98,7 +96,7 @@ public class SupportReferenceManifest extends ReferenceManifest {
         try {
             logProcessor = new TCGEventLog(this.getRimBytes());
             return logProcessor.getEventList();
-        } catch (CertificateException | NoSuchAlgorithmException | IOException exception) {
+        } catch (IOException exception) {
             log.error(exception);
         }
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/DeviceInfoProcessorService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/DeviceInfoProcessorService.java
@@ -37,7 +37,6 @@ import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -643,7 +642,7 @@ public class DeviceInfoProcessorService {
                         }
                     }
                 }
-            } catch (CertificateException | NoSuchAlgorithmException | IOException ex) {
+            } catch (IOException ex) {
                 log.error(ex);
             }
         }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestPageService.java
@@ -32,8 +32,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -632,7 +630,7 @@ public class ReferenceManifestPageService {
 
                             referenceDigestValueRepository.save(newRdv);
                         }
-                    } catch (CertificateException | NoSuchAlgorithmException | IOException e) {
+                    } catch (IOException e) {
                         e.printStackTrace();
                     }
                 } else {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
@@ -269,10 +269,6 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
         try {
             logProcessor = new TCGEventLog(supportReferenceManifest.getRimBytes());
             baseline = logProcessor.getExpectedPCRValues();
-//        } catch (CertificateException cEx) {
-//            log.error(cEx);
-//        } catch (NoSuchAlgorithmException noSaEx) {
-//            log.error(noSaEx);
         } catch (IOException ioEx) {
             log.error(ioEx);
         }
@@ -317,10 +313,6 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
                         tpmPcrEvents.addAll(pcrValidator.validateTpmEvents(
                                 tcgMeasurementLog, eventValueMap, policySettings));
                     }
-//                } catch (NoSuchAlgorithmException e) {
-//                    log.error(e);
-//                } catch (CertificateException cEx) {
-//                    log.error(cEx);
                 } catch (IOException e) {
                     log.error(e);
                 }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
@@ -21,8 +21,6 @@ import lombok.extern.log4j.Log4j2;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -271,10 +269,10 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
         try {
             logProcessor = new TCGEventLog(supportReferenceManifest.getRimBytes());
             baseline = logProcessor.getExpectedPCRValues();
-        } catch (CertificateException cEx) {
-            log.error(cEx);
-        } catch (NoSuchAlgorithmException noSaEx) {
-            log.error(noSaEx);
+//        } catch (CertificateException cEx) {
+//            log.error(cEx);
+//        } catch (NoSuchAlgorithmException noSaEx) {
+//            log.error(noSaEx);
         } catch (IOException ioEx) {
             log.error(ioEx);
         }
@@ -319,10 +317,10 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
                         tpmPcrEvents.addAll(pcrValidator.validateTpmEvents(
                                 tcgMeasurementLog, eventValueMap, policySettings));
                     }
-                } catch (NoSuchAlgorithmException e) {
-                    log.error(e);
-                } catch (CertificateException cEx) {
-                    log.error(cEx);
+//                } catch (NoSuchAlgorithmException e) {
+//                    log.error(e);
+//                } catch (CertificateException cEx) {
+//                    log.error(cEx);
                 } catch (IOException e) {
                     log.error(e);
                 }

--- a/HIRS_Utils/src/main/java/hirs/utils/crypto/AlgorithmsIds.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/crypto/AlgorithmsIds.java
@@ -1,5 +1,6 @@
 package hirs.utils.crypto;
 
+import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.util.NoSuchElementException;
 
@@ -226,11 +227,10 @@ public final class AlgorithmsIds {
      * @param spec int id of specification for original algorithm
      * @param alg string id of algorithm
      * @return row in array if alg found, -1 if not found
-     * @throws NoSuchAlgorithmException if the original algorithm type is
-     * invalid
+     * @throws IllegalArgumentException if any of the parameters are invalid
      */
     public static int findAlgId(final String algType, final int spec, final String alg)
-            throws NoSuchAlgorithmException {
+            throws IllegalArgumentException {
 
         int index = -1;
 
@@ -248,7 +248,7 @@ public final class AlgorithmsIds {
             }
         } else if (algType.compareTo(ALG_TYPE_SIG) == 0) {
             if (spec == SPEC_COSWID_ALG) {
-                throw new NoSuchElementException("There is no COSWID signing algorithm");
+                throw new IllegalArgumentException("There is no COSWID signing algorithm");
             }
             for (int i = 0; i < SIG_ALGORITHMS.length; i++) {
                 if (alg.compareTo(SIG_ALGORITHMS[i][spec]) == 0) {
@@ -256,10 +256,10 @@ public final class AlgorithmsIds {
                 }
             }
         } else {
-            throw new NoSuchAlgorithmException("Invalid algorithm type " + algType);
+            throw new IllegalArgumentException("Invalid algorithm type " + algType);
         }
         if (index == -1) {
-            throw new NoSuchElementException("Algorithm " + algType + " is not defined in "
+            throw new IllegalArgumentException("Algorithm " + algType + " is not defined in "
                     + ALG_TABLES_SPEC_COLUMNS[0][spec] + " spec");
         }
         return index;

--- a/HIRS_Utils/src/main/java/hirs/utils/crypto/AlgorithmsIds.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/crypto/AlgorithmsIds.java
@@ -1,6 +1,5 @@
 package hirs.utils.crypto;
 
-import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.util.NoSuchElementException;
 
@@ -177,10 +176,14 @@ public final class AlgorithmsIds {
      */
     public static String translateAlgId(final String algType, final int originalSpec,
                                         final String originalAlg, final int newSpec)
-            throws NoSuchAlgorithmException {
+            throws IllegalArgumentException, NoSuchElementException {
 
         String newAlgId = "";
 
+        if ((originalSpec != SPEC_TCG_ALG) && (originalSpec != SPEC_XML_ALG) && (originalSpec != SPEC_COSWID_ALG)
+                && (originalSpec != SPEC_COSE_ALG) && (originalSpec != SPEC_X509_ALG)) {
+            throw new IllegalArgumentException("Invalid original spec");
+        }
         if ((newSpec != SPEC_TCG_ALG) && (newSpec != SPEC_XML_ALG) && (newSpec != SPEC_COSWID_ALG)
                 && (newSpec != SPEC_COSE_ALG) && (newSpec != SPEC_X509_ALG)) {
             throw new IllegalArgumentException("Invalid new spec");
@@ -248,7 +251,7 @@ public final class AlgorithmsIds {
             }
         } else if (algType.compareTo(ALG_TYPE_SIG) == 0) {
             if (spec == SPEC_COSWID_ALG) {
-                throw new IllegalArgumentException("There is no COSWID signing algorithm");
+                throw new NoSuchElementException("There is no COSWID signing algorithm");
             }
             for (int i = 0; i < SIG_ALGORITHMS.length; i++) {
                 if (alg.compareTo(SIG_ALGORITHMS[i][spec]) == 0) {
@@ -256,10 +259,10 @@ public final class AlgorithmsIds {
                 }
             }
         } else {
-            throw new IllegalArgumentException("Invalid algorithm type " + algType);
+            throw new NoSuchElementException("Invalid algorithm type " + algType);
         }
         if (index == -1) {
-            throw new IllegalArgumentException("Algorithm " + algType + " is not defined in "
+            throw new NoSuchElementException("Algorithm " + algType + " is not defined in "
                     + ALG_TABLES_SPEC_COLUMNS[0][spec] + " spec");
         }
         return index;

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
@@ -322,7 +322,7 @@ public final class TCGEventLog {
             strongestEvLogHashAlgName = currentStrongestAlg;
 
             //TEMPORARILY use SHA256 until updates on Provisioner are pushed
-            strongestEvLogHashAlgName = "TPM_ALG_SHA256";
+//            strongestEvLogHashAlgName = "TPM_ALG_SHA256";
 
             // if more than one set of PCR banks exists in this log, store the one with strongest algorithm
             switch (strongestEvLogHashAlgName) {

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
@@ -193,12 +193,10 @@ public final class TCGEventLog {
      * Simple constructor for Event Log.
      *
      * @param rawlog data for the event log file.
-     * @throws java.security.NoSuchAlgorithmException  if an unknown algorithm is encountered.
-     * @throws java.security.cert.CertificateException if a certificate in the log cannot be parsed.
      * @throws java.io.IOException                     IO Stream if event cannot be parsed.
      */
     public TCGEventLog(final byte[] rawlog)
-            throws CertificateException, NoSuchAlgorithmException, IOException {
+            throws IOException {
         this(rawlog, false, false, false);
     }
 
@@ -209,13 +207,11 @@ public final class TCGEventLog {
      * @param bEventFlag    if true provides human-readable event descriptions.
      * @param bContentFlag  if true provides hex output for Content in the description.
      * @param bHexEventFlag if true provides hex event structure in the description.
-     * @throws java.security.NoSuchAlgorithmException  if an unknown algorithm is encountered.
-     * @throws java.security.cert.CertificateException if a certificate in the log cannot be parsed.
      * @throws java.io.IOException                     IO Stream if event cannot be parsed.
      */
     public TCGEventLog(final byte[] rawlog, final boolean bEventFlag,
                        final boolean bContentFlag, final boolean bHexEventFlag)
-            throws CertificateException, NoSuchAlgorithmException, IOException {
+            throws IOException {
 
         bContent = bContentFlag;
         bEvent = bEventFlag;
@@ -280,14 +276,14 @@ public final class TCGEventLog {
             String error = "IO error parsing event log at Event #" + (eventNumber);
             log.error(error + ": " + i);
             throw new IOException(error);
-        } catch (CertificateException c) {
-            String error = "Certificate error parsing event log at Event#" + (eventNumber);
-            log.error(error + ": " + c);
-            throw new CertificateException(error);
-        } catch (NoSuchAlgorithmException a) {
-            String error = "Algorithm error parsing event log at Event #" + (eventNumber);
-            log.error(error + ": " + a);
-            throw new NoSuchAlgorithmException(error);
+//        } catch (CertificateException c) {
+//            String error = "Certificate error parsing event log at Event#" + (eventNumber);
+//            log.error(error + ": " + c);
+//            throw new CertificateException(error);
+//        } catch (NoSuchAlgorithmException a) {
+//            String error = "Algorithm error parsing event log at Event #" + (eventNumber);
+//            log.error(error + ": " + a);
+//            throw new NoSuchAlgorithmException(error);
         } catch (RuntimeException r) {
             String error = "Error parsing event log at Event #" + (eventNumber);
             log.error(error + ": " + r);
@@ -301,12 +297,11 @@ public final class TCGEventLog {
      * If first event is EV_NO_ACTION Spec Id, then the log is crypto agile.
      * Need info from this event about algorithms.
      *
-     * @param firstEvent                                the first event in the log
-     * @throws java.security.NoSuchAlgorithmException   if an unknown algorithm is encountered.
-     * @throws java.io.UnsupportedEncodingException     if EvNoAction input fails to parse.
+     * @param firstEvent               the first event in the log.
+     * @throws java.io.IOException     if first event cannot initialize values.
      */
     private void useFirstEventToInitValues(final TpmPcrEvent1 firstEvent)
-            throws NoSuchAlgorithmException, UnsupportedEncodingException {
+            throws IOException {
 
         // if first event is EV_NO_ACTION Spec Id Event, the log is crypto agile
         if (firstEvent.isNoActionSpecIdEvent()) {
@@ -317,13 +312,17 @@ public final class TCGEventLog {
 
             // find the strongest algorithm used and select that for processing
             String currentStrongestAlg = algList.get(0);
-            int currentStrongestAlgRow = findAlgId(ALG_TYPE_HASH, SPEC_TCG_ALG, currentStrongestAlg);
-            for (int i = 1; i < algList.size(); i++) {
-                String newAlg = algList.get(i);
-                int newAlgRow = findAlgId(ALG_TYPE_HASH, SPEC_TCG_ALG, newAlg);
-                if (newAlgRow > currentStrongestAlgRow) {
-                    currentStrongestAlg = newAlg;
+            try {
+                int currentStrongestAlgRow = findAlgId(ALG_TYPE_HASH, SPEC_TCG_ALG, currentStrongestAlg);
+                for (int i = 1; i < algList.size(); i++) {
+                    String newAlg = algList.get(i);
+                    int newAlgRow = findAlgId(ALG_TYPE_HASH, SPEC_TCG_ALG, newAlg);
+                    if (newAlgRow > currentStrongestAlgRow) {
+                        currentStrongestAlg = newAlg;
+                    }
                 }
+            } catch (IllegalArgumentException i) {
+                throw new IOException("Could not determine info about algorithm from first event", i);
             }
             strongestEvLogHashAlgName = currentStrongestAlg;
 
@@ -387,7 +386,7 @@ public final class TCGEventLog {
      * Calculates the Expected Values for TPM PCRs based upon Event digests in the Event Log.
      * Uses the algorithm and eventList passed into the constructor.
      */
-    private void calculatePcrValues() throws UnsupportedEncodingException {
+    private void calculatePcrValues() {
         byte[] extendedPCR;
         initPcrList();
         for (TpmPcrEvent currentEvent : eventList.values()) {

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TCGEventLog.java
@@ -16,10 +16,8 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
@@ -142,7 +140,7 @@ public final class TCGEventLog {
     /**
      * Content Output Flag use.
      */
-    private boolean bContent = false;
+    private boolean bHexContent = false;
     /**
      * Event Output Flag use.
      */
@@ -152,7 +150,7 @@ public final class TCGEventLog {
      */
     private boolean bEvent = false;
     /**
-     * Event Output Flag use.
+     * Flag to indicate whether event is crypto agile.
      */
     @Getter
     private boolean bCryptoAgile = false;
@@ -203,41 +201,46 @@ public final class TCGEventLog {
     /**
      * Default constructor for just the rawlog that'll set up SHA1 Log.
      *
-     * @param rawlog        data for the event log file.
-     * @param bEventFlag    if true provides human-readable event descriptions.
-     * @param bContentFlag  if true provides hex output for Content in the description.
-     * @param bHexEventFlag if true provides hex event structure in the description.
+     * @param rawlog            data for the event log file.
+     * @param bEventFlag        if true provides human-readable event descriptions.
+     * @param bHexContentFlag   if true provides hex output for Content in the description.
+     * @param bHexEventFlag     if true provides hex event structure in the description.
      * @throws java.io.IOException                     IO Stream if event cannot be parsed.
      */
     public TCGEventLog(final byte[] rawlog, final boolean bEventFlag,
-                       final boolean bContentFlag, final boolean bHexEventFlag)
+                       final boolean bHexContentFlag, final boolean bHexEventFlag)
             throws IOException {
 
-        bContent = bContentFlag;
         bEvent = bEventFlag;
+        bHexContent = bHexContentFlag;
         bHexEvent = bHexEventFlag;
 
         int eventNumber = 0;
         ByteArrayInputStream is = new ByteArrayInputStream(rawlog);
+        long logFileBytesRemaining = rawlog.length;
 
         try {
             // Process the 1st entry as a SHA1 format (per the spec) and put into the event list
-            TpmPcrEvent1 firstEvent = new TpmPcrEvent1(is, eventNumber);
+            TpmPcrEvent1 firstEvent = new TpmPcrEvent1(is, logFileBytesRemaining, eventNumber);
             eventList.put(eventNumber++, firstEvent);
+            logFileBytesRemaining -= (firstEvent.getEventHeader().length + firstEvent.getEventContent().length);
             useFirstEventToInitValues(firstEvent);
 
             // put the remaining events into the event list
             while (is.available() > 0) {
                 if (bCryptoAgile) {
-                    TpmPcrEvent2 event2 = new TpmPcrEvent2(is, eventNumber, strongestEvLogHashAlgName);
+                    TpmPcrEvent2 event2 =
+                            new TpmPcrEvent2(is, logFileBytesRemaining, eventNumber, strongestEvLogHashAlgName);
                     eventList.put(eventNumber++, event2);
+                    logFileBytesRemaining -= (event2.getEventHeader().length + event2.getEventContent().length);
                     if (event2.isStartupLocalityEvent()) {
                         EvNoAction event = new EvNoAction(event2.getEventContent());
                         startupLocality = event.getStartupLocality();
                     }
                 } else {
-                    TpmPcrEvent1 event1 = new TpmPcrEvent1(is, eventNumber);
+                    TpmPcrEvent1 event1 = new TpmPcrEvent1(is, logFileBytesRemaining, eventNumber);
                     eventList.put(eventNumber++, event1);
+                    logFileBytesRemaining -= (event1.getEventHeader().length + event1.getEventContent().length);
                 }
 
                 // first check if any previous event has not been able to access vendor-table.json,
@@ -276,14 +279,6 @@ public final class TCGEventLog {
             String error = "IO error parsing event log at Event #" + (eventNumber);
             log.error(error + ": " + i);
             throw new IOException(error);
-//        } catch (CertificateException c) {
-//            String error = "Certificate error parsing event log at Event#" + (eventNumber);
-//            log.error(error + ": " + c);
-//            throw new CertificateException(error);
-//        } catch (NoSuchAlgorithmException a) {
-//            String error = "Algorithm error parsing event log at Event #" + (eventNumber);
-//            log.error(error + ": " + a);
-//            throw new NoSuchAlgorithmException(error);
         } catch (RuntimeException r) {
             String error = "Error parsing event log at Event #" + (eventNumber);
             log.error(error + ": " + r);
@@ -483,7 +478,7 @@ public final class TCGEventLog {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         for (TpmPcrEvent event : eventList.values()) {
-            sb.append(event.toString(bEvent, bHexEvent, bContent));
+            sb.append(event.toString(bEvent, bHexEvent, bHexContent));
         }
         sb.append("Event Log processing completed.\n");
         return sb.toString();
@@ -502,7 +497,7 @@ public final class TCGEventLog {
                            final boolean content) {
         this.bEvent = event;
         this.bHexEvent = hexEvent;
-        this.bContent = content;
+        this.bHexContent = content;
 
         return this.toString();
     }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
@@ -120,11 +120,6 @@ public class TpmPcrEvent {
     @Setter
     private boolean error = false;
 
-    /**
-     * An error was found in parsing of Event Content. This should not stop processing.
-     */
-    boolean hasEventContentError = false;
-
 //    /**
 //     * Track status of vendor-table.json file.
 //     * See TCGEventLog for more detail.

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
@@ -91,14 +91,14 @@ public class TpmPcrEvent {
      * Event digest. If more than one digest in the Event, use the strongest one.
      */
     private byte[] strongestDigest = null;
-    /**
-     * Event hash for SHA1 event logs.
-     */
-    private byte[] eventDataSha1hash;
-    /**
-     * Event hash for Crypto Agile events.
-     */
-    private byte[] eventDataSha256hash;
+//    /**
+//     * Event hash for SHA1 event logs.
+//     */
+//    private byte[] eventDataSha1hash;
+//    /**
+//     * Event hash for Crypto Agile events.
+//     */
+//    private byte[] eventDataSha256hash;
     /**
      * Event data (no content).
      */
@@ -135,6 +135,11 @@ public class TpmPcrEvent {
     @Setter
     private boolean error = false;
 
+    /**
+     * An error was found in parsing of Event Content. This should not stop processing.
+     */
+    boolean hasEventContentError = false;
+
 //    /**
 //     * Track status of vendor-table.json file.
 //     * See TCGEventLog for more detail.
@@ -153,9 +158,8 @@ public class TpmPcrEvent {
      * Constructor.
      *
      * @param baIs ByteArrayInputStream holding the event
-     * @throws java.io.IOException when event can't be parsed
      */
-    public TpmPcrEvent(final ByteArrayInputStream baIs) throws IOException {
+    public TpmPcrEvent(final ByteArrayInputStream baIs) {
 
     }
 
@@ -281,8 +285,13 @@ public class TpmPcrEvent {
      *
      * @param eventIndex TCG Event PCR Index as defined in the PFP
      */
-    protected void setPcrIndex(final byte[] eventIndex) {
+    protected boolean setPcrIndex(final byte[] eventIndex) {
+        int pcrIndexIn = HexUtils.leReverseInt(eventIndex);
+        if((pcrIndexIn < 0) || (pcrIndexIn > 23)) {
+            return false;
+        }
         pcrIndex = HexUtils.leReverseInt(eventIndex);
+        return true;
     }
 
     /**
@@ -428,7 +437,7 @@ public class TpmPcrEvent {
             case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
                 try {
                     sb.append(new UefiVariable((int) eventType, eventContent));
-                } catch (NoSuchAlgorithmException | IOException exception) {
+                } catch ( IOException exception) {
                     log.error(exception);
                     sb.append(exception);
                 }
@@ -474,17 +483,16 @@ public class TpmPcrEvent {
     /**
      * Parses the event content and creates a human-readable description of each event.
      *
-     * @param eventData     the byte array holding the event data.
      * @param content       the byte array holding the event content.
      * @param eventPosition event position within the event log.
      * @return String description of the event.
-     * @throws CertificateException     if the event contains an event that cannot be processed.
      * @throws NoSuchAlgorithmException if an event contains an unsupported algorithm.
      * @throws java.io.IOException      if the event cannot be parsed.
      */
-    public String processEvent(final byte[] eventData, final byte[] content,
-                               final int eventPosition)
-            throws CertificateException, NoSuchAlgorithmException, IOException {
+    public String processEvent(final byte[] content, final int eventPosition)
+//    public String processEvent(final byte[] eventData, final byte[] content,
+//                               final int eventPosition)
+            throws  IOException {
         int eventID = (int) eventType;
         this.eventNumber = eventPosition;
         description += "Event# " + eventPosition + ": ";
@@ -496,12 +504,12 @@ public class TpmPcrEvent {
         }
         // Calculate both the SHA1 and SHA256 on the event since this will equal the digest
         // field of about half the log messages.
-        MessageDigest md1 = MessageDigest.getInstance("SHA-1");
-        md1.update(eventData);
-        eventDataSha1hash = md1.digest();
-        MessageDigest md2 = MessageDigest.getInstance("SHA-256");
-        md2.update(eventData);
-        eventDataSha256hash = md2.digest();
+//        MessageDigest md1 = MessageDigest.getInstance("SHA-1");
+//        md1.update(eventData);
+//        eventDataSha1hash = md1.digest();
+//        MessageDigest md2 = MessageDigest.getInstance("SHA-256");
+//        md2.update(eventData);
+//        eventDataSha256hash = md2.digest();
 
         switch (eventID) {
             case EvConstants.EV_PREBOOT_CERT:
@@ -602,31 +610,31 @@ public class TpmPcrEvent {
         return description;
     }
 
-    /**
-     * Human-readable output of a check of input against the current event hash.
-     *
-     * @return human-readable string.
-     */
-    private String eventHashCheck() {
-        String result = "";
-        if (logFormat == 1) {
-            if (Arrays.equals(strongestDigest, eventDataSha1hash)) {
-                result
-                        += "Event digest matched hash of the event data " + "\n";
-            } else {
-                result += "Event digest DID NOT match the hash of the event data :"
-                        + Hex.encodeHexString(getEventStrongestDigest()) + "\n";
-            }
-        } else {
-            if (Arrays.equals(strongestDigest, eventDataSha256hash)) {
-                result += "Event digest matched hash of the event data " + "\n";
-            } else {
-                result += "Event digest DID NOT match the hash of the event data :"
-                        + Hex.encodeHexString(getEventStrongestDigest()) + "\n";
-            }
-        }
-        return result;
-    }
+//    /**
+//     * Human-readable output of a check of input against the current event hash.
+//     *
+//     * @return human-readable string.
+//     */
+//    private String eventHashCheck() {
+//        String result = "";
+//        if (logFormat == 1) {
+//            if (Arrays.equals(strongestDigest, eventDataSha1hash)) {
+//                result
+//                        += "Event digest matched hash of the event data " + "\n";
+//            } else {
+//                result += "Event digest DID NOT match the hash of the event data :"
+//                        + Hex.encodeHexString(getEventStrongestDigest()) + "\n";
+//            }
+//        } else {
+//            if (Arrays.equals(strongestDigest, eventDataSha256hash)) {
+//                result += "Event digest matched hash of the event data " + "\n";
+//            } else {
+//                result += "Event digest DID NOT match the hash of the event data :"
+//                        + Hex.encodeHexString(getEventStrongestDigest()) + "\n";
+//            }
+//        }
+//        return result;
+//    }
 
     /**
      * This method takes in an event and compares the hashes to verify that they match.

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
@@ -271,7 +271,7 @@ public class TpmPcrEvent {
         if ((pcrIndexIn < 0) || (pcrIndexIn > 23)) {
             return false;
         }
-        pcrIndex = HexUtils.leReverseInt(eventIndex);
+        pcrIndex = pcrIndexIn;
         return true;
     }
 
@@ -333,11 +333,11 @@ public class TpmPcrEvent {
     /**
      * Sets the event content data (not the entire event structure) after processing.
      *
-     * @param eventData The PFP defined event content
+     * @param eventContentData The PFP defined event content
      */
-    protected void setEventContent(final byte[] eventData) {
-        eventContent = new byte[eventData.length];
-        System.arraycopy(eventData, 0, eventContent, 0, eventData.length);
+    protected void setEventContent(final byte[] eventContentData) {
+        eventContent = new byte[eventContentData.length];
+        System.arraycopy(eventContentData, 0, eventContent, 0, eventContentData.length);
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
@@ -60,10 +60,6 @@ public class TpmPcrEvent {
      */
     protected final ArrayList<EventDigest> hashListFromEvent = new ArrayList<>();
     /**
-     * list of digests by calculating the hash of the event.
-     */
-    private final ArrayList<EventDigest> hashListCalculated = new ArrayList<>();
-    /**
      * Description for toString support.
      */
     protected String description = "";
@@ -88,14 +84,6 @@ public class TpmPcrEvent {
      * Event digest. If more than one digest in the Event, use the strongest one.
      */
     private byte[] strongestDigest = null;
-//    /**
-//     * Event hash for SHA1 event logs.
-//     */
-//    private byte[] eventDataSha1hash;
-//    /**
-//     * Event hash for Crypto Agile events.
-//     */
-//    private byte[] eventDataSha256hash;
     /**
      * Event header data (no content).
      */
@@ -354,7 +342,6 @@ public class TpmPcrEvent {
      */
     protected void setEventContent(final byte[] eventData) {
         eventContent = new byte[eventData.length];
-        //EvPostCode evPostCode = new EvPostCode(eventContent);
         System.arraycopy(eventData, 0, eventContent, 0, eventData.length);
     }
 
@@ -482,12 +469,9 @@ public class TpmPcrEvent {
      *
      * @param content       the byte array holding the event content.
      * @param eventPosition event position within the event log.
-     * @return String description of the event.
      * @throws java.io.IOException      if the event cannot be parsed.
      */
-    public String processEvent(final byte[] content, final int eventPosition)
-//    public String processEvent(final byte[] eventData, final byte[] content,
-//                               final int eventPosition)
+    public void processEvent(final byte[] content, final int eventPosition)
             throws  IOException {
         int eventID = (int) eventType;
         this.eventNumber = eventPosition;
@@ -498,14 +482,6 @@ public class TpmPcrEvent {
         if (eventID != UefiConstants.SIZE_4) {
             description += "\n";
         }
-        // Calculate both the SHA1 and SHA256 on the event since this will equal the digest
-        // field of about half the log messages.
-//        MessageDigest md1 = MessageDigest.getInstance("SHA-1");
-//        md1.update(eventData);
-//        eventDataSha1hash = md1.digest();
-//        MessageDigest md2 = MessageDigest.getInstance("SHA-256");
-//        md2.update(eventData);
-//        eventDataSha256hash = md2.digest();
 
         switch (eventID) {
             case EvConstants.EV_PREBOOT_CERT:
@@ -603,34 +579,7 @@ public class TpmPcrEvent {
             default:
                 description += " Unknown Event found" + "\n";
         }
-        return description;
     }
-
-//    /**
-//     * Human-readable output of a check of input against the current event hash.
-//     *
-//     * @return human-readable string.
-//     */
-//    private String eventHashCheck() {
-//        String result = "";
-//        if (logFormat == 1) {
-//            if (Arrays.equals(strongestDigest, eventDataSha1hash)) {
-//                result
-//                        += "Event digest matched hash of the event data " + "\n";
-//            } else {
-//                result += "Event digest DID NOT match the hash of the event data :"
-//                        + Hex.encodeHexString(getEventStrongestDigest()) + "\n";
-//            }
-//        } else {
-//            if (Arrays.equals(strongestDigest, eventDataSha256hash)) {
-//                result += "Event digest matched hash of the event data " + "\n";
-//            } else {
-//                result += "Event digest DID NOT match the hash of the event data :"
-//                        + Hex.encodeHexString(getEventStrongestDigest()) + "\n";
-//            }
-//        }
-//        return result;
-//    }
 
     /**
      * This method takes in an event and compares the hashes to verify that they match.

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent.java
@@ -27,9 +27,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -100,9 +97,9 @@ public class TpmPcrEvent {
 //     */
 //    private byte[] eventDataSha256hash;
     /**
-     * Event data (no content).
+     * Event header data (no content).
      */
-    private byte[] event;
+    private byte[] eventHeader;
     /**
      * Event content data.
      */
@@ -170,7 +167,7 @@ public class TpmPcrEvent {
      * @param event the event id.
      * @return TCG defined String that represents the event id
      */
-    private static String eventString(final long event) {
+    protected static String eventString(final long event) {
 
         if (event == EvConstants.EV_PREBOOT_CERT) {
             return "EV_PREBOOT_CERT";
@@ -284,10 +281,11 @@ public class TpmPcrEvent {
      * Sets the event PCR index value from a TCG Event.
      *
      * @param eventIndex TCG Event PCR Index as defined in the PFP
+     * @return whether the PCR index was in proper range
      */
     protected boolean setPcrIndex(final byte[] eventIndex) {
         int pcrIndexIn = HexUtils.leReverseInt(eventIndex);
-        if((pcrIndexIn < 0) || (pcrIndexIn > 23)) {
+        if ((pcrIndexIn < 0) || (pcrIndexIn > 23)) {
             return false;
         }
         pcrIndex = HexUtils.leReverseInt(eventIndex);
@@ -322,27 +320,26 @@ public class TpmPcrEvent {
     }
 
     /**
-     * Sets the event data after processing.
+     * Sets the event header data (no event content) after processing.
      *
-     * @param eventData The PFP defined event content
+     * @param eventHeaderData The PFP defined event header data
      */
-    protected void setEventData(final byte[] eventData) {
-        event = new byte[eventData.length];
-        System.arraycopy(eventData, 0, event, 0, eventData.length);
+    protected void setEventHeader(final byte[] eventHeaderData) {
+        eventHeader = new byte[eventHeaderData.length];
+        System.arraycopy(eventHeaderData, 0, eventHeader, 0, eventHeaderData.length);
     }
 
     /**
-     * Gets the Event Data (no event content) for the event.
-     * event log format.
+     * Gets the event header data (no event content) for the event.
      *
      * @return byte array holding the event structure.
      */
-    public byte[] getEvent() {
-        return Arrays.copyOf(event, event.length);
+    public byte[] getEventHeader() {
+        return Arrays.copyOf(eventHeader, eventHeader.length);
     }
 
     /**
-     * Gets the event Content Data (not the entire event structure).
+     * Gets the event content data (not the entire event structure).
      *
      * @return byte array holding the events content field
      */
@@ -351,7 +348,7 @@ public class TpmPcrEvent {
     }
 
     /**
-     * Sets the event content after processing.
+     * Sets the event content data (not the entire event structure) after processing.
      *
      * @param eventData The PFP defined event content
      */
@@ -437,7 +434,7 @@ public class TpmPcrEvent {
             case EvConstants.EV_EFI_SPDM_DEVICE_AUTHORITY:
                 try {
                     sb.append(new UefiVariable((int) eventType, eventContent));
-                } catch ( IOException exception) {
+                } catch (IOException exception) {
                     log.error(exception);
                     sb.append(exception);
                 }
@@ -486,7 +483,6 @@ public class TpmPcrEvent {
      * @param content       the byte array holding the event content.
      * @param eventPosition event position within the event log.
      * @return String description of the event.
-     * @throws NoSuchAlgorithmException if an event contains an unsupported algorithm.
      * @throws java.io.IOException      if the event cannot be parsed.
      */
     public String processEvent(final byte[] content, final int eventPosition)
@@ -678,24 +674,30 @@ public class TpmPcrEvent {
      * Human-readable string representing the contents of the Event Log.
      *
      * @param bEvent    event Flag.
-     * @param bContent  content flag.
-     * @param bHexEvent hex event flag.
+     * @param bHexEventContent  content flag.
+     * @param bHexEventHeader hex event flag.
      * @return Description of the log.
      */
-    public String toString(final boolean bEvent, final boolean bContent, final boolean bHexEvent) {
+    public String toString(final boolean bEvent, final boolean bHexEventHeader, final boolean bHexEventContent) {
         StringBuilder sb = new StringBuilder();
+        // add event human-readable description
         if (bEvent) {
             sb.append(description);
         }
-        if (bHexEvent) {
-            if (bEvent || bContent) {
+        // add hex of event header
+        if (bHexEventHeader) {
+            if (bEvent) {
                 sb.append("\n");
             }
-            byte[] eventData = getEvent();
-            sb.append("Event (Hex no Content) (" + eventData.length + " bytes): "
-                    + Hex.encodeHexString(eventData));
+            byte[] eventHeader = getEventHeader();
+            sb.append("Event header (Hex) (" + eventHeader.length + " bytes): "
+                    + Hex.encodeHexString(eventHeader));
         }
-        if (bContent) {
+        // add hex of event content
+        if (bHexEventContent) {
+            if (bEvent || bHexEventHeader) {
+                sb.append("\n");
+            }
             byte[] evContent = getEventContent();
             sb.append("Event content (Hex) (" + evContent.length + " bytes): "
                     + Hex.encodeHexString(evContent));

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
@@ -39,7 +39,7 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
      * @throws java.security.cert.CertificateException If a certificate within an event can't be processed.
      */
     public TpmPcrEvent1(final ByteArrayInputStream is, final int eventNumber)
-            throws IOException, CertificateException, NoSuchAlgorithmException {
+            throws IOException {
         super(is);
 
         setLogFormat(1);

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
@@ -79,7 +79,7 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
             // track event header length
             int eventHeaderLength = rawIndex.length + rawType.length + eventDigest.length + rawEventSize.length;
 
-            // read event size (size of event data)
+            // read event size (size of event content)
             is.read(rawEventSize);
             eventSize = HexUtils.leReverseInt(rawEventSize);
             if ((eventSize < 0) || (eventSize > (logFileBytesRemaining - eventHeaderLength))) {

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
@@ -16,7 +16,7 @@ import java.security.cert.CertificateException;
  * TCG Platform Firmware Profile specification.
  * typedef struct {
  * UINT32                   PCRIndex;        //PCR Index value that either
- * .                                        //matches the PCRIndex of a
+ * .                                        //matches the PCR Index of a
  * .                                        //previous extend operation or
  * .                                        //indicates that this Event Log
  * .                                        //entry is not associated with
@@ -55,7 +55,9 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
         int eventSize = 0;
         if (is.available() > UefiConstants.SIZE_32) {
             is.read(rawIndex);
-            setPcrIndex(rawIndex);
+            if(!setPcrIndex(rawIndex)) {
+                throw new IOException("PCR Index out of range; possibly corrupt byte file.");
+            }
             is.read(rawType);
             setEventType(rawType);
             is.read(eventDigest);
@@ -66,6 +68,9 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
 
             is.read(rawEventSize);
             eventSize = HexUtils.leReverseInt(rawEventSize);
+            if(eventSize < 0) {
+                throw new IOException("Event size is a negative value; possibly corrupt byte file.");
+            }
             eventContent = new byte[eventSize];
             is.read(eventContent);
             setEventContent(eventContent);
@@ -85,7 +90,8 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
             setEventData(event1);
             //System.arraycopy(eventContent, 0, event, offset, eventContent.length);
 
-            this.processEvent(event1, eventContent, eventNumber);
+            this.processEvent(eventContent, eventNumber);
+//            this.processEvent(event1, eventContent, eventNumber);
             description +=  "\ndigest (SHA-1): " + Hex.encodeHexString(eventDigest);
         }
     }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
@@ -3,49 +3,52 @@ package hirs.utils.tpm.eventlog;
 import hirs.utils.HexUtils;
 import hirs.utils.tpm.eventlog.events.EvConstants;
 import hirs.utils.tpm.eventlog.uefi.UefiConstants;
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Hex;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 
 /**
  * Class to process a TCG_PCR_EVENT.
  * TCG_PCR_EVENT is used when the Event log uses the SHA1 Format as described in the
  * TCG Platform Firmware Profile specification.
  * typedef struct {
- * UINT32                   PCRIndex;        //PCR Index value that either
+ * UINT32                   pcrIndex;        //PCR Index value that either
  * .                                        //matches the PCR Index of a
  * .                                        //previous extend operation or
  * .                                        //indicates that this Event Log
  * .                                        //entry is not associated with
  * .                                        //an extend operation
- * UINT32                   EventType;       //See Log event types
- * BYTE                     digest[20];      //The SHA1 hash of the event data
- * UINT32                   EventSize;       //Size of the event data
- * UINT8                    Event[1];        //
- * } TCG_PCR_EVENT;                             //The event data structure to be added
+ * UINT32                   eventType;       //See Log event types
+ * BYTE                     digest[20];      //digest
+ * UINT32                   eventSize;       //Size of the event data
+ * UINT8                    event[1];        //The event content
+ * } TCG_PCR_EVENT;                          //The event data structure to be added
+ *
+ * In this code:
+ * .   Event header = pcrIndex + eventType + digest + eventSize
+ * .   Event content = event[1]
  */
+@Log4j2
 public class TpmPcrEvent1 extends TpmPcrEvent {
 
     /**
      * Constructor.
      *
-     * @param is          ByteArrayInputStream holding the TCG Log event.
-     * @param eventNumber event position within the event log.
-     * @throws java.io.IOException                     if an error occurs in parsing the event.
-     * @throws java.security.NoSuchAlgorithmException  if an undefined algorithm is encountered.
-     * @throws java.security.cert.CertificateException If a certificate within an event can't be processed.
+     * @param is                        ByteArrayInputStream holding the TCG Log event
+     * @param logFileBytesRemaining     number of bytes remaining in log file (for error checking)
+     * @param eventNumber               event position within the event log
+     * @throws java.io.IOException      if an error occurs in parsing the event
      */
-    public TpmPcrEvent1(final ByteArrayInputStream is, final int eventNumber)
+    public TpmPcrEvent1(final ByteArrayInputStream is, final long logFileBytesRemaining, final int eventNumber)
             throws IOException {
         super(is);
 
         setLogFormat(1);
 
         // Event data.
-        byte[] event1;
+        byte[] eventHeader;
         byte[] rawIndex = new byte[UefiConstants.SIZE_4];
         byte[] rawType = new byte[UefiConstants.SIZE_4];
         byte[] rawEventSize = new byte[UefiConstants.SIZE_4];
@@ -54,45 +57,66 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
 
         int eventSize = 0;
         if (is.available() > UefiConstants.SIZE_32) {
+
+            // read PCR index
             is.read(rawIndex);
-            if(!setPcrIndex(rawIndex)) {
+            if (!setPcrIndex(rawIndex)) {
                 throw new IOException("PCR Index out of range; possibly corrupt byte file.");
             }
+            String pcrIndexStr = "Index PCR[" + getPcrIndex() + "]";
+
+            // read event type
             is.read(rawType);
             setEventType(rawType);
+            String eventTypeStr = "Event Type: 0x" + Long.toHexString(getEventType()) + " "
+                    + eventString((int) getEventType());
+
+            // read event digest
             is.read(eventDigest);
-
             hashListFromEvent.add(new EventDigest("TPM_ALG_SHA1", eventDigest));
-
             setEventStrongestDigest(eventDigest);
 
+            // track event header length
+            int eventHeaderLength = rawIndex.length + rawType.length + eventDigest.length + rawEventSize.length;
+
+            // read event size (size of event data)
             is.read(rawEventSize);
             eventSize = HexUtils.leReverseInt(rawEventSize);
-            if(eventSize < 0) {
-                throw new IOException("Event size is a negative value; possibly corrupt byte file.");
+            if ((eventSize < 0) || (eventSize > (logFileBytesRemaining - eventHeaderLength))) {
+                throw new IOException("Event size is not valid; possibly corrupt byte file.");
             }
-            eventContent = new byte[eventSize];
-            is.read(eventContent);
-            setEventContent(eventContent);
-            // copy entire event into a byte array for processing
-            int eventLength = rawIndex.length + rawType.length + eventDigest.length
-                    + rawEventSize.length;
+
+            // copy entire event header into a byte array for processing
             int offset = 0;
-            event1 = new byte[eventLength];
-            System.arraycopy(rawIndex, 0, event1, offset, rawIndex.length);
+            eventHeader = new byte[eventHeaderLength];
+            System.arraycopy(rawIndex, 0, eventHeader, offset, rawIndex.length);
             offset += rawIndex.length;
-            System.arraycopy(rawType, 0, event1, offset, rawType.length);
+            System.arraycopy(rawType, 0, eventHeader, offset, rawType.length);
             offset += rawType.length;
-            System.arraycopy(eventDigest, 0, event1, offset, eventDigest.length);
+            System.arraycopy(eventDigest, 0, eventHeader, offset, eventDigest.length);
             offset += eventDigest.length;
-            System.arraycopy(rawEventSize, 0, event1, offset, rawEventSize.length);
-            offset += rawEventSize.length;
-            setEventData(event1);
+            System.arraycopy(rawEventSize, 0, eventHeader, offset, rawEventSize.length);
+            //offset += rawEventSize.length;
+            setEventHeader(eventHeader);
             //System.arraycopy(eventContent, 0, event, offset, eventContent.length);
 
-            this.processEvent(eventContent, eventNumber);
+            // if event content cannot be processed, this is not fatal; log error and continue with attestation
+            try {
+                // read event content
+                eventContent = new byte[eventSize];
+                is.read(eventContent);
+                setEventContent(eventContent);
+
+                this.processEvent(eventContent, eventNumber);
 //            this.processEvent(event1, eventContent, eventNumber);
-            description +=  "\ndigest (SHA-1): " + Hex.encodeHexString(eventDigest);
+            } catch (RuntimeException e) {
+                throw e;
+            } catch (Exception e) {
+                String error = "Error parsing event #" + eventNumber + ", " + eventTypeStr + ", " + pcrIndexStr;
+                log.error(error, e);
+            }
+
+            description += "\ndigest (SHA-1): " + Hex.encodeHexString(eventDigest);
         }
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent1.java
@@ -108,7 +108,6 @@ public class TpmPcrEvent1 extends TpmPcrEvent {
                 setEventContent(eventContent);
 
                 this.processEvent(eventContent, eventNumber);
-//            this.processEvent(event1, eventContent, eventNumber);
             } catch (RuntimeException e) {
                 throw e;
             } catch (Exception e) {

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
@@ -130,22 +130,22 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
                 }
             }
 
-            // track event length
-            int eventLength = rawIndex.length + rawType.length + rawEventSize.length;
+            // track event header length
+            int eventHeaderLength = rawIndex.length + rawType.length + rawEventSize.length;
             for (TcgTpmtHa hash : hashList) {
-                eventLength += hash.getBuffer().length;
+                eventHeaderLength += hash.getBuffer().length;
             }
 
-            // read event size (size of event data)
+            // read event size (size of event content)
             is.read(rawEventSize);
             eventSize = HexUtils.leReverseInt(rawEventSize);
-            if ((eventSize < 0) || (eventSize > (logFileBytesRemaining - eventLength))) {
+            if ((eventSize < 0) || (eventSize > (logFileBytesRemaining - eventHeaderLength))) {
                 throw new IOException("Event size is not valid; possibly corrupt byte file.");
             }
 
             // copy entire event header into a byte array for processing
             int offset = 0;
-            eventHeader = new byte[eventLength];
+            eventHeader = new byte[eventHeaderLength];
             System.arraycopy(rawIndex, 0, eventHeader, offset, rawIndex.length);
             offset += rawIndex.length;
             System.arraycopy(rawType, 0, eventHeader, offset, rawType.length);

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
@@ -17,7 +17,7 @@ import java.util.ArrayList;
  * This class will only process SHA-256 digests.
  * typedef struct {
  * .    UINT32                 PCRIndex;  //PCR Index value that either
- * .                                      //matches the PCRIndex of a
+ * .                                      //matches the PCR Index of a
  * .                                      //previous extend operation or
  * .                                      //indicates that this Event Log
  * .                                      //entry is not associated with
@@ -29,7 +29,7 @@ import java.util.ArrayList;
  * } TCG_PCR_EVENT2;                     //The event data structure to be added
  * typedef struct {
  * .    UINT32  count;
- * .    TPMT_HA digests[HASH_COUNT];
+ * .    TPMT_HA digests[count];
  * } TPML_DIGEST_VALUES;
  * typedef struct {
  * .    TPMI_ALG_HASH hashAlg;
@@ -92,15 +92,24 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
         //TCG_PCR_EVENT2
         if (is.available() > UefiConstants.SIZE_32) {
             is.read(rawIndex);
-            setPcrIndex(rawIndex);
+            if(!setPcrIndex(rawIndex)) {
+                throw new IOException("PCR Index out of range; possibly corrupt byte file.");
+            }
             is.read(rawType);
             setEventType(rawType);
             // TPML_DIGEST_VALUES (algCount should match 'numberOfAlgorithms' in Spec ID event)
             is.read(algCountBytes);
             algCount = HexUtils.leReverseInt(algCountBytes);
+            if(algCount < 0) {
+                throw new IOException("Number of digests is a negative value; possibly corrupt byte file.");
+            }
             // Process TPMT_HA,
             for (int i = 0; i < algCount; i++) {
-                hashAlg = new TcgTpmtHa(is);
+                try {
+                    hashAlg = new TcgTpmtHa(is);
+                } catch(IOException io) {
+                    throw new IOException("Issue reading hash algorithm and digests; possibly corrupt byte file.", io);
+                }
                 hashName = hashAlg.getHashName();
                 eventDigest = new byte[hashAlg.getHashLength()];
                 hashList.add(hashAlg);
@@ -111,6 +120,9 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
             }
             is.read(rawEventSize);
             eventSize = HexUtils.leReverseInt(rawEventSize);
+            if(eventSize < 0) {
+                throw new IOException("Event size is a negative value; possibly corrupt byte file.");
+            }
             eventContent = new byte[eventSize];
             is.read(eventContent);
             setEventContent(eventContent);
@@ -134,7 +146,8 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
             }
             setEventData(event2);
 
-            this.processEvent(event2, eventContent, eventNumber);
+            this.processEvent(eventContent, eventNumber);
+//            this.processEvent(event2, eventContent, eventNumber);
             for (int i = 0; i < algCount; i++) {
                 description +=  "\ndigest (" + hashList.get(i).getHashName() + "): "
                         + Hex.encodeHexString(hashList.get(i).getDigest());

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
@@ -166,7 +166,6 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
                 setEventContent(eventContent);
 
                 this.processEvent(eventContent, eventNumber);
-//            this.processEvent(event2, eventContent, eventNumber);
             } catch (RuntimeException r) {
                 throw r;
             } catch (Exception e) {

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
@@ -2,12 +2,11 @@ package hirs.utils.tpm.eventlog;
 
 import hirs.utils.HexUtils;
 import hirs.utils.tpm.eventlog.uefi.UefiConstants;
+import lombok.extern.log4j.Log4j2;
 import org.apache.commons.codec.binary.Hex;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.util.ArrayList;
 
 /**
@@ -16,17 +15,20 @@ import java.util.ArrayList;
  * TCG Platform Firmware Profile specification.
  * This class will only process SHA-256 digests.
  * typedef struct {
- * .    UINT32                 PCRIndex;  //PCR Index value that either
- * .                                      //matches the PCR Index of a
- * .                                      //previous extend operation or
- * .                                      //indicates that this Event Log
- * .                                      //entry is not associated with
- * .                                      //an extend operation
- * .    UINT32                EventType; //See Log event types
- * .    TPML_DIGEST_VALUES    digest;    //The hash of the event data
- * .    UINT32                EventSize; //Size of the event data
- * .    BYTE                  Event[1];  //The event data
- * } TCG_PCR_EVENT2;                     //The event data structure to be added
+ * .    UINT32                 pcrIndex;        //PCR Index value that either
+ * .                                            //matches the PCR Index of a
+ * .                                            //previous extend operation or
+ * .                                            //indicates that this Event Log
+ * .                                            //entry is not associated with
+ * .                                            //an extend operation
+ * .    UINT32                eventType;        //See Log event types
+ * .    TPML_DIGEST_VALUES    digest;           //Number & list of tagged digests
+ * .    UINT32                eventSize;        //Size of the event content
+ * .    BYTE                  event[EventSize]; //The event content
+ * } TCG_PCR_EVENT2;                            //The event data structure to be added
+ * In this code:
+ * .   Event header = pcrIndex + eventType + digests + eventSize
+ * .   Event content = event[EventSize]
  * typedef struct {
  * .    UINT32  count;
  * .    TPMT_HA digests[count];
@@ -52,6 +54,7 @@ import java.util.ArrayList;
  * define TPM_ALG_SHA384         (TPM_ALG_ID)(0x000C)
  * define TPM_ALG_SHA512         (TPM_ALG_ID)(0x000D)
  */
+@Log4j2
 public class TpmPcrEvent2 extends TpmPcrEvent {
     /**
      * algorithms found.
@@ -66,21 +69,21 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
     /**
      * Constructor.
      *
-     * @param is            ByteArrayInputStream holding the TCG Log event
-     * @param eventNumber   event position within the event log.
-     * @param strongestAlg  name of strongest hash algorithm used in the log
+     * @param is                        ByteArrayInputStream holding the TCG Log event
+     * @param logFileBytesRemaining     number of bytes remaining in log file (for error checking)
+     * @param eventNumber               event position within the event log
+     * @param strongestAlg              name of strongest hash algorithm used in the log
      * @throws java.io.IOException                     if an error occurs in parsing the event
-     * @throws java.security.NoSuchAlgorithmException  if an undefined algorithm is encountered.
-     * @throws java.security.cert.CertificateException If a certificate within an event can't be processed.
      */
-    public TpmPcrEvent2(final ByteArrayInputStream is, final int eventNumber, final String strongestAlg)
+    public TpmPcrEvent2(final ByteArrayInputStream is, final long logFileBytesRemaining,
+                        final int eventNumber, final String strongestAlg)
             throws IOException {
 
         super(is);
         setLogFormat(2);
         // Event data.
         String hashName = "";
-        byte[] event2;
+        byte[] eventHeader;
         byte[] rawIndex = new byte[UefiConstants.SIZE_4];
         byte[] algCountBytes = new byte[UefiConstants.SIZE_4];
         byte[] rawType = new byte[UefiConstants.SIZE_4];
@@ -91,23 +94,31 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
         int eventSize = 0;
         //TCG_PCR_EVENT2
         if (is.available() > UefiConstants.SIZE_32) {
+
+            // read PCR index
             is.read(rawIndex);
-            if(!setPcrIndex(rawIndex)) {
+            if (!setPcrIndex(rawIndex)) {
                 throw new IOException("PCR Index out of range; possibly corrupt byte file.");
             }
+            String pcrIndexStr = "Index PCR[" + getPcrIndex() + "]";
+
+            // read event type
             is.read(rawType);
             setEventType(rawType);
-            // TPML_DIGEST_VALUES (algCount should match 'numberOfAlgorithms' in Spec ID event)
+            String eventTypeStr = "Event Type: 0x" + Long.toHexString(getEventType()) + " "
+                    + eventString((int) getEventType());
+
+            // read TPML_DIGEST_VALUES (algCount should match 'numberOfAlgorithms' in Spec ID event)
             is.read(algCountBytes);
             algCount = HexUtils.leReverseInt(algCountBytes);
-            if(algCount < 0) {
+            if (algCount < 0) {
                 throw new IOException("Number of digests is a negative value; possibly corrupt byte file.");
             }
-            // Process TPMT_HA,
+            // Process TPMT_HA
             for (int i = 0; i < algCount; i++) {
                 try {
                     hashAlg = new TcgTpmtHa(is);
-                } catch(IOException io) {
+                } catch (IOException io) {
                     throw new IOException("Issue reading hash algorithm and digests; possibly corrupt byte file.", io);
                 }
                 hashName = hashAlg.getHashName();
@@ -118,42 +129,53 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
                     setEventStrongestDigest(hashAlg.getDigest());
                 }
             }
-            is.read(rawEventSize);
-            eventSize = HexUtils.leReverseInt(rawEventSize);
-            if(eventSize < 0) {
-                throw new IOException("Event size is a negative value; possibly corrupt byte file.");
-            }
 
-
-            // HERE - throw the rest of this into a try/catch and handle all errors
-
-            eventContent = new byte[eventSize];
-            is.read(eventContent);
-            setEventContent(eventContent);
-            int eventLength = rawIndex.length + rawType.length
-                    + rawEventSize.length;
-            int offset = 0;
+            // track event length
+            int eventLength = rawIndex.length + rawType.length + rawEventSize.length;
             for (TcgTpmtHa hash : hashList) {
                 eventLength += hash.getBuffer().length;
             }
-            event2 = new byte[eventLength];
-            System.arraycopy(rawIndex, 0, event2, offset, rawIndex.length);
-            offset += rawIndex.length;
-            System.arraycopy(rawType, 0, event2, offset, rawType.length);
-            offset += rawType.length;
-            System.arraycopy(rawEventSize, 0, event2, offset, rawEventSize.length);
-            offset += rawEventSize.length;
 
+            // read event size (size of event data)
+            is.read(rawEventSize);
+            eventSize = HexUtils.leReverseInt(rawEventSize);
+            if ((eventSize < 0) || (eventSize > (logFileBytesRemaining - eventLength))) {
+                throw new IOException("Event size is not valid; possibly corrupt byte file.");
+            }
+
+            // copy entire event header into a byte array for processing
+            int offset = 0;
+            eventHeader = new byte[eventLength];
+            System.arraycopy(rawIndex, 0, eventHeader, offset, rawIndex.length);
+            offset += rawIndex.length;
+            System.arraycopy(rawType, 0, eventHeader, offset, rawType.length);
+            offset += rawType.length;
+            System.arraycopy(rawEventSize, 0, eventHeader, offset, rawEventSize.length);
+            offset += rawEventSize.length;
             for (TcgTpmtHa hash : hashList) {
-                System.arraycopy(hash.getBuffer(), 0, event2, offset, hash.getBuffer().length);
+                System.arraycopy(hash.getBuffer(), 0, eventHeader, offset, hash.getBuffer().length);
                 offset += hash.getBuffer().length;
             }
-            setEventData(event2);
+            setEventHeader(eventHeader);
 
-            this.processEvent(eventContent, eventNumber);
+            // if event content cannot be processed, this is not fatal; log error and continue with attestation
+            try {
+                // read event content
+                eventContent = new byte[eventSize];
+                is.read(eventContent);
+                setEventContent(eventContent);
+
+                this.processEvent(eventContent, eventNumber);
 //            this.processEvent(event2, eventContent, eventNumber);
+            } catch (RuntimeException r) {
+                throw r;
+            } catch (Exception e) {
+                String error = "Error parsing event #" + eventNumber + ", " + eventTypeStr + ", " + pcrIndexStr;
+                log.error(error, e);
+            }
+
             for (int i = 0; i < algCount; i++) {
-                description +=  "\ndigest (" + hashList.get(i).getHashName() + "): "
+                description += "\ndigest (" + hashList.get(i).getHashName() + "): "
                         + Hex.encodeHexString(hashList.get(i).getDigest());
             }
         }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/TpmPcrEvent2.java
@@ -74,7 +74,7 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
      * @throws java.security.cert.CertificateException If a certificate within an event can't be processed.
      */
     public TpmPcrEvent2(final ByteArrayInputStream is, final int eventNumber, final String strongestAlg)
-            throws IOException, CertificateException, NoSuchAlgorithmException {
+            throws IOException {
 
         super(is);
         setLogFormat(2);
@@ -123,6 +123,10 @@ public class TpmPcrEvent2 extends TpmPcrEvent {
             if(eventSize < 0) {
                 throw new IOException("Event size is a negative value; possibly corrupt byte file.");
             }
+
+
+            // HERE - throw the rest of this into a try/catch and handle all errors
+
             eventContent = new byte[eventSize];
             is.read(eventContent);
             setEventContent(eventContent);

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/spdm/SpdmCertificateChain.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/spdm/SpdmCertificateChain.java
@@ -110,9 +110,6 @@ public class SpdmCertificateChain {
         ByteArrayInputStream certChainDataIS = new ByteArrayInputStream(certChainData);
         while (certChainDataIS.available() > 0) {
 
-            // java.io.IOException                     If there's a problem parsing the cert chain data.
-            // java.security.cert.CertificateException if there's a problem parsing the X509 certificate.
-            // java.security.NoSuchAlgorithmException  if there's a problem hashing the certificate.
             try {
                 byte[] certType = new byte[2];
                 certChainDataIS.read(certType);
@@ -128,21 +125,18 @@ public class SpdmCertificateChain {
                 System.arraycopy(certType, 0, certBlob, 0, 2);
                 System.arraycopy(certLength, 0, certBlob, 2, 2);
                 System.arraycopy(certData, 0, certBlob, certBlobStartIndex, cLength);
-                cert = new UefiX509Cert(certBlob);
+                try {
+                    cert = new UefiX509Cert(certBlob);
+                } catch (CertificateException | NoSuchAlgorithmException e) {
+                    certProcessingError += "Error with Cert # " + (numberOfCerts + 1) + "; e";
+                    break;
+                }
+
                 //cert = new X509Certificate(certBlob);
                 certList.add(cert);
                 numberOfCerts++;
             } catch (IOException e) {
-                certProcessingError += "Error with Cert # " + (numberOfCerts + 1)
-                        + ": IOException (error reading cert data)";
-                break;
-            } catch (CertificateException e) {
-                certProcessingError += "Error with Cert # " + (numberOfCerts + 1)
-                        + ": CertificateException";
-                break;
-            } catch (NoSuchAlgorithmException e) {
-                certProcessingError += "Error with Cert # " + (numberOfCerts + 1)
-                        + ": CNoSuchAlgorithmException";
+                certProcessingError += "Error with Cert # " + (numberOfCerts + 1) + "; e";
                 break;
             }
         }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureData.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureData.java
@@ -90,7 +90,7 @@ public class UefiSignatureData {
      * @throws java.security.NoSuchAlgorithmException  if there's a problem hashing the certificate.
      */
     UefiSignatureData(final ByteArrayInputStream inputStream, final UefiGuid sigType)
-            throws IOException, NoSuchAlgorithmException {
+            throws IOException {
         signatureType = sigType;
         // UEFI spec section 32.5.3.3 states that SignatureListType of EFI_CERT_SHA256_GUID
         // only contains a hash, not a cert
@@ -115,15 +115,18 @@ public class UefiSignatureData {
      * Default EFISignatureData Constructor.
      *
      * @param data byte array of the EFISignatureData to process
-     * @throws java.security.cert.CertificateException If there a problem parsing the X509 certificate.
-     * @throws java.security.NoSuchAlgorithmException  if there's a problem hashing the certificate.
      */
-    UefiSignatureData(final byte[] data) throws CertificateException, NoSuchAlgorithmException {
+    UefiSignatureData(final byte[] data) {
         System.arraycopy(data, 0, guid, 0, UefiConstants.SIZE_16);
         sigData = new byte[data.length - UefiConstants.SIZE_16];
         System.arraycopy(data, UefiConstants.OFFSET_16, sigData, 0,
                 data.length - UefiConstants.SIZE_16);
-        cert = new UefiX509Cert(sigData);
+        try {
+            cert = new UefiX509Cert(sigData);
+        } catch (CertificateException | NoSuchAlgorithmException e) {
+            errorStatus = "\n   **** UefiSignatureData Certificate Issue ****: " + e.getMessage();
+            log.warn("UefiSignatureData Certificate Issue: {}", e.getMessage());
+        }
         efiVarGuid = new UefiGuid(guid);
     }
 
@@ -136,7 +139,7 @@ public class UefiSignatureData {
      * @throws java.security.NoSuchAlgorithmException  if there's a problem creating a hash.
      */
     private void processC509Cert(final ByteArrayInputStream inputStream)
-            throws IOException, NoSuchAlgorithmException {
+            throws IOException {
 
         // Read in Type and Length separately so we calculate the rest of the cert size
         byte[] certType = new byte[UefiConstants.SIZE_2];
@@ -152,7 +155,7 @@ public class UefiSignatureData {
         System.arraycopy(certData, 0, certBlob, UefiConstants.OFFSET_4, certDataLength);
         try {
             cert = new UefiX509Cert(certBlob);
-        } catch (CertificateException e) {
+        } catch (CertificateException | NoSuchAlgorithmException e) {
             errorStatus = "\n   **** UefiSignatureData Certificate Issue ****: " + e.getMessage();
             log.warn("UefiSignatureData Certificate Issue: {}", e.getMessage());
         }

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
@@ -4,7 +4,6 @@ import hirs.utils.HexUtils;
 import lombok.Getter;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 
 /**
@@ -159,7 +158,6 @@ public class UefiSignatureList {
      *
      * @param lists ByteArrayInputStream containing an EFI Signature list.
      * @throws IOException              If there's a problem in reading he input stream.
-     * @throws NoSuchAlgorithmException if there's a problem hashing the certificate.
      */
     UefiSignatureList(final ByteArrayInputStream lists) throws IOException {
         byte[] guid = new byte[UefiConstants.SIZE_16];
@@ -195,7 +193,6 @@ public class UefiSignatureList {
      * Method for processing the data in an EFI SignatureList (ex. can be one or more X509 certs)
      *
      * @param efiSigData Byte array holding the SignatureList data
-     * @throws NoSuchAlgorithmException if there's a problem hashing the certificate.
      * @throws IOException              If there's a problem parsing the signature data.
      */
     private void processSignatureList(final byte[] efiSigData) throws IOException {

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiSignatureList.java
@@ -161,7 +161,7 @@ public class UefiSignatureList {
      * @throws IOException              If there's a problem in reading he input stream.
      * @throws NoSuchAlgorithmException if there's a problem hashing the certificate.
      */
-    UefiSignatureList(final ByteArrayInputStream lists) throws IOException, NoSuchAlgorithmException {
+    UefiSignatureList(final ByteArrayInputStream lists) throws IOException {
         byte[] guid = new byte[UefiConstants.SIZE_16];
         lists.read(guid);
         signatureType = new UefiGuid(guid);
@@ -198,7 +198,7 @@ public class UefiSignatureList {
      * @throws NoSuchAlgorithmException if there's a problem hashing the certificate.
      * @throws IOException              If there's a problem parsing the signature data.
      */
-    private void processSignatureList(final byte[] efiSigData) throws NoSuchAlgorithmException, IOException {
+    private void processSignatureList(final byte[] efiSigData) throws IOException {
         efiSigDataIS = new ByteArrayInputStream(efiSigData);
         while (efiSigDataIS.available() > 0) {
             UefiSignatureData tmpSigData = new UefiSignatureData(efiSigDataIS, signatureType);

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -109,13 +110,11 @@ public class UefiVariable {
      *
      * @param eventTypeIn the event type
      * @param variableData byte array holding the UEFI Variable.
-     * @throws java.security.NoSuchAlgorithmException if there's a problem
-     *                                                hashing the certificate.
      * @throws java.io.IOException                    If there's a problem
      *                                                parsing the signature data.
      */
     public UefiVariable(final int eventTypeIn, final byte[] variableData)
-            throws NoSuchAlgorithmException, IOException {
+            throws  IOException {
 
         eventType = eventTypeIn;
         certSuperList = new ArrayList<>();
@@ -208,15 +207,11 @@ public class UefiVariable {
      * Processes the data as a list of UEFI defined Signature Lists.
      *
      * @param data the bye array holding one or more Signature Lists.
-     * @throws java.security.cert.CertificateException If there's a problem
-     *                                                 parsing the X509 certificate.
-     * @throws java.security.NoSuchAlgorithmException  if there's a problem
-     *                                                 hashing the certificate.
      * @throws java.io.IOException                     If there's a problem
      *                                                 parsing the signature data.
      */
     private void processSigList(final byte[] data)
-            throws NoSuchAlgorithmException, IOException {
+            throws  IOException {
         ByteArrayInputStream certData = new ByteArrayInputStream(data);
         while (certData.available() > 0) {
             UefiSignatureList list;
@@ -250,12 +245,10 @@ public class UefiVariable {
      * Method for processing the data in an EFI Signature Data, where the data is known to be an X509 cert.
      *
      * @param efiSigData Byte array holding the SignatureData data
-     * @throws java.security.cert.CertificateException If there's a problem parsing the X509 certificate.
-     * @throws java.security.NoSuchAlgorithmException  if there's a problem hashing the certificate.
      * @throws java.io.IOException                     If there's a problem parsing the signature data.
      */
     private void processSigDataX509(final byte[] efiSigData)
-            throws NoSuchAlgorithmException, IOException {
+            throws IOException {
 
         ByteArrayInputStream efiSigDataIS = new ByteArrayInputStream(efiSigData);
         ArrayList<UefiSignatureData> sigList = new ArrayList<UefiSignatureData>();
@@ -377,7 +370,7 @@ public class UefiVariable {
         try {
             UefiX509Cert cert = new UefiX509Cert(certData);
             certInfo = cert.toString();
-        } catch (Exception e) {
+        } catch (CertificateException | NoSuchAlgorithmException e) {
             certInfo = "Error Processing Certificate : " + e.getMessage();
         }
         return (certInfo);

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiVariable.java
@@ -324,7 +324,7 @@ public class UefiVariable {
             }
         }
 
-        if(!uefiVariableDataProcessed) {
+        if (!uefiVariableDataProcessed) {
             efiVariable.append("      Code does not yet process this Uefi Variable\n");
         }
 

--- a/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiX509Cert.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/tpm/eventlog/uefi/UefiX509Cert.java
@@ -37,9 +37,12 @@ public class UefiX509Cert {
         } catch (CertificateException e) {
             throw new CertificateException("\n   Error parsing UEFI X509 certificate: " + e.getMessage());
         }
-
-        MessageDigest md = MessageDigest.getInstance("SHA1");
-        md.update(certData);
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA1");
+            md.update(certData);
+        } catch (NoSuchAlgorithmException e) {
+            throw new NoSuchAlgorithmException("\n   Error getting message digest of X509 Cert", e);
+        }
     }
 
     /**

--- a/HIRS_Utils/src/test/java/hirs/utils/crypto/AlgorithmsIdsTest.java
+++ b/HIRS_Utils/src/test/java/hirs/utils/crypto/AlgorithmsIdsTest.java
@@ -59,7 +59,7 @@ public class AlgorithmsIdsTest {
     @Test
     public final void testTranslateAlgIdInvalidAlgType() {
 
-        assertThrows(NoSuchAlgorithmException.class, () ->
+        assertThrows(NoSuchElementException.class, () ->
                 AlgorithmsIds.translateAlgId(INVALID_ALG_TYPE,
                         AlgorithmsIds.SPEC_TCG_ALG, HASH_ALG_TCG_SHA512, AlgorithmsIds.SPEC_XML_ALG)
         );

--- a/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
+++ b/tools/tcg_eventlog_tool/src/main/java/hirs/tcg_eventlog/Main.java
@@ -12,8 +12,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -168,7 +166,7 @@ final class Main {
                                 || commander.getPcrNumber() == -1) {
                             if (bHexFlag) {
                                 if (bHexFlag || bHexEvent) {
-                                    writeOut(HexUtils.byteArrayToHexString(event.getEvent())
+                                    writeOut(HexUtils.byteArrayToHexString(event.getEventHeader())
                                             + "\n");
                                 }
                                 if (bContentFlag) {
@@ -183,8 +181,12 @@ final class Main {
                     }
                 }
             }
-        } catch (IOException | CertificateException | NoSuchAlgorithmException | RuntimeException e) {
-            displayError(e);
+        } catch (IOException | RuntimeException e) {
+            displayException(e);
+            System.exit(1);
+        } catch (OutOfMemoryError e) {
+            String error = "FATAL: System ran out of memory. The event log file may be corrupt.";
+            displayError(error, e);
             System.exit(1);
         }
     }
@@ -284,7 +286,7 @@ final class Main {
                 for (TpmPcrEvent error : errors) {
                     if (bHexFlag) {
                         if (bEventFlag || bHexEvent) {
-                            sb.append(HexUtils.byteArrayToHexString(error.getEvent()) + "\n");
+                            sb.append(HexUtils.byteArrayToHexString(error.getEventHeader()) + "\n");
                         }
                         if (bContentFlag) {
                             sb.append(HexUtils.byteArrayToHexString(error.getEventContent())
@@ -295,8 +297,8 @@ final class Main {
                     }
                 }
             }
-        } catch (IOException | CertificateException | NoSuchAlgorithmException | RuntimeException e) {
-            displayError(e);
+        } catch (IOException | RuntimeException e) {
+            displayException(e);
             System.exit(1);
         }
         return sb.toString();
@@ -305,7 +307,7 @@ final class Main {
     /**
      * Compare this event log against a second event log.
      * Returns a String Array of event descriptions in which the digests from the first
-     * did no match the second. Return value is null if all events matched.
+     * did not match the second. Return value is null if all events matched.
      *
      * @param eventList  initial events.
      * @param eventList2 events to compare against.
@@ -368,12 +370,35 @@ final class Main {
      *
      * @param e Error message to be displayed.
      */
-    private static void displayError(final Exception e) {
+    private static void displayException(final Exception e) {
 
         System.out.print("Error processing Event Log " + commander.getInFileName()
                 + "\nError was " + e.toString());
 
-        String popupMessage = "A fatal error occurred and the application must close:\n" + e.getMessage();
+        String popupMessage = "A fatal error occurred and the application must close:\n" + e.getMessage()
+                + "\nPossibly corrupt byte file";
+
+        if (!GraphicsEnvironment.isHeadless()) {
+            // Modal dialog: forces user to interact with it
+            JOptionPane.showMessageDialog(null,
+                    popupMessage,
+                    "Fatal Error",
+                    JOptionPane.ERROR_MESSAGE);
+        }
+    }
+
+    /**
+     * Opens a window displaying an error message.
+     *
+     * @param errorStr Error message to be displayed.
+     * @param e Java error object.
+     */
+    private static void displayError(final String errorStr, final Error e) {
+
+        System.out.print("Error processing Event Log " + commander.getInFileName()
+                + "\nError was " + e.toString());
+
+        String popupMessage = errorStr + "\nThe application must close.";
 
         if (!GraphicsEnvironment.isHeadless()) {
             // Modal dialog: forces user to interact with it


### PR DESCRIPTION
Closes 1168.

Event logs that cannot be parsed produce exceptions that don't get properly handled.

This issue covers:

1. Divides the exceptions in TCGEventLog into "digest parsing errors" (-> validation cannot continue) and "event content parsing errors" (-> validation can continue). 
2. TCG Event Log will now only send up either an IO exception or a Runtime exception , either of which will require that validation stops. Any other exceptions will be caught and handled in the TCG Event Log or below.
- In event header fields: More robust error checking is done on the event header fields so that if the file is corrupt, this will be caught before an exception is thrown (such as a length field that is larger than the remaining bytes of the file). That error will be noted and thrown as an IO exception from the TCGEventLog to the caller, to stop attestation.
- In event content: This is now surrounded by a try/catch, and any error that occurs here (other than a runtime error) will be caught and logged but not sent from the TCGEventLog to the caller.
3. Additionally, clarify code, variable names, etc. when it comes to event header vs content.

This issue does not cover:
- A future issue will need to use the exception updates presented in this issue to base the decision to not upload/process event log file in ACA & display.

To test:
- Using the eventlog tool print function, test as many RIMs as possible, to include RIMs with errors. 
(Note for testing: This issue does not yet fix the ACA RIM upload error.)