### PR TITLE
DN not matching comma

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/CredentialHelper.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/util/CredentialHelper.java
@@ -3,6 +3,8 @@ package hirs.attestationca.persist.util;
 import hirs.attestationca.persist.entity.userdefined.certificate.CertificateAuthorityCredential;
 import hirs.attestationca.persist.entity.userdefined.certificate.CertificateVariables;
 import lombok.extern.log4j.Log4j2;
+import org.bouncycastle.asn1.x500.RDN;
+import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.util.encoders.Base64;
 
 import java.io.IOException;
@@ -205,32 +207,48 @@ public final class CredentialHelper {
 
     /**
      * This method is to take the DNs from certificates and sort them in an order
-     * that will be used to lookup issuer certificates.  This will not be stored in
-     * the certificate, just the DB for lookup.
+     * that will be used to lookup issuer certificates.
      *
      * @param distinguishedName the original DN string.
      * @return a modified string of sorted DNs
      */
     public static String parseSortDNs(final String distinguishedName) {
         StringBuilder sb = new StringBuilder();
-        String dnsString;
 
         if (distinguishedName == null || distinguishedName.isEmpty()) {
             sb.append("BLANK");
         } else {
-            dnsString = distinguishedName.trim();
-            dnsString = dnsString.toLowerCase();
-            List<String> dnValArray = Arrays.asList(dnsString.split(","));
-            Collections.sort(dnValArray);
-            ListIterator<String> dnListIter = dnValArray.listIterator();
-            while (dnListIter.hasNext()) {
-                sb.append(dnListIter.next());
-                if (dnListIter.hasNext()) {
-                    sb.append(",");
-                }
-            }
+            sb.append(sortParsedDistinguishedName(distinguishedName));
         }
 
+        return sb.toString();
+    }
+
+    private static String sortParsedDistinguishedName(final String distinguishedName) {
+        String dnsString;
+        List<String> dnValArray = new ArrayList<>();
+
+        try {
+            X500Name x500Name = new X500Name(distinguishedName.trim());
+            for (RDN rdn : x500Name.getRDNs()) {
+                dnValArray.add(new X500Name(new RDN[]{rdn}).toString().toLowerCase());
+            }
+        } catch (IllegalArgumentException iaEx) {
+            log.error("Unable to parse distinguished name for sorting: {}", distinguishedName, iaEx);
+            dnsString = distinguishedName.trim();
+            dnsString = dnsString.toLowerCase();
+            dnValArray = Arrays.asList(dnsString.split(","));
+        }
+
+        Collections.sort(dnValArray);
+        ListIterator<String> dnListIter = dnValArray.listIterator();
+        StringBuilder sb = new StringBuilder();
+        while (dnListIter.hasNext()) {
+            sb.append(dnListIter.next());
+            if (dnListIter.hasNext()) {
+                sb.append(",");
+            }
+        }
         return sb.toString();
     }
 }

--- a/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/util/CredentialHelperTest.java
+++ b/HIRS_AttestationCA/src/test/java/hirs/attestationca/persist/util/CredentialHelperTest.java
@@ -1,0 +1,24 @@
+package hirs.attestationca.persist.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests methods in the {@link CredentialHelper} utility class.
+ */
+public class CredentialHelperTest {
+
+    private static final String DN_WITH_ESCAPED_COMMA =
+            "CN=PCTEST\\, FANCY.,L=Here,ST=There,C=US";
+
+    /**
+     * Tests that sorting a DN preserves escaped commas inside RDN values.
+     */
+    @Test
+    public void testParseSortDNsPreservesEscapedComma() {
+        String sortedDn = CredentialHelper.parseSortDNs(DN_WITH_ESCAPED_COMMA);
+
+        assertEquals("c=us,cn=pctest\\, fancy.,l=here,st=there", sortedDn);
+    }
+}

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -290,8 +290,8 @@ public final class CertificateStringMapBuilder {
                 issuerResult = certificate.isIssuer(issuerCert);
                 if (issuerResult.isEmpty()) {
                     //Check if it's root certificate
-                    if (BouncyCastleUtils.x500NameCompare(issuerCert.getIssuerSorted(),
-                            issuerCert.getSubjectSorted())) {
+                    if (BouncyCastleUtils.x500NameCompare(issuerCert.getIssuer(),
+                            issuerCert.getSubject())) {
                         return null;
                     }
                     return containsAllChain(issuerCert, caCredentialRepository);

--- a/HIRS_Utils/src/test/java/hirs/utils/BouncyCastleUtilsTest.java
+++ b/HIRS_Utils/src/test/java/hirs/utils/BouncyCastleUtilsTest.java
@@ -15,6 +15,10 @@ public class BouncyCastleUtilsTest {
 
     private static final String VALID_RDN_STRING_SWITCHED = "C=US,OU=PCTest,O=example.com";
     private static final String VALID_RDN_STRING_UPPERCASE = "OU=PCTEST,O=EXAMPLE.COM,C=US";
+    private static final String VALID_RDN_STRING_ESCAPED_COMMA =
+            "CN=PCTEST\\, FANCY.,L=Here,ST=There,C=US";
+    private static final String VALID_RDN_STRING_ESCAPED_COMMA_SWITCHED =
+            "C=US,ST=There,L=Here,CN=PCTEST\\, FANCY.";
     private static final String UNEQUAL_RDN_STRING = "OU=PCTest,O=example1.com,C=US";
     private static final String MALFORMED_RDN_STRING = "OU=PCTest,OZ=example1.com,C=US";
 
@@ -27,6 +31,8 @@ public class BouncyCastleUtilsTest {
                 VALID_RDN_STRING, VALID_RDN_STRING_SWITCHED));
         assertTrue(BouncyCastleUtils.x500NameCompare(
                 VALID_RDN_STRING, VALID_RDN_STRING_UPPERCASE));
+        assertTrue(BouncyCastleUtils.x500NameCompare(
+                VALID_RDN_STRING_ESCAPED_COMMA, VALID_RDN_STRING_ESCAPED_COMMA_SWITCHED));
         assertTrue(BouncyCastleUtils.x500NameCompare(Strings.EMPTY, Strings.EMPTY));
     }
 


### PR DESCRIPTION
Certificate DN searching would break on escaped commas. This should fix that.

To test:

Upload a certification path where certificate(s) have commas in the subject or issuer DN. You should be able to view details of each certificate. 