### PR TITLE
[#1183] Better logging for missing array in JSON config

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/utils/swid/HashSwid.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/HashSwid.java
@@ -28,7 +28,8 @@ public class HashSwid {
      * @return the SHA-256 hash of the file's contents, as a hexadecimal string.
      * @throws Exception if any issues arise while retrieving the SHA256 hash
      */
-    public static String get256Hash(final String filepath) throws Exception {
+    public static String get256Hash(final String filepath)
+            throws NoSuchAlgorithmException, IOException {
         return getHashValue(filepath, SHA256);
     }
 
@@ -44,7 +45,8 @@ public class HashSwid {
      * @return the hash of the file's contents, as a hexadecimal string
      * @throws Exception if any issues arise while retrieving the hash value
      */
-    private static String getHashValue(final String filepath, final String sha) throws Exception {
+    private static String getHashValue(final String filepath, final String sha)
+            throws NoSuchAlgorithmException, IOException {
         String resultString = null;
         try {
             MessageDigest md = MessageDigest.getInstance(sha);
@@ -55,15 +57,11 @@ public class HashSwid {
                 sb.append(Integer.toString((bytes[i] & 0xff) + 0x100, 16).substring(1));
             }
             resultString = sb.toString();
-        } catch (NoSuchAlgorithmException | IOException e) {
-            String errorMessage = "Error hashing file " + filepath + ": ";
-            if (e instanceof UnsupportedEncodingException
-                    || e instanceof NoSuchAlgorithmException) {
-                errorMessage += e.getMessage();
-            } else if (e instanceof IOException) {
-                errorMessage += "error reading file.";
-            }
-            throw new Exception(errorMessage);
+        } catch (NoSuchAlgorithmException e) {
+            throw new NoSuchAlgorithmException(
+                    String.format("Hashing algorithm {} not recognized.", sha));
+        } catch (IOException e) {
+            throw new IOException(String.format("Error hashing {}.", filepath));
         }
 
         return resultString;

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
@@ -220,12 +220,10 @@ public class SwidTagGateway {
             throw new RuntimeException("Error reading JSON attributes: " + e.getMessage());
         } catch (FileNotFoundException e) {
             throw new RuntimeException("File does not exist or cannot be read: " + e.getMessage());
-        } catch (Exception e) {
-            throw new RuntimeException("File does not exist or cannot be read: " + e.getMessage());
         }
     }
 
-    private Document assembleCompositePayload(final JsonObject configProperties) throws Exception {
+    private Document assembleCompositePayload(final JsonObject configProperties) {
         //Directory
         Directory directory = createDirectory(
                 configProperties.getJsonObject(SwidTagConstants.PAYLOAD)
@@ -234,11 +232,23 @@ public class SwidTagGateway {
         Document dirDoc = convertToDocument(jaxbDirectory);
 
         //File(s)
-        JsonArray files = configProperties.getJsonObject(SwidTagConstants.PAYLOAD)
-                .getJsonObject(SwidTagConstants.DIRECTORY).getJsonArray(SwidTagConstants.FILE);
+        JsonArray files;
+        try {
+            files = configProperties.getJsonObject(SwidTagConstants.PAYLOAD)
+                    .getJsonObject(SwidTagConstants.DIRECTORY).getJsonArray(SwidTagConstants.FILE);
+        } catch (ClassCastException e) {
+            throw new ClassCastException(
+                    String.format("Please verify in {} that File's value is an [array].",
+                            attributesFile));
+        }
         Iterator itr = files.iterator();
         while (itr.hasNext()) {
-            hirs.utils.xjc.File file = createFile((JsonObject) itr.next());
+            hirs.utils.xjc.File file;
+            try {
+                file = createFile((JsonObject) itr.next());
+            } catch (NoSuchAlgorithmException | IOException e) {
+                throw new JsonException(e.getMessage());
+            }
             JAXBElement<FilesystemItem> jaxbFile = objectFactory.createDirectoryFile(file);
             Document fileDoc = convertToDocument(jaxbFile);
             Node fileNode = dirDoc.importNode(fileDoc.getDocumentElement(), true);
@@ -495,7 +505,8 @@ public class SwidTagGateway {
      * @param jsonObject the Properties object containing parameters from file
      * @return File object created from the properties
      */
-    private hirs.utils.xjc.File createFile(final JsonObject jsonObject) throws Exception {
+    private hirs.utils.xjc.File createFile(final JsonObject jsonObject)
+        throws NoSuchAlgorithmException, IOException {
         hirs.utils.xjc.File file = objectFactory.createFile();
         file.setName(jsonObject.getString(SwidTagConstants.NAME, ""));
         file.setSize(new BigInteger(jsonObject.getString(SwidTagConstants.SIZE, "0")));


### PR DESCRIPTION
These changes clarify the error message that arises from a PCRIM JSON config file not having an array value for File:
`"File":  {...}` vs `"File":  [{...}]`

#### Testing ####
1. Navigate to `/opt/rimtool/data/pcrim`.
2. Confirm that `rim create -r pcrim -c rim_fields.json -l TpmLog.bin -k rimKey.pem -p RimSignCert.pem -o test.swidtag` creates a base RIM as expected.
3. Edit `rim_fields.json` and remove the square brackets `[...]` surrounding the value of File.
4. Confirm that `rim create -r pcrim -c rim_fields.json -l TpmLog.bin -k rimKey.pem -p RimSignCert.pem -o test.swidtag` now fails and prints a message identifying the problem.


Closes #1183 