### PR TITLE
[#1177] Better logging for provisioning RIMs

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/DeviceInfoProcessorService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/DeviceInfoProcessorService.java
@@ -355,7 +355,7 @@ public class DeviceInfoProcessorService {
                 final String swidFileHash =
                         Base64.getEncoder().encodeToString(messageDigest.digest(swidFile.toByteArray()));
 
-                final BaseReferenceManifest baseRim =
+                BaseReferenceManifest baseRim =
                         (BaseReferenceManifest) referenceManifestRepository.findByBase64Hash(swidFileHash);
                 /*  Either the swidFile does not have a corresponding base RIM in the backend,
                 or it was deleted. Check if there is a replacement by comparing tagId against
@@ -377,26 +377,24 @@ public class DeviceInfoProcessorService {
                                 matchedReplacementBaseRIMOptional.get();
                         matchedReplacementBaseRIM.setDeviceName(replacementBaseRIM.getDeviceName());
                         referenceManifestRepository.save(matchedReplacementBaseRIM);
+                        baseRim = matchedReplacementBaseRIM;
                         log.info("Base RIM with manufacturer {} and model {} matched by tagId.",
                                 matchedReplacementBaseRIM.getPlatformManufacturer(),
                                 matchedReplacementBaseRIM.getPlatformModel());
-                        continue;
                     } else {
-                        log.error("Unable to locate base RIM with manufacturer {} and product name {}.",
-                                provisionedDeviceInfo.getHw().getManufacturer(),
-                                provisionedDeviceInfo.getHw().getProductName());
+                        // otherwise save the replacement base RIM we created
+                        referenceManifestRepository.save(replacementBaseRIM);
+                        baseRim = replacementBaseRIM;
                     }
-
-                    // otherwise save the replacement base RIM we created
-                    referenceManifestRepository.save(replacementBaseRIM);
                 } else if (baseRim.isArchived()) {
                         /*  This block accounts for RIMs that may have been soft-deleted (archived)
                         in an older version of the ACA. */
                     // Filter out unarchived base RIMs that match the tagId and are newer than the baseRim
+                    BaseReferenceManifest finalBaseRim = baseRim;
                     Optional<BaseReferenceManifest> matchedUnarchivedBaseRIMOptional = unarchivedRims.stream()
                             .filter(rim -> rim.isBase()
-                                    && rim.getTagId().equals(baseRim.getTagId())
-                                    && rim.getCreateTime().after(baseRim.getCreateTime()))
+                                    && rim.getTagId().equals(finalBaseRim.getTagId())
+                                    && rim.getCreateTime().after(finalBaseRim.getCreateTime()))
                             .map(rim -> (BaseReferenceManifest) rim)
                             .findFirst();
 
@@ -412,16 +410,26 @@ public class DeviceInfoProcessorService {
                     final BaseReferenceManifest matchedUnarchivedBaseRIM = matchedUnarchivedBaseRIMOptional.get();
                     matchedUnarchivedBaseRIM.setDeviceName(deviceHostName);
                     referenceManifestRepository.save(matchedUnarchivedBaseRIM);
+                    baseRim = matchedUnarchivedBaseRIM;
                     log.info("Original base RIM is archived; however a base RIM"
                                    + " with manufacturer {} and model {} matched by tagId.",
                             matchedUnarchivedBaseRIM.getPlatformManufacturer(),
                             matchedUnarchivedBaseRIM.getPlatformModel());
-                } else {
-                    baseRim.setDeviceName(deviceHostName);
-                    referenceManifestRepository.save(baseRim);
-                    log.info("Base RIM with manufacturer {} and model {} found.",
+                }
+
+                if (provisionedDeviceInfo.getHw().getManufacturer().equals(
+                        baseRim.getPlatformManufacturer()) &&
+                        provisionedDeviceInfo.getHw().getProductName().equals(
+                                baseRim.getPlatformModel())) {
+                    log.info("Base RIM with manufacturer {} and model {} received from {}.",
                             baseRim.getPlatformManufacturer(),
-                            baseRim.getPlatformModel());
+                            baseRim.getPlatformModel(),
+                            deviceHostName);
+                } else {
+                    log.warn("Base RIM manufacturer {} and model {} do not match those from {}.",
+                            baseRim.getPlatformManufacturer(),
+                            baseRim.getPlatformModel(),
+                            deviceHostName);
                 }
             } catch (Exception exception) {
                 log.error("Failed to process Base RIM file for device {}: {}",

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/DeviceInfoProcessorService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/DeviceInfoProcessorService.java
@@ -377,7 +377,14 @@ public class DeviceInfoProcessorService {
                                 matchedReplacementBaseRIMOptional.get();
                         matchedReplacementBaseRIM.setDeviceName(replacementBaseRIM.getDeviceName());
                         referenceManifestRepository.save(matchedReplacementBaseRIM);
+                        log.info("Base RIM with manufacturer {} and model {} matched by tagId.",
+                                matchedReplacementBaseRIM.getPlatformManufacturer(),
+                                matchedReplacementBaseRIM.getPlatformModel());
                         continue;
+                    } else {
+                        log.error("Unable to locate base RIM with manufacturer {} and product name {}.",
+                                provisionedDeviceInfo.getHw().getManufacturer(),
+                                provisionedDeviceInfo.getHw().getProductName());
                     }
 
                     // otherwise save the replacement base RIM we created
@@ -394,19 +401,32 @@ public class DeviceInfoProcessorService {
                             .findFirst();
 
                     if (matchedUnarchivedBaseRIMOptional.isEmpty()) {
-                        throw new Exception("Unable to locate an unarchived base RIM.");
+                        String errorMessage = String.format("Unable to locate an unarchived base RIM"
+                                + " with manufacturer %s and model %s.",
+                                baseRim.getPlatformManufacturer(),
+                                baseRim.getPlatformModel());
+                        log.error(errorMessage);
+                        throw new Exception(errorMessage);
                     }
 
                     final BaseReferenceManifest matchedUnarchivedBaseRIM = matchedUnarchivedBaseRIMOptional.get();
                     matchedUnarchivedBaseRIM.setDeviceName(deviceHostName);
                     referenceManifestRepository.save(matchedUnarchivedBaseRIM);
+                    log.info("Original base RIM is archived; however a base RIM"
+                                   + " with manufacturer {} and model {} matched by tagId.",
+                            matchedUnarchivedBaseRIM.getPlatformManufacturer(),
+                            matchedUnarchivedBaseRIM.getPlatformModel());
                 } else {
                     baseRim.setDeviceName(deviceHostName);
                     referenceManifestRepository.save(baseRim);
+                    log.info("Base RIM with manufacturer {} and model {} found.",
+                            baseRim.getPlatformManufacturer(),
+                            baseRim.getPlatformModel());
                 }
             } catch (Exception exception) {
-                log.error("Failed to process Base RIM file for device {}: {}", deviceHostName,
-                        exception.getMessage(), exception);
+                log.error("Failed to process Base RIM file for device {}: {}",
+                        deviceHostName,
+                        exception.getMessage());
             }
         }
     }
@@ -455,6 +475,11 @@ public class DeviceInfoProcessorService {
                                     replacementSupportRIM.getHexDecHash().length() - numOfVariables)));
                     replacementSupportRIM.setDeviceName(deviceHostName);
                     referenceManifestRepository.save(replacementSupportRIM);
+                    log.info("Support RIM with manufacturer {} and model {} was not found, "
+                            + "but a replacement was generated from {}'s log file.",
+                            provisionedDeviceInfo.getHw().getManufacturer(),
+                            provisionedDeviceInfo.getHw().getProductName(),
+                            deviceHostName);
                 } else if (supportRim.isArchived()) {
                     /*
                      This block accounts for RIMs that may have been soft-deleted (archived)
@@ -481,8 +506,9 @@ public class DeviceInfoProcessorService {
                     referenceManifestRepository.save(supportRim);
                 }
             } catch (Exception exception) {
-                log.error("Failed to process Support RIM file for device {}: {}", deviceHostName,
-                        exception.getMessage(), exception);
+                log.error("Failed to process Support RIM file for device {}: {}",
+                        deviceHostName,
+                        exception.getMessage());
 
             }
         }
@@ -675,30 +701,36 @@ public class DeviceInfoProcessorService {
                 referenceManifestRepository.save(integrityMeasurements);
             }
 
-            List<BaseReferenceManifest> baseRims = referenceManifestRepository.getBaseByManufacturerModel(
-                    provisionedDeviceInfo.getHw().getManufacturer(),
-                    provisionedDeviceInfo.getHw().getProductName());
-
             provisionedEventLog.setDeviceName(deviceHostName);
             provisionedEventLog.setPlatformManufacturer(provisionedDeviceInfo.getHw().getManufacturer());
             provisionedEventLog.setPlatformModel(provisionedDeviceInfo.getHw().getProductName());
             referenceManifestRepository.save(provisionedEventLog);
 
-            for (BaseReferenceManifest bRim : baseRims) {
-                if (bRim != null) {
-                    // pull the base versions of the swidtag and rimel and set the
-                    // event log hash for use during provision
-                    SupportReferenceManifest sBaseRim =
-                            referenceManifestRepository.getSupportRimEntityById(bRim.getAssociatedRim());
-                    if (sBaseRim != null) {
-                        bRim.setEventLogHash(provisionedEventLog.getHexDecHash());
-                        sBaseRim.setEventLogHash(provisionedEventLog.getHexDecHash());
-                        referenceManifestRepository.save(bRim);
-                        referenceManifestRepository.save(sBaseRim);
-                    } else {
-                        log.warn("Could not locate support RIM associated with base RIM {}", bRim.getId());
+            List<BaseReferenceManifest> baseRims = referenceManifestRepository.getBaseByManufacturerModel(
+                    provisionedDeviceInfo.getHw().getManufacturer(),
+                    provisionedDeviceInfo.getHw().getProductName());
+            if (baseRims.size() > 0) {
+                for (BaseReferenceManifest bRim : baseRims) {
+                    if (bRim != null) {
+                        // pull the base versions of the swidtag and rimel and set the
+                        // event log hash for use during provision
+                        SupportReferenceManifest sBaseRim =
+                                referenceManifestRepository.getSupportRimEntityById(bRim.getAssociatedRim());
+                        if (sBaseRim != null) {
+                            bRim.setEventLogHash(provisionedEventLog.getHexDecHash());
+                            sBaseRim.setEventLogHash(provisionedEventLog.getHexDecHash());
+                            referenceManifestRepository.save(bRim);
+                            referenceManifestRepository.save(sBaseRim);
+                        } else {
+                            log.warn("Could not locate support RIM associated with base RIM {}", bRim.getId());
+                        }
                     }
                 }
+            } else {
+                log.warn("No base RIMs found with manufacturer {} and model {}, "
+                        + "this may cause firmware validation errors.",
+                        provisionedDeviceInfo.getHw().getManufacturer(),
+                        provisionedDeviceInfo.getHw().getProductName());
             }
         } catch (Exception exception) {
             log.error(exception);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/SupplyChainValidationService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/SupplyChainValidationService.java
@@ -319,9 +319,10 @@ public class SupplyChainValidationService {
                 if (sRim == null) {
                     fwStatus = new AppraisalStatus(FAIL,
                             String.format("Firmware Quote validation failed: "
-                                            + "No associated Support RIM file "
-                                            + "could be found for %s",
-                                    deviceName));
+                                        + "support RIM with manufacturer %s and model %s not found for %s.",
+                                        device.getDeviceInfo().getHardwareInfo().getManufacturer(),
+                                        device.getDeviceInfo().getHardwareInfo().getProductName(),
+                                        deviceName));
                 } else {
                     ReferenceManifest manifest = referenceManifestRepository
                             .findByHexDecHashAndRimTypeUnarchived(sRim.getEventLogHash(),
@@ -332,9 +333,7 @@ public class SupplyChainValidationService {
                 }
                 if (eventLog == null) {
                     fwStatus = new AppraisalStatus(FAIL,
-                            String.format("Firmware Quote validation failed: "
-                                            + "No associated Client Log file "
-                                            + "could be found for %s",
+                            String.format("Firmware Quote validation failed: verify RIMs for %s",
                                     deviceName));
                 } else {
                     String[] storedPcrs = eventLog.getExpectedPCRList();


### PR DESCRIPTION
The changes here mostly concern logging the platform manufacturer and model during device firmware provisioning.  Including these two pieces of information will help diagnose RIM errors.

### Testing ###
#### Good bundle ####
1. Generate a known, good base + support RIM bundle
2. Provision using this bundle
3. Note the following log messages:

> INFO  : Device [device] sent SWID tag files
> INFO  : Base RIM with manufacturer [device manufacturer] and model [device model] received from [device].
> INFO  : Device [device] sent Support RIM files
> INFO  : Device [device] sent bios measurement log...
> 

#### Bad bundle ####
1. Generate a RIM bundle where the manufacturer and/or model is empty or not the expected value for the provisioning device
2. Provision using this bundle
3. Note the following log messages:

> INFO  : Device [device] sent SWID tag files
> WARN  : Base RIM manufacturer [manufacturer] and model [model] do not match those from  [device].
> INFO  : Device [device] sent Support RIM files
> INFO  : Device [device] sent bios measurement log...
> WARN  :  No base RIMs found with manufacturer [device manufacturer] and model [device model], this may cause firmware validation errors.
> ERROR  : Firmware Quote validation failed: verify RIMs for [device]


Closes #1177 