### PR TITLE
[#1195] Add empty/null check for Link Href attribute in Base RIM

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -209,15 +209,18 @@ public class ReferenceManifestDetailsPageService {
         data.put("entityThumbprint", baseRim.getEntityThumbprint());
 
         // Link
-        data.put("linkHref", baseRim.getLinkHref());
+        String linkHref = baseRim.getLinkHref();
+        data.put("linkHref", linkHref);
         data.put("linkHrefLink", "");
 
-        List<BaseReferenceManifest> baseReferenceManifests =
-                this.referenceManifestRepository.findAllBaseRims();
-
-        for (BaseReferenceManifest bRim : baseReferenceManifests) {
-            if (baseRim.getLinkHref().contains(bRim.getTagId())) {
-                data.put("linkHrefLink", bRim.getId());
+        if (linkHref != null && !linkHref.isEmpty()) {
+            List<BaseReferenceManifest> baseReferenceManifests =
+                    this.referenceManifestRepository.findAllBaseRims();
+            for (BaseReferenceManifest bRim : baseReferenceManifests) {
+                if (bRim.getTagId() != null && linkHref.contains(bRim.getTagId())) {
+                    data.put("linkHrefLink", bRim.getId());
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Previously, Base RIMs without a Link attribute would cause a 500 error on ACA RIM details page. This PR allows Link field to be empty without the ACA stopping like that.

To test:
1. Upload a base rim to ACA that does not have Link attribute, and make sure you can still view details.
2. Upload a base rim to ACA that does have Link attribute, and make sure it displays properly.

Resolves #1195 