### PR TITLE
Add Platform Serial to Issued Certificate details

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -710,6 +710,7 @@ public final class CertificateStringMapBuilder {
                     data.put("manufacturer", pc.getManufacturer());
                     data.put("model", pc.getModel());
                     data.put("version", pc.getVersion());
+                    data.put("platformSerial", pc.getPlatformSerial());
                     data.put("majorVersion",
                             Integer.toString(pc.getMajorVersion()));
                     data.put("minorVersion",


### PR DESCRIPTION
This PR is intended to add the serial number from Platform Certificates to respective ISsued Certificate details page, which was previously missing.

To test, spin up a local ACA using this branch, provision to generate an Issued Certificate that is chained to a Platform Certificate, and view Issued Certificate details to confirm that the "Serial Number" field has a valid value.