### PR TITLE
[#1194] Add embedded certificate display to RIM details page

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
@@ -1,14 +1,12 @@
 package hirs.attestationca.persist.entity.userdefined.rim;
 
 import hirs.attestationca.persist.entity.userdefined.ReferenceManifest;
+import hirs.attestationca.persist.entity.userdefined.certificate.CertificateAuthorityCredential;
 import hirs.utils.SwidResource;
+import hirs.utils.rim.SwidTagParser;
 import hirs.utils.swid.SwidTagConstants;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.UnmarshalException;
-import jakarta.xml.bind.Unmarshaller;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -18,22 +16,15 @@ import lombok.extern.log4j.Log4j2;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  *
@@ -49,8 +40,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
      * Holds the name of the 'base64Hash' field.
      */
     public static final String BASE_64_HASH_FIELD = "base64Hash";
-
-    private static JAXBContext jaxbContext;
 
     @Column
     private String swidName = null;
@@ -103,13 +92,15 @@ public class BaseReferenceManifest extends ReferenceManifest {
 
     private String linkRel = null;
 
+    private List<CertificateAuthorityCredential> embeddedCertificates = new ArrayList<>();
+
     /**
      * Support constructor for the RIM object.
      *
      * @param rimBytes - the file content of the uploaded file.
-     * @throws UnmarshalException - thrown if the file is invalid.
+     * @throws IOException - thrown if file cannot be read.
      */
-    public BaseReferenceManifest(final byte[] rimBytes) throws UnmarshalException {
+    public BaseReferenceManifest(final byte[] rimBytes) throws IOException {
         this("", rimBytes);
     }
 
@@ -119,14 +110,15 @@ public class BaseReferenceManifest extends ReferenceManifest {
      *
      * @param fileName - string representation of the uploaded file.
      * @param rimBytes byte array representation of the RIM
-     * @throws UnmarshalException if unable to unmarshal the string
+     * @throws IOException if unable to read file
      */
     public BaseReferenceManifest(final String fileName, final byte[] rimBytes)
-            throws UnmarshalException {
+            throws IOException {
         super(rimBytes);
         this.setRimType(BASE_RIM);
         this.setFileName(fileName);
-        Document document = unmarshallSwidTag(new ByteArrayInputStream(rimBytes));
+        Document document = SwidTagParser.validateSwidtagSchema(SwidTagParser.removeXMLWhitespace(new StreamSource(
+                new ByteArrayInputStream(rimBytes))));
         Element softwareIdentity;
         Element meta;
         Element entity;
@@ -155,6 +147,20 @@ public class BaseReferenceManifest extends ReferenceManifest {
             parseSoftwareMeta(meta);
             parseEntity(entity);
             parseLink(link);
+            List<X509Certificate> rawEmbeddedCertificates = SwidTagParser.getEmbeddedCertificates(document);
+            if (rawEmbeddedCertificates != null && !rawEmbeddedCertificates.isEmpty()) {
+                for (X509Certificate embeddedCert : rawEmbeddedCertificates) {
+                    try {
+                        CertificateAuthorityCredential cert = new CertificateAuthorityCredential(
+                                embeddedCert.getEncoded());
+                        cert.setId(UUID.randomUUID());
+                        embeddedCertificates.add(cert);
+                    } catch (CertificateEncodingException | IOException e){
+                        log.error("Error creating CertificateAuthorityCredential from embedded X509" +
+                                "Certificate: {}", e.getMessage());
+                    }
+                }
+            }
         }
     }
 
@@ -246,9 +252,10 @@ public class BaseReferenceManifest extends ReferenceManifest {
     private Element getDirectoryTag(final ByteArrayInputStream byteArrayInputStream) {
         Document document = null;
         try {
-            document = unmarshallSwidTag(byteArrayInputStream);
-        } catch (UnmarshalException e) {
-            log.error("Error while parsing Directory tag: {}", e.getMessage());
+            document = SwidTagParser.validateSwidtagSchema(SwidTagParser.removeXMLWhitespace(
+                    new StreamSource(byteArrayInputStream)));
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
         if (document != null) {
             Element softwareIdentity =
@@ -299,82 +306,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
         }
 
         return validHashes;
-    }
-
-    /**
-     * This method unmarshalls the swidtag found at [path] into a Document object
-     * and validates it according to the schema.
-     *
-     * @param byteArrayInputStream to the input swidtag
-     * @return the Document element at the root of the swidtag
-     */
-    private Document unmarshallSwidTag(final ByteArrayInputStream byteArrayInputStream)
-            throws UnmarshalException {
-        InputStream is = null;
-        Document document = null;
-        Unmarshaller unmarshaller = null;
-        try {
-            document = removeXMLWhitespace(byteArrayInputStream);
-            SchemaFactory schemaFactory = SchemaFactory.newInstance(SCHEMA_LANGUAGE);
-            is = getClass().getClassLoader().getResourceAsStream(SwidTagConstants.SCHEMA_URL);
-            Schema schema = schemaFactory.newSchema(new StreamSource(is));
-            if (jaxbContext == null) {
-                jaxbContext = JAXBContext.newInstance(SCHEMA_PACKAGE);
-            }
-            unmarshaller = jaxbContext.createUnmarshaller();
-            unmarshaller.setSchema(schema);
-            unmarshaller.unmarshal(document);
-        } catch (IOException e) {
-            log.error(e.getMessage());
-        } catch (SAXException e) {
-            log.error("Error setting schema for validation!");
-        } catch (UnmarshalException e) {
-            throw new UnmarshalException("Error unmarshalling swidtag file: " + e.getCause());
-        } catch (IllegalArgumentException e) {
-            log.error("Input file empty.");
-        } catch (JAXBException e) {
-            e.printStackTrace();
-        } finally {
-            if (is != null) {
-                try {
-                    is.close();
-                } catch (IOException e) {
-                    System.out.println("Error closing input stream");
-                }
-            }
-        }
-
-        return document;
-    }
-
-    /**
-     * This method strips all whitespace from an xml file, including indents and spaces
-     * added for human-readability.
-     *
-     * @param byteArrayInputStream to the xml file
-     * @return Document object without whitespace
-     */
-    private Document removeXMLWhitespace(final ByteArrayInputStream byteArrayInputStream) throws IOException {
-        TransformerFactory tf = TransformerFactory.newInstance();
-        Source source = new StreamSource(
-                getClass().getClassLoader().getResourceAsStream("identity_transform.xslt"));
-        Document document = null;
-        if (byteArrayInputStream.available() > 0) {
-            try {
-                Transformer transformer = tf.newTransformer(source);
-                DOMResult result = new DOMResult();
-                transformer.transform(new StreamSource(byteArrayInputStream), result);
-                document = (Document) result.getNode();
-            } catch (TransformerConfigurationException tcEx) {
-                log.error("Error configuring transformer!");
-            } catch (TransformerException tEx) {
-                log.error("Error transforming input!");
-            }
-        } else {
-            throw new IOException("Input file is empty!");
-        }
-
-        return document;
     }
 
     /**

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
@@ -147,20 +147,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
             parseSoftwareMeta(meta);
             parseEntity(entity);
             parseLink(link);
-            List<X509Certificate> rawEmbeddedCertificates = SwidTagParser.getEmbeddedCertificates(document);
-            if (rawEmbeddedCertificates != null && !rawEmbeddedCertificates.isEmpty()) {
-                for (X509Certificate embeddedCert : rawEmbeddedCertificates) {
-                    try {
-                        CertificateAuthorityCredential cert = new CertificateAuthorityCredential(
-                                embeddedCert.getEncoded());
-                        cert.setId(UUID.randomUUID());
-                        embeddedCertificates.add(cert);
-                    } catch (CertificateEncodingException | IOException e){
-                        log.error("Error creating CertificateAuthorityCredential from embedded X509" +
-                                "Certificate: {}", e.getMessage());
-                    }
-                }
-            }
         }
     }
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
@@ -99,7 +99,8 @@ public class BaseReferenceManifest extends ReferenceManifest {
      * @param rimBytes - the file content of the uploaded file.
      * @throws IOException - thrown if file cannot be read.
      */
-    public BaseReferenceManifest(final byte[] rimBytes) throws IOException, ParserConfigurationException, SAXException, UnmarshalException {
+    public BaseReferenceManifest(final byte[] rimBytes) throws IOException, ParserConfigurationException,
+            SAXException, UnmarshalException {
         this("", rimBytes);
     }
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
@@ -7,6 +7,7 @@ import hirs.utils.rim.SwidTagParser;
 import hirs.utils.swid.SwidTagConstants;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.xml.bind.UnmarshalException;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -16,15 +17,13 @@ import lombok.extern.log4j.Log4j2;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
 
-import javax.xml.transform.stream.StreamSource;
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 /**
  *
@@ -100,7 +99,7 @@ public class BaseReferenceManifest extends ReferenceManifest {
      * @param rimBytes - the file content of the uploaded file.
      * @throws IOException - thrown if file cannot be read.
      */
-    public BaseReferenceManifest(final byte[] rimBytes) throws IOException {
+    public BaseReferenceManifest(final byte[] rimBytes) throws IOException, ParserConfigurationException, SAXException, UnmarshalException {
         this("", rimBytes);
     }
 
@@ -113,12 +112,11 @@ public class BaseReferenceManifest extends ReferenceManifest {
      * @throws IOException if unable to read file
      */
     public BaseReferenceManifest(final String fileName, final byte[] rimBytes)
-            throws IOException {
+            throws IOException, ParserConfigurationException, SAXException, UnmarshalException {
         super(rimBytes);
         this.setRimType(BASE_RIM);
         this.setFileName(fileName);
-        Document document = SwidTagParser.validateSwidtagSchema(SwidTagParser.removeXMLWhitespace(new StreamSource(
-                new ByteArrayInputStream(rimBytes))));
+        Document document = SwidTagParser.validateSwidtagSchema(SwidTagParser.convertToDocument(rimBytes));
         Element softwareIdentity;
         Element meta;
         Element entity;
@@ -238,10 +236,15 @@ public class BaseReferenceManifest extends ReferenceManifest {
     private Element getDirectoryTag(final ByteArrayInputStream byteArrayInputStream) {
         Document document = null;
         try {
-            document = SwidTagParser.validateSwidtagSchema(SwidTagParser.removeXMLWhitespace(
-                    new StreamSource(byteArrayInputStream)));
+            document = SwidTagParser.validateSwidtagSchema(SwidTagParser.convertToDocument(
+                    byteArrayInputStream.readAllBytes()));
         } catch (IOException e) {
             log.error(e.getMessage());
+        } catch (ParserConfigurationException e) {
+            log.error("Error encountered setting up to parse rim bytes: {}", e.getMessage());
+            throw new RuntimeException(e);
+        } catch (SAXException | UnmarshalException e) {
+            log.error("Error while parsing Base RIM: {}", e.getMessage());
         }
         if (document != null) {
             Element softwareIdentity =

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -317,7 +317,16 @@ public class ReferenceManifestDetailsPageService {
                 }
             }
         }
-
+        List<CertificateAuthorityCredential> embeddedCertificates = baseRim.getEmbeddedCertificates();
+        if (embeddedCertificates != null && !embeddedCertificates.isEmpty()) {
+            List<String> embeddedCertIds = new ArrayList<>();
+            for (CertificateAuthorityCredential embeddedCert : embeddedCertificates) {
+                if (embeddedCert != null && embeddedCert.getId() != null) {
+                    embeddedCertIds.add(embeddedCert.getId().toString());
+                }
+            }
+            data.put("embeddedCertIds", embeddedCertIds);
+        }
         data.put("skID", referenceManifestValidator.getSubjectKeyIdentifier());
         try {
             if (referenceManifestValidator.getPublicKey() != null) {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -17,6 +17,7 @@ import hirs.attestationca.persist.validation.SupplyChainCredentialValidator;
 import hirs.attestationca.persist.validation.ValidationService;
 import hirs.utils.SwidResource;
 import hirs.utils.rim.ReferenceManifestValidator;
+import hirs.utils.rim.SwidTagParser;
 import hirs.utils.tpm.eventlog.TCGEventLog;
 import hirs.utils.tpm.eventlog.TpmPcrEvent;
 import hirs.utils.tpm.eventlog.events.EvConstants;
@@ -24,9 +25,13 @@ import hirs.utils.tpm.eventlog.uefi.UefiConstants;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.w3c.dom.Document;
 
+import javax.xml.transform.stream.StreamSource;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.KeyStore;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -317,12 +322,25 @@ public class ReferenceManifestDetailsPageService {
                 }
             }
         }
-        List<CertificateAuthorityCredential> embeddedCertificates = baseRim.getEmbeddedCertificates();
-        if (embeddedCertificates != null && !embeddedCertificates.isEmpty()) {
-            List<String> embeddedCertIds = new ArrayList<>();
-            for (CertificateAuthorityCredential embeddedCert : embeddedCertificates) {
-                if (embeddedCert != null && embeddedCert.getId() != null) {
-                    embeddedCertIds.add(embeddedCert.getId().toString());
+
+        List<CertificateAuthorityCredential> embeddedCertificates = new ArrayList<>();
+        List<X509Certificate> rawEmbeddedCertificates = SwidTagParser.getEmbeddedCertificates(
+                SwidTagParser.validateSwidtagSchema(SwidTagParser.removeXMLWhitespace(
+                        new StreamSource(new ByteArrayInputStream(baseRim.getRimBytes())))));
+        List<String> embeddedCertIds = new ArrayList<>();
+        if (rawEmbeddedCertificates != null && !rawEmbeddedCertificates.isEmpty()) {
+            for (X509Certificate rawEmbeddedCertificate : rawEmbeddedCertificates) {
+                try {
+                    CertificateAuthorityCredential embeddedCertificate =
+                            new CertificateAuthorityCredential(rawEmbeddedCertificate.getEncoded());
+                    embeddedCertificate.setId(UUID.randomUUID());
+                    embeddedCertificates.add(embeddedCertificate);
+                    baseRim.setEmbeddedCertificates(embeddedCertificates);
+                    referenceManifestRepository.save(baseRim);
+                    embeddedCertIds.add(embeddedCertificate.getId().toString());
+                } catch (CertificateEncodingException | IOException e) {
+                    log.error("Error creating CertificateAuthorityCredential from embedded X509"
+                            + "Certificate: {}", e.getMessage());
                 }
             }
             data.put("embeddedCertIds", embeddedCertIds);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -26,14 +26,12 @@ import jakarta.xml.bind.UnmarshalException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.stream.StreamSource;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -291,47 +289,10 @@ public class ReferenceManifestDetailsPageService {
             data.put("pcrList", support.getExpectedPCRList());
         }
 
-        List<Certificate> certificates = certificateRepository.findByType("CertificateAuthorityCredential");
-
-        CertificateAuthorityCredential caCert;
-
-        //Report invalid signature unless referenceManifestValidator validates it and cert path is valid
-        data.put("signatureValid", false);
-
-        for (Certificate certificate : certificates) {
-            caCert = (CertificateAuthorityCredential) certificate;
-            KeyStore keystore = ValidationService.getCaChain(caCert, caCertificateRepository);
-            try {
-                Set<CertificateAuthorityCredential> caChain = ValidationService.getCaChainRec(caCert,
-                        Collections.emptySet(),
-                        caCertificateRepository);
-                caChain.add(caCert);
-                List<X509Certificate> truststore =
-                        convertCACsToX509Certificates(caChain);
-                referenceManifestValidator.setTrustStore(truststore);
-            } catch (IOException e) {
-                log.error("Error building CA chain for {}: {}", caCert.getSubjectKeyIdentifier(),
-                        e.getMessage());
-            }
-
-            if (referenceManifestValidator.validateXmlSignature(caCert.getX509Certificate().getPublicKey(),
-                    caCert.getSubjectKeyIdString())) {
-                try {
-                    if (SupplyChainCredentialValidator.verifyCertificate(
-                            caCert.getX509Certificate(), keystore)) {
-                        data.replace("signatureValid", true);
-                        break;
-                    }
-                } catch (SupplyChainValidatorException scvEx) {
-                    log.error("Error verifying cert chain: {}", scvEx.getMessage());
-                }
-            }
-        }
-
         List<CertificateAuthorityCredential> embeddedCertificates = new ArrayList<>();
-        List<X509Certificate> rawEmbeddedCertificates = null;
+        List<X509Certificate> rawEmbeddedCertificates;
         try {
-            rawEmbeddedCertificates = SwidTagParser.getEmbeddedCertificates(
+            rawEmbeddedCertificates = SwidTagParser.getEmbeddedX509Certificates(
                     SwidTagParser.validateSwidtagSchema(SwidTagParser.convertToDocument(baseRim.getRimBytes())));
         } catch (ParserConfigurationException e) {
             log.error("Error while reading RIM: {}", e.getMessage());
@@ -357,15 +318,78 @@ public class ReferenceManifestDetailsPageService {
                 }
             }
             data.put("embeddedCertIds", embeddedCertIds);
+
         }
+        List<Certificate> certificates = new ArrayList<>(
+                certificateRepository.findByType("CertificateAuthorityCredential"));
+        certificates.addAll(embeddedCertificates);
+
+        //Report invalid signature unless referenceManifestValidator validates it and cert path is valid
+        data.put("signatureValid", false);
+        CertificateAuthorityCredential caCert;
+        for (Certificate certificate : certificates) {
+            caCert = (CertificateAuthorityCredential) certificate;
+            KeyStore keystore = ValidationService.getCaChain(caCert, caCertificateRepository);
+            try {
+                for (CertificateAuthorityCredential embedded : embeddedCertificates) {
+                    keystore.setCertificateEntry("embedded-" + Arrays.toString(embedded.getSubjectKeyIdentifier()), embedded.getX509Certificate());
+                }
+            } catch (KeyStoreException e) {
+                log.error("Error adding embedded certificates to keystore: {}", e.getMessage());
+            }
+            try {
+                Set<CertificateAuthorityCredential> caChain = ValidationService.getCaChainRec(caCert,
+                        Collections.emptySet(),
+                        caCertificateRepository);
+                caChain.add(caCert);
+                List<X509Certificate> truststore =
+                        convertCACsToX509Certificates(caChain);
+                if (rawEmbeddedCertificates != null) {
+                    truststore.addAll(rawEmbeddedCertificates);
+                }
+                referenceManifestValidator.setTrustStore(truststore);
+            } catch (IOException e) {
+                log.error("Error building CA chain for {}: {}", caCert.getSubjectKeyIdentifier(),
+                        e.getMessage());
+            }
+
+            if (referenceManifestValidator.validateXmlSignature(caCert.getX509Certificate().getPublicKey(),
+                    caCert.getSubjectKeyIdString())) {
+                try {
+                    if (SupplyChainCredentialValidator.verifyCertificate(
+                            caCert.getX509Certificate(), keystore)) {
+                        data.replace("signatureValid", true);
+                        break;
+                    }
+                } catch (SupplyChainValidatorException scvEx) {
+                    log.error("Error verifying cert chain: {}", scvEx.getMessage());
+                }
+            }
+        }
+
         data.put("skID", referenceManifestValidator.getSubjectKeyIdentifier());
         try {
-            if (referenceManifestValidator.getPublicKey() != null) {
+            X509Certificate signingCert = referenceManifestValidator.getSigningCertificate();
+            if (signingCert != null) {
                 for (Certificate certificate : certificates) {
                     caCert = (CertificateAuthorityCredential) certificate;
-                    if (Arrays.equals(caCert.getEncodedPublicKey(),
-                            referenceManifestValidator.getPublicKey().getEncoded())) {
+                    if (caCert.getX509Certificate() != null &&
+                            Arrays.equals(
+                                    caCert.getX509Certificate().getEncoded(),
+                                    signingCert.getEncoded()
+                            )) {
                         data.put("issuerID", caCert.getId().toString());
+                        break;
+                    }
+                }
+            } else {
+                if (referenceManifestValidator.getPublicKey() != null) {
+                    for (Certificate certificate : certificates) {
+                        caCert = (CertificateAuthorityCredential) certificate;
+                        if (Arrays.equals(caCert.getEncodedPublicKey(),
+                                referenceManifestValidator.getPublicKey().getEncoded())) {
+                            data.put("issuerID", caCert.getId().toString());
+                        }
                     }
                 }
             }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -22,11 +22,14 @@ import hirs.utils.tpm.eventlog.TCGEventLog;
 import hirs.utils.tpm.eventlog.TpmPcrEvent;
 import hirs.utils.tpm.eventlog.events.EvConstants;
 import hirs.utils.tpm.eventlog.uefi.UefiConstants;
+import jakarta.xml.bind.UnmarshalException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -326,9 +329,17 @@ public class ReferenceManifestDetailsPageService {
         }
 
         List<CertificateAuthorityCredential> embeddedCertificates = new ArrayList<>();
-        List<X509Certificate> rawEmbeddedCertificates = SwidTagParser.getEmbeddedCertificates(
-                SwidTagParser.validateSwidtagSchema(SwidTagParser.removeXMLWhitespace(
-                        new StreamSource(new ByteArrayInputStream(baseRim.getRimBytes())))));
+        List<X509Certificate> rawEmbeddedCertificates = null;
+        try {
+            rawEmbeddedCertificates = SwidTagParser.getEmbeddedCertificates(
+                    SwidTagParser.validateSwidtagSchema(SwidTagParser.convertToDocument(baseRim.getRimBytes())));
+        } catch (ParserConfigurationException e) {
+            log.error("Error while reading RIM: {}", e.getMessage());
+            throw new IOException(e);
+        } catch (SAXException | UnmarshalException e) {
+            log.error("Error while parsing RIM: {}", e.getMessage());
+            throw new IOException(e);
+        }
         List<String> embeddedCertIds = new ArrayList<>();
         if (rawEmbeddedCertificates != null && !rawEmbeddedCertificates.isEmpty()) {
             for (X509Certificate rawEmbeddedCertificate : rawEmbeddedCertificates) {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -332,7 +332,8 @@ public class ReferenceManifestDetailsPageService {
             KeyStore keystore = ValidationService.getCaChain(caCert, caCertificateRepository);
             try {
                 for (CertificateAuthorityCredential embedded : embeddedCertificates) {
-                    keystore.setCertificateEntry("embedded-" + Arrays.toString(embedded.getSubjectKeyIdentifier()), embedded.getX509Certificate());
+                    keystore.setCertificateEntry("embedded-" + Arrays.toString(
+                            embedded.getSubjectKeyIdentifier()), embedded.getX509Certificate());
                 }
             } catch (KeyStoreException e) {
                 log.error("Error adding embedded certificates to keystore: {}", e.getMessage());
@@ -373,8 +374,8 @@ public class ReferenceManifestDetailsPageService {
             if (signingCert != null) {
                 for (Certificate certificate : certificates) {
                     caCert = (CertificateAuthorityCredential) certificate;
-                    if (caCert.getX509Certificate() != null &&
-                            Arrays.equals(
+                    if (caCert.getX509Certificate() != null
+                            && Arrays.equals(
                                     caCert.getX509Certificate().getEncoded(),
                                     signingCert.getEncoded()
                             )) {

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateDetailsPageController.java
@@ -42,6 +42,7 @@ public class CertificateDetailsPageController extends PageController<Certificate
      * @param certificateRepository     the certificate repository
      * @param componentResultRepository the component result repository
      * @param caCredentialRepository    the ca credential manager
+     * @param referenceManifestRepository the rim repository
      */
     @Autowired
     public CertificateDetailsPageController(final CertificateRepository certificateRepository,

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateDetailsPageController.java
@@ -3,6 +3,7 @@ package hirs.attestationca.portal.page.controllers;
 import hirs.attestationca.persist.entity.manager.CACredentialRepository;
 import hirs.attestationca.persist.entity.manager.CertificateRepository;
 import hirs.attestationca.persist.entity.manager.ComponentResultRepository;
+import hirs.attestationca.persist.entity.manager.ReferenceManifestRepository;
 import hirs.attestationca.portal.page.Page;
 import hirs.attestationca.persist.dto.PageMessages;
 import hirs.attestationca.portal.page.params.CertificateDetailsPageParams;
@@ -33,6 +34,7 @@ public class CertificateDetailsPageController extends PageController<Certificate
     private final CertificateRepository certificateRepository;
     private final CACredentialRepository caCredentialRepository;
     private final ComponentResultRepository componentResultRepository;
+    private final ReferenceManifestRepository referenceManifestRepository;
 
     /**
      * Constructor providing the Page's display and routing specification.
@@ -44,11 +46,13 @@ public class CertificateDetailsPageController extends PageController<Certificate
     @Autowired
     public CertificateDetailsPageController(final CertificateRepository certificateRepository,
                                             final ComponentResultRepository componentResultRepository,
-                                            final CACredentialRepository caCredentialRepository) {
+                                            final CACredentialRepository caCredentialRepository,
+                                            final ReferenceManifestRepository referenceManifestRepository) {
         super(Page.CERTIFICATE_DETAILS);
         this.certificateRepository = certificateRepository;
         this.componentResultRepository = componentResultRepository;
         this.caCredentialRepository = caCredentialRepository;
+        this.referenceManifestRepository = referenceManifestRepository;
     }
 
     /**
@@ -86,7 +90,7 @@ public class CertificateDetailsPageController extends PageController<Certificate
                 switch (type) {
                     case "certificateauthority":
                         data.putAll(CertificateStringMapBuilder.getCertificateAuthorityInformation(
-                                uuid, certificateRepository, caCredentialRepository));
+                                uuid, certificateRepository, caCredentialRepository, referenceManifestRepository));
                         break;
                     case "endorsement":
                         data.putAll(CertificateStringMapBuilder.getEndorsementInformation(uuid,

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/TrustChainCertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/TrustChainCertificatePageController.java
@@ -44,6 +44,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -141,6 +142,7 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
                 certificateRepository,
                 caCredentialRepository,
                 acaTrustChainCertificates[0],
+                Collections.emptyList(),
                 "Leaf ACA Certificate Not Found")));
 
         // add object that contains the intermediate ACA certificate information
@@ -149,6 +151,7 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
                         certificateRepository,
                         caCredentialRepository,
                         acaTrustChainCertificates[1],
+                        Collections.emptyList(),
                         "Intermediate ACA Certificate Not Found")));
 
         // add object that contains the root ACA certificate information
@@ -156,6 +159,7 @@ public class TrustChainCertificatePageController extends PageController<NoPagePa
                 certificateRepository,
                 caCredentialRepository,
                 acaTrustChainCertificates[2],
+                Collections.emptyList(),
                 "Root ACA Certificate Not Found")));
 
         return mav;

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -3,7 +3,9 @@ package hirs.attestationca.portal.page.utils;
 import hirs.attestationca.persist.entity.manager.CACredentialRepository;
 import hirs.attestationca.persist.entity.manager.CertificateRepository;
 import hirs.attestationca.persist.entity.manager.ComponentResultRepository;
+import hirs.attestationca.persist.entity.manager.ReferenceManifestRepository;
 import hirs.attestationca.persist.entity.userdefined.Certificate;
+import hirs.attestationca.persist.entity.userdefined.ReferenceManifest;
 import hirs.attestationca.persist.entity.userdefined.certificate.CertificateAuthorityCredential;
 import hirs.attestationca.persist.entity.userdefined.certificate.ComponentResult;
 import hirs.attestationca.persist.entity.userdefined.certificate.EndorsementCredential;
@@ -15,6 +17,7 @@ import hirs.attestationca.persist.entity.userdefined.certificate.attributes.Dice
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.PlatformConfigurationV1;
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.V2.ComponentIdentifierV2;
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.V2.PlatformConfigurationV2;
+import hirs.attestationca.persist.entity.userdefined.rim.BaseReferenceManifest;
 import hirs.attestationca.persist.exceptions.NonUniqueSKIException;
 import hirs.attestationca.persist.util.AcaPciIds;
 import hirs.utils.BouncyCastleUtils;
@@ -316,15 +319,44 @@ public final class CertificateStringMapBuilder {
     public static HashMap<String, String>
     getCertificateAuthorityInformation(final UUID uuid,
                                        final CertificateRepository certificateRepository,
-                                       final CACredentialRepository caCertificateRepository) {
+                                       final CACredentialRepository caCertificateRepository,
+                                       final ReferenceManifestRepository referenceManifestRepository) {
 
-        if (!caCertificateRepository.existsById(uuid)) {
-            return new HashMap<>();
+        CertificateAuthorityCredential certificate = null;
+
+        if (caCertificateRepository.existsById(uuid)) {
+            certificate = caCertificateRepository.getReferenceById(uuid);
         }
-        CertificateAuthorityCredential certificate = caCertificateRepository.getReferenceById(uuid);
 
+        if (certificate == null) {
+            Iterable<ReferenceManifest> rims = referenceManifestRepository.findAll();
+            for (ReferenceManifest rim : rims) {
+                if (!rim.isBase()) {
+                    continue;
+                }
+                BaseReferenceManifest baseRim = (BaseReferenceManifest) rim;
+                List<CertificateAuthorityCredential> embeddedCerts =
+                        baseRim.getEmbeddedCertificates();
+                if (embeddedCerts == null || embeddedCerts.isEmpty()) {
+                    continue;
+                }
+                for (CertificateAuthorityCredential embeddedCert : embeddedCerts) {
+                    UUID certId = embeddedCert.getId();
+                    if (certId != null && certId.equals(uuid)) {
+                        certificate = caCertificateRepository
+                                .findBySubjectKeyIdStringAndArchiveFlag(
+                                        embeddedCert.getSubjectKeyIdString(), false);
+                        if (certificate != null) {
+                            break;
+                        }
+                    }
+                }
+                if (certificate != null) {
+                    break;
+                }
+            }
+        }
         final String notFoundMessage = "Unable to find Certificate Authority Credential with ID: " + uuid;
-
         return getCertificateAuthorityInfoHelper(certificateRepository, caCertificateRepository,
                 certificate,
                 notFoundMessage);

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -89,7 +89,8 @@ public final class CertificateStringMapBuilder {
     public static HashMap<String, String> getGeneralCertificateInfo(
             final Certificate certificate,
             final CertificateRepository certificateRepository,
-            final CACredentialRepository caCertificateRepository) {
+            final CACredentialRepository caCertificateRepository,
+            final List<CertificateAuthorityCredential> embeddedCertificates) {
         HashMap<String, String> data = new HashMap<>();
         Map<String, String> ekuMap = getExtendedKeyUsageMap();
 
@@ -184,7 +185,7 @@ public final class CertificateStringMapBuilder {
                 //Get the missing certificate chain for not self sign
                 Certificate missingCert = null;
                 try {
-                    missingCert = containsAllChain(certificate, caCertificateRepository);
+                    missingCert = containsAllChain(certificate, caCertificateRepository, embeddedCertificates);
                 } catch (NonUniqueSKIException e) {
                     data.put("missingChainIssuer",
                             "Chain contains Root CA whose SKI is non-unique within CA repository.");
@@ -197,10 +198,11 @@ public final class CertificateStringMapBuilder {
                 }
 
                 // Match AKI against SKI
+                CertificateAuthorityCredential keyIdMatch = null;
                 if (certificate.getAuthorityKeyIdentifier() != null
                         && !certificate.getAuthorityKeyIdentifier().isEmpty()) {
                     try {
-                        CertificateAuthorityCredential keyIdMatch = caCertificateRepository
+                        keyIdMatch = caCertificateRepository
                                 .findBySubjectKeyIdStringAndArchiveFlag(
                                         certificate.getAuthorityKeyIdentifier(), false);
                         if (keyIdMatch != null) {
@@ -211,11 +213,28 @@ public final class CertificateStringMapBuilder {
                         log.error("Duplicate Root CA SKI detected while matching AKI to SKI: {}",
                                 certificate.getAuthorityKeyIdentifier(), e);
                     }
+                    if (keyIdMatch == null && embeddedCertificates != null) {
+                        keyIdMatch = embeddedCertificates.stream()
+                                .filter(cert -> certificate.getAuthorityKeyIdentifier().equals(cert.getSubjectKeyIdString()))
+                                .findFirst()
+                                .orElse(null);
+                    }
+                    if (keyIdMatch != null && keyIdMatch.getId() != null) {
+                        data.put("issuerID", keyIdMatch.getId().toString());
+                        return data;
+                    }
                 }
 
                 // If no AKI SKI match found, fall back on DN match
                 List<Certificate> certificates = certificateRepository.findBySubjectSorted(
                         certificate.getIssuerSorted(), "CertificateAuthorityCredential");
+                if (embeddedCertificates != null) {
+                    embeddedCertificates.stream()
+                            .filter(cert -> certificate.getIssuerSorted() != null
+                                    ? certificate.getIssuerSorted().equals(cert.getSubjectSorted())
+                                    : certificate.getIssuer().equals(cert.getSubject()))
+                            .forEach(certificates::add);
+                }
                 //Find all certificates that could be the issuer certificate based on subject name
                 for (Certificate issuerCert : certificates) {
                     try {
@@ -250,7 +269,8 @@ public final class CertificateStringMapBuilder {
      */
     public static Certificate containsAllChain(
             final Certificate certificate,
-            final CACredentialRepository caCredentialRepository) {
+            final CACredentialRepository caCredentialRepository,
+            final List<CertificateAuthorityCredential> embeddedCertificates) {
         List<CertificateAuthorityCredential> issuerCertificates = new ArrayList<>();
         CertificateAuthorityCredential skiCA = null;
         String issuerResult;
@@ -268,6 +288,12 @@ public final class CertificateStringMapBuilder {
                         "Duplicate Root CA SKI detected in CA Credential Repository: "
                                 + certificate.getAuthorityKeyIdentifier(), e);
             }
+            if (skiCA == null && embeddedCertificates != null) {
+                skiCA = embeddedCertificates.stream()
+                        .filter(cert -> certificate.getAuthorityKeyIdentifier().equals(cert.getSubjectKeyIdString()))
+                        .findFirst()
+                        .orElse(null);
+            }
         } else {
             log.error("Certificate ({}) for {} has no authority key identifier.",
                     certificate.getClass(), certificate.getSubject());
@@ -279,10 +305,20 @@ public final class CertificateStringMapBuilder {
                 //Get certificates by subject
                 issuerCertificates =
                         caCredentialRepository.findBySubjectAndArchiveFlag(certificate.getIssuer(), false);
+                if (embeddedCertificates != null) {
+                    embeddedCertificates.stream()
+                            .filter(cert -> certificate.getIssuer().equals(cert.getSubject()))
+                            .forEach(issuerCertificates::add);
+                }
             } else {
                 //Get certificates by subject organization
                 issuerCertificates = caCredentialRepository.findBySubjectSortedAndArchiveFlag(
                         certificate.getIssuerSorted(), false);
+                if (embeddedCertificates != null) {
+                    embeddedCertificates.stream()
+                            .filter(cert -> certificate.getIssuerSorted().equals(cert.getSubjectSorted()))
+                            .forEach(issuerCertificates::add);
+                }
             }
         } else {
             issuerCertificates.add(skiCA);
@@ -298,7 +334,7 @@ public final class CertificateStringMapBuilder {
                             issuerCert.getSubject())) {
                         return null;
                     }
-                    return containsAllChain(issuerCert, caCredentialRepository);
+                    return containsAllChain(issuerCert, caCredentialRepository, embeddedCertificates);
                 }
             } catch (IOException ioEx) {
                 log.error(ioEx);
@@ -361,9 +397,25 @@ public final class CertificateStringMapBuilder {
             }
         }
         final String notFoundMessage = "Unable to find Certificate Authority Credential with ID: " + uuid;
+        List<CertificateAuthorityCredential> embeddedCertificates = Collections.emptyList();
+        if (referenceManifestRepository != null) {
+            for (ReferenceManifest rim : referenceManifestRepository.findAll()) {
+                if (!(rim instanceof BaseReferenceManifest baseRim)) {
+                    continue;
+                }
+                List<CertificateAuthorityCredential> possibleEmbeddedCerts = baseRim.getEmbeddedCertificates();
+                if (possibleEmbeddedCerts == null || possibleEmbeddedCerts.isEmpty()) {
+                    continue;
+                }
+                boolean contains = possibleEmbeddedCerts.stream()
+                        .anyMatch(c -> uuid.equals(c.getId()));
+                if (contains) {
+                    embeddedCertificates = possibleEmbeddedCerts;
+                }
+            }
+        }
         return getCertificateAuthorityInfoHelper(certificateRepository, caCertificateRepository,
-                certificate,
-                notFoundMessage);
+                certificate, embeddedCertificates, notFoundMessage);
     }
 
     /**
@@ -379,6 +431,7 @@ public final class CertificateStringMapBuilder {
             final CertificateRepository certificateRepository,
             final CACredentialRepository caCertificateRepository,
             final CertificateAuthorityCredential certificateAuthorityCredential,
+            final List<CertificateAuthorityCredential> embeddedCertificates,
             final String notFoundMessage) {
 
         if (certificateAuthorityCredential == null) {
@@ -388,7 +441,7 @@ public final class CertificateStringMapBuilder {
 
         HashMap<String, String> data =
                 new HashMap<>(getGeneralCertificateInfo(certificateAuthorityCredential, certificateRepository,
-                        caCertificateRepository));
+                        caCertificateRepository, embeddedCertificates));
 
         data.put("subjectKeyIdentifier", Arrays.toString(certificateAuthorityCredential.getSubjectKeyIdentifier()));
         //x509 credential version
@@ -415,8 +468,8 @@ public final class CertificateStringMapBuilder {
                 (EndorsementCredential) certificateRepository.getCertificate(uuid);
 
         if (certificate != null) {
-            data.putAll(
-                    getGeneralCertificateInfo(certificate, certificateRepository, caCertificateRepository));
+            data.putAll(getGeneralCertificateInfo(certificate, certificateRepository,
+                    caCertificateRepository, Collections.emptyList()));
             // Set extra fields
             data.put("manufacturer", certificate.getManufacturer());
             data.put("model", certificate.getModel());
@@ -484,8 +537,8 @@ public final class CertificateStringMapBuilder {
         PlatformCredential certificate = (PlatformCredential) certificateRepository.getCertificate(uuid);
 
         if (certificate != null) {
-            data.putAll(
-                    getGeneralCertificateInfo(certificate, certificateRepository, caCertificateRepository));
+            data.putAll(getGeneralCertificateInfo(certificate, certificateRepository,
+                            caCertificateRepository, Collections.emptyList()));
             data.put("credentialType", certificate.getCredentialType());
             data.put("platformType", certificate.getPlatformChainType());
             data.put("manufacturer", certificate.getManufacturer());
@@ -724,8 +777,8 @@ public final class CertificateStringMapBuilder {
                 (IssuedAttestationCertificate) certificateRepository.getCertificate(uuid);
 
         if (certificate != null) {
-            data.putAll(
-                    getGeneralCertificateInfo(certificate, certificateRepository, caCredentialRepository));
+            data.putAll(getGeneralCertificateInfo(certificate, certificateRepository,
+                    caCredentialRepository, Collections.emptyList()));
 
             // add endorsement credential ID if not null
             if (certificate.getEndorsementCredential() != null) {
@@ -791,8 +844,8 @@ public final class CertificateStringMapBuilder {
         IDevIDCertificate certificate = (IDevIDCertificate) certificateRepository.getCertificate(uuid);
 
         if (certificate != null) {
-            data.putAll(
-                    getGeneralCertificateInfo(certificate, certificateRepository, caCredentialRepository));
+            data.putAll(getGeneralCertificateInfo(certificate, certificateRepository,
+                    caCredentialRepository, Collections.emptyList()));
 
             if (certificate.getHwType() != null) {
                 data.put("hwType", certificate.getHwType());

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -330,8 +330,14 @@ public final class CertificateStringMapBuilder {
             certificate = caCertificateRepository.getReferenceById(uuid);
         }
 
-        if (certificate == null) {
-            Iterable<ReferenceManifest> rims = referenceManifestRepository.findAll();
+        if (certificate == null && referenceManifestRepository != null) {
+            Iterable<ReferenceManifest> rims;
+            try {
+                rims = referenceManifestRepository.findAll();
+            } catch (Exception e) {
+                log.warn("RIM repository unavailable during embedded cert lookup");
+                rims = Collections.emptyList();
+            }
             for (ReferenceManifest rim : rims) {
                 if (!rim.isBase()) {
                     continue;
@@ -345,12 +351,8 @@ public final class CertificateStringMapBuilder {
                 for (CertificateAuthorityCredential embeddedCert : embeddedCerts) {
                     UUID certId = embeddedCert.getId();
                     if (certId != null && certId.equals(uuid)) {
-                        certificate = caCertificateRepository
-                                .findBySubjectKeyIdStringAndArchiveFlag(
-                                        embeddedCert.getSubjectKeyIdString(), false);
-                        if (certificate != null) {
-                            break;
-                        }
+                        certificate = embeddedCert;
+                        break;
                     }
                 }
                 if (certificate != null) {

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -19,7 +19,6 @@ import hirs.attestationca.persist.entity.userdefined.certificate.attributes.V2.C
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.V2.PlatformConfigurationV2;
 import hirs.attestationca.persist.entity.userdefined.rim.BaseReferenceManifest;
 import hirs.attestationca.persist.exceptions.NonUniqueSKIException;
-import hirs.attestationca.persist.service.ReferenceManifestDetailsPageService;
 import hirs.attestationca.persist.util.AcaPciIds;
 import hirs.utils.BouncyCastleUtils;
 import hirs.utils.PciIds;
@@ -84,6 +83,7 @@ public final class CertificateStringMapBuilder {
      * @param certificate             certificate to get the general information.
      * @param caCertificateRepository CA Certificate repository
      * @param certificateRepository   the certificate repository for retrieving certs.
+     * @param embeddedCertificates    embedded certificates extracted from a rim
      * @return a hash map with the general certificate information.
      */
     public static HashMap<String, String> getGeneralCertificateInfo(
@@ -215,9 +215,8 @@ public final class CertificateStringMapBuilder {
                     }
                     if (keyIdMatch == null && embeddedCertificates != null) {
                         keyIdMatch = embeddedCertificates.stream()
-                                .filter(cert -> certificate.getAuthorityKeyIdentifier().equals(cert.getSubjectKeyIdString()))
-                                .findFirst()
-                                .orElse(null);
+                                .filter(cert -> certificate.getAuthorityKeyIdentifier()
+                                        .equals(cert.getSubjectKeyIdString())).findFirst().orElse(null);
                     }
                     if (keyIdMatch != null && keyIdMatch.getId() != null) {
                         data.put("issuerID", keyIdMatch.getId().toString());
@@ -265,6 +264,7 @@ public final class CertificateStringMapBuilder {
      *
      * @param certificate            certificate to get the issuer
      * @param caCredentialRepository CA Certificate repository
+     * @param embeddedCertificates   certificates extracted from a rim
      * @return a boolean indicating if it has the full chain or not.
      */
     public static Certificate containsAllChain(
@@ -361,30 +361,28 @@ public final class CertificateStringMapBuilder {
                                        final ReferenceManifestRepository referenceManifestRepository) {
 
         CertificateAuthorityCredential certificate = null;
-
+        Iterable<ReferenceManifest> rims = Collections.emptyList();
+        List<CertificateAuthorityCredential> embeddedCertificates = Collections.emptyList();
         if (caCertificateRepository.existsById(uuid)) {
             certificate = caCertificateRepository.getReferenceById(uuid);
         }
 
         if (certificate == null && referenceManifestRepository != null) {
-            Iterable<ReferenceManifest> rims;
             try {
                 rims = referenceManifestRepository.findAll();
             } catch (Exception e) {
                 log.warn("RIM repository unavailable during embedded cert lookup");
-                rims = Collections.emptyList();
             }
             for (ReferenceManifest rim : rims) {
                 if (!rim.isBase()) {
                     continue;
                 }
                 BaseReferenceManifest baseRim = (BaseReferenceManifest) rim;
-                List<CertificateAuthorityCredential> embeddedCerts =
-                        baseRim.getEmbeddedCertificates();
-                if (embeddedCerts == null || embeddedCerts.isEmpty()) {
+                embeddedCertificates = baseRim.getEmbeddedCertificates();
+                if (embeddedCertificates == null || embeddedCertificates.isEmpty()) {
                     continue;
                 }
-                for (CertificateAuthorityCredential embeddedCert : embeddedCerts) {
+                for (CertificateAuthorityCredential embeddedCert : embeddedCertificates) {
                     UUID certId = embeddedCert.getId();
                     if (certId != null && certId.equals(uuid)) {
                         certificate = embeddedCert;
@@ -393,27 +391,12 @@ public final class CertificateStringMapBuilder {
                 }
                 if (certificate != null) {
                     break;
+                } else {
+                    embeddedCertificates = Collections.emptyList();
                 }
             }
         }
         final String notFoundMessage = "Unable to find Certificate Authority Credential with ID: " + uuid;
-        List<CertificateAuthorityCredential> embeddedCertificates = Collections.emptyList();
-        if (referenceManifestRepository != null) {
-            for (ReferenceManifest rim : referenceManifestRepository.findAll()) {
-                if (!(rim instanceof BaseReferenceManifest baseRim)) {
-                    continue;
-                }
-                List<CertificateAuthorityCredential> possibleEmbeddedCerts = baseRim.getEmbeddedCertificates();
-                if (possibleEmbeddedCerts == null || possibleEmbeddedCerts.isEmpty()) {
-                    continue;
-                }
-                boolean contains = possibleEmbeddedCerts.stream()
-                        .anyMatch(c -> uuid.equals(c.getId()));
-                if (contains) {
-                    embeddedCertificates = possibleEmbeddedCerts;
-                }
-            }
-        }
         return getCertificateAuthorityInfoHelper(certificateRepository, caCertificateRepository,
                 certificate, embeddedCertificates, notFoundMessage);
     }
@@ -425,6 +408,7 @@ public final class CertificateStringMapBuilder {
      * @param caCertificateRepository        CA Certificate repository
      * @param certificateAuthorityCredential certificate authority credential
      * @param notFoundMessage                error message
+     * @param embeddedCertificates           certificates extracted from a rim
      * @return a hash map with the certificate authority credential information.
      */
     public static HashMap<String, String> getCertificateAuthorityInfoHelper(

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -19,6 +19,7 @@ import hirs.attestationca.persist.entity.userdefined.certificate.attributes.V2.C
 import hirs.attestationca.persist.entity.userdefined.certificate.attributes.V2.PlatformConfigurationV2;
 import hirs.attestationca.persist.entity.userdefined.rim.BaseReferenceManifest;
 import hirs.attestationca.persist.exceptions.NonUniqueSKIException;
+import hirs.attestationca.persist.service.ReferenceManifestDetailsPageService;
 import hirs.attestationca.persist.util.AcaPciIds;
 import hirs.utils.BouncyCastleUtils;
 import hirs.utils.PciIds;
@@ -314,6 +315,7 @@ public final class CertificateStringMapBuilder {
      * @param uuid                    ID for the certificate.
      * @param certificateRepository   the certificate manager for retrieving certs.
      * @param caCertificateRepository CA Certificate repository
+     * @param referenceManifestRepository rim repository
      * @return a hash map with the certificate authority credential information.
      */
     public static HashMap<String, String>

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
@@ -617,8 +617,16 @@
                         th:if="${not #strings.isEmpty(initialData.get('issuerID'))}">
                         Signing certificate
                     </a>
-                    <span th:text="${'Subject Key Identifier: ' + initialData.get('skID')}"
-                        th:if="${not #strings.isEmpty(initialData.get('skID'))}" />
+                    <div class="col col-md-8">
+                        <div th:each="id, iterStat : ${initialData.get('embeddedCertIds')}">
+                            <a th:href="@{/HIRS_AttestationCAPortal/portal/certificate-details(id=${id}, type='certificateauthority')}">
+                                Embedded Certificate <span th:text="${iterStat.index + 1}"></span>
+                            </a>
+                        </div>
+                        <div th:if="${#lists.isEmpty(initialData.get('embeddedCertIds')) and not #strings.isEmpty(initialData.get('skID'))}">
+                            <span th:text="${'Subject Key Identifier: ' + initialData.get('skID')}"></span>
+                        </div>
+                    </div>
                 </div><!--signature-->
             </div><!--signature row-->
         </th:block><!--Base RIM-->

--- a/HIRS_AttestationCAPortal/src/test/java/hirs/attestationca/portal/page/controllers/CertificateDetailsPageControllerTest.java
+++ b/HIRS_AttestationCAPortal/src/test/java/hirs/attestationca/portal/page/controllers/CertificateDetailsPageControllerTest.java
@@ -2,6 +2,7 @@ package hirs.attestationca.portal.page.controllers;
 
 import hirs.attestationca.persist.entity.manager.CertificateRepository;
 import hirs.attestationca.persist.entity.manager.DeviceRepository;
+import hirs.attestationca.persist.entity.manager.ReferenceManifestRepository;
 import hirs.attestationca.persist.entity.userdefined.Device;
 import hirs.attestationca.persist.entity.userdefined.certificate.CertificateAuthorityCredential;
 import hirs.attestationca.persist.entity.userdefined.certificate.EndorsementCredential;
@@ -73,6 +74,9 @@ public class CertificateDetailsPageControllerTest extends PageControllerTest {
     // Repository manager to handle data access between certificate entity and data storage in db
     @Autowired
     private CertificateRepository certificateRepository;
+
+    @Autowired
+    private ReferenceManifestRepository referenceManifestRepository;
 
     private CertificateAuthorityCredential caCertificate;
 

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -1,10 +1,6 @@
 package hirs.utils.rim;
 
 import hirs.utils.swid.SwidTagConstants;
-import jakarta.xml.bind.JAXBContext;
-import jakarta.xml.bind.JAXBException;
-import jakarta.xml.bind.UnmarshalException;
-import jakarta.xml.bind.Unmarshaller;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
@@ -16,10 +12,8 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 import javax.security.auth.x500.X500Principal;
-import javax.xml.XMLConstants;
 import javax.xml.crypto.AlgorithmMethod;
 import javax.xml.crypto.KeySelector;
 import javax.xml.crypto.KeySelectorException;
@@ -35,22 +29,12 @@ import javax.xml.crypto.dsig.dom.DOMValidateContext;
 import javax.xml.crypto.dsig.keyinfo.KeyInfo;
 import javax.xml.crypto.dsig.keyinfo.KeyValue;
 import javax.xml.crypto.dsig.keyinfo.X509Data;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -82,22 +66,15 @@ import java.util.stream.Stream;
 public class ReferenceManifestValidator {
     private static final String SIGNATURE_ALGORITHM_RSA_SHA256 =
             "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
-    private static final String SCHEMA_PACKAGE = "hirs.utils.xjc";
-    private static final String SCHEMA_URL = "swid_schema.xsd";
-    private static final String SCHEMA_LANGUAGE = XMLConstants.W3C_XML_SCHEMA_NS_URI;
-    private static final String IDENTITY_TRANSFORM = "identity_transform.xslt";
     private static final String SHA256 = "SHA-256";
     private static final int EIGHT_BIT_MASK = 0xff;
     private static final int LEFT_SHIFT = 0x100;
     private static final int RADIX = 16;
 
     private Document rim;
-    private Unmarshaller unmarshaller;
 
     @Getter
     private PublicKey publicKey;
-
-    private Schema schema;
 
     @Getter
     private String subjectKeyIdentifier;
@@ -128,24 +105,16 @@ public class ReferenceManifestValidator {
      * time during validation calls later.
      */
     public ReferenceManifestValidator() {
-        try {
-            Security.addProvider(new BouncyCastleProvider());
-            InputStream is = ReferenceManifestValidator.class
-                    .getClassLoader().getResourceAsStream(SCHEMA_URL);
-            SchemaFactory schemaFactory = SchemaFactory.newInstance(SCHEMA_LANGUAGE);
-            schema = schemaFactory.newSchema(new StreamSource(is));
-            rim = null;
-            hasSupportRim = false;
-            signatureValid = false;
-            supportRimValid = false;
-            supportRimDirectory = "";
-            publicKey = null;
-            trustStoreFile = null;
-            trustStore = null;
-            subjectKeyIdentifier = "(not found)";
-        } catch (SAXException e) {
-            log.warn("Error setting schema for validation!");
-        }
+        Security.addProvider(new BouncyCastleProvider());
+        rim = null;
+        hasSupportRim = false;
+        signatureValid = false;
+        supportRimValid = false;
+        supportRimDirectory = "";
+        publicKey = null;
+        trustStoreFile = null;
+        trustStore = null;
+        subjectKeyIdentifier = "(not found)";
     }
 
     /**
@@ -156,9 +125,8 @@ public class ReferenceManifestValidator {
      */
     public void setRim(final byte[] rimBytes) {
         try {
-            Document doc = validateSwidtagSchema(removeXMLWhitespace(new StreamSource(
+            this.rim = SwidTagParser.validateSwidtagSchema(SwidTagParser.removeXMLWhitespace(new StreamSource(
                     new ByteArrayInputStream(rimBytes))));
-            this.rim = doc;
         } catch (IOException e) {
             log.error("Error while unmarshalling rim bytes using the provided rim bytes: {}", e.getMessage());
         }
@@ -173,7 +141,7 @@ public class ReferenceManifestValidator {
     public void setRim(final String path) {
         File swidtagFile = new File(path);
         try {
-            Document doc = validateSwidtagSchema(removeXMLWhitespace(new StreamSource(swidtagFile)));
+            Document doc = SwidTagParser.validateSwidtagSchema(SwidTagParser.removeXMLWhitespace(new StreamSource(swidtagFile)));
             this.rim = doc;
         } catch (IOException e) {
             log.error("Error while unmarshalling rim bytes using the provided file path: {}", e.getMessage());
@@ -209,7 +177,7 @@ public class ReferenceManifestValidator {
 
             NodeList certElement = getXmlElement(XMLSignature.XMLNS, "X509Certificate");
             if (certElement.getLength() > 0) {
-                X509Certificate embeddedCert = parseCertFromPEMString(
+                X509Certificate embeddedCert = SwidTagParser.parseCertFromPEMString(
                         certElement.item(0).getTextContent());
                 if (embeddedCert != null) {
                     if (isCertChainValid(embeddedCert)) {
@@ -737,32 +705,6 @@ public class ReferenceManifestValidator {
     }
 
     /**
-     * This method extracts certificate bytes from a string. The bytes are assumed to be
-     * PEM format, and a header and footer are concatenated with the input string to
-     * facilitate proper parsing.
-     *
-     * @param pemString the input string
-     * @return an X509Certificate created from the string, or null
-     */
-    private X509Certificate parseCertFromPEMString(final String pemString) {
-        String certificateHeader = "-----BEGIN CERTIFICATE-----";
-        String certificateFooter = "-----END CERTIFICATE-----";
-        try {
-            CertificateFactory factory = CertificateFactory.getInstance("X.509");
-            InputStream inputStream = new ByteArrayInputStream((certificateHeader
-                    + System.lineSeparator()
-                    + pemString
-                    + System.lineSeparator()
-                    + certificateFooter).getBytes(StandardCharsets.UTF_8));
-            return (X509Certificate) factory.generateCertificate(inputStream);
-        } catch (CertificateException e) {
-            log.warn("Error creating CertificateFactory instance: {}", e.getMessage());
-        }
-
-        return null;
-    }
-
-    /**
      * This method returns the X509Certificates found in a PEM file.
      * Unchecked type case warnings are suppressed because the CertificateFactory
      * implements X509Certificate objects explicitly.
@@ -857,58 +799,6 @@ public class ReferenceManifestValidator {
         }
 
         return xmlElement;
-    }
-
-    /**
-     * This method validates the Document against the schema.
-     *
-     * @param doc of the input swidtag.
-     * @return document validated against the schema.
-     */
-    private Document validateSwidtagSchema(final Document doc) {
-        try {
-            JAXBContext jaxbContext = JAXBContext.newInstance(SCHEMA_PACKAGE);
-            unmarshaller = jaxbContext.createUnmarshaller();
-            unmarshaller.setSchema(schema);
-            unmarshaller.unmarshal(doc);
-        } catch (UnmarshalException e) {
-            log.warn("Error validating swidtag file!");
-        } catch (IllegalArgumentException e) {
-            log.warn("Input file empty.");
-        } catch (JAXBException e) {
-            e.printStackTrace();
-        }
-
-        return doc;
-    }
-
-    /**
-     * This method strips all whitespace from an xml file, including indents and spaces
-     * added for human-readability.
-     *
-     * @param source of the input xml.
-     * @return Document representation of the xml.
-     */
-    private Document removeXMLWhitespace(final StreamSource source) throws IOException {
-        TransformerFactory tf = TransformerFactory.newInstance();
-        Source identitySource = new StreamSource(
-                ReferenceManifestValidator.class.getClassLoader()
-                        .getResourceAsStream(IDENTITY_TRANSFORM));
-        Document doc = null;
-        try {
-            Transformer transformer = tf.newTransformer(identitySource);
-            DOMResult result = new DOMResult();
-            transformer.transform(source, result);
-            doc = (Document) result.getNode();
-        } catch (TransformerConfigurationException e) {
-            log.warn("Error configuring transformer!");
-            e.printStackTrace();
-        } catch (TransformerException e) {
-            log.warn("Error transforming input!");
-            e.printStackTrace();
-        }
-
-        return doc;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -51,6 +51,7 @@ import java.security.SignatureException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -99,6 +100,9 @@ public class ReferenceManifestValidator {
     @Getter
     private String validationErrorMessage;
 
+    @Getter
+    private X509Certificate signingCertificate;
+
     /**
      * This default constructor creates the Schema object from SCHEMA_URL immediately to save
      * time during validation calls later.
@@ -110,7 +114,6 @@ public class ReferenceManifestValidator {
         signatureValid = false;
         supportRimValid = false;
         supportRimDirectory = "";
-        publicKey = null;
         trustStoreFile = null;
         trustStore = null;
         subjectKeyIdentifier = "(not found)";
@@ -164,7 +167,6 @@ public class ReferenceManifestValidator {
      * or the RIM's subject key identifier.  If the cert is matched then validation proceeds,
      * otherwise validation ends.
      *
-     * @param publicKey          public key from the CA credential
      * @param subjectKeyIdString string version of the subjet key id of the CA credential
      * @return true if the signature element is validated, false otherwise
      */
@@ -187,15 +189,23 @@ public class ReferenceManifestValidator {
 
             NodeList certElement = getXmlElement(XMLSignature.XMLNS, "X509Certificate");
             if (certElement.getLength() > 0) {
-                X509Certificate embeddedCert = SwidTagParser.parseCertFromPEMString(
-                        certElement.item(0).getTextContent());
-                if (embeddedCert != null) {
-                    if (isCertChainValid(embeddedCert)) {
-                        context = new DOMValidateContext(new X509KeySelector(), nodes.item(0));
-                        subjectKeyIdentifier = getCertificateSubjectKeyIdentifier(embeddedCert);
-                    } else {
-                        validationErrorMessage += "embedded cert chain invalid.";
+                List<X509Certificate> embeddedCerts =
+                        SwidTagParser.getEmbeddedX509Certificates(rim);
+                if (embeddedCerts != null && !embeddedCerts.isEmpty()) {
+                    for (X509Certificate embeddedCert : embeddedCerts) {
+                        if (isCertChainValid(embeddedCert)) {
+                            context = new DOMValidateContext(new X509KeySelector(), nodes.item(0));
+                            subjectKeyIdentifier = getCertificateSubjectKeyIdentifier(embeddedCert);
+                            validationErrorMessage = "";
+                            this.publicKey = publicKey;
+                            signatureValid = validateSignedXMLDocument(context);
+                            if (signatureValid) {
+                                signingCertificate = embeddedCert;
+                                return true;
+                            }
+                        }
                     }
+                    validationErrorMessage += "embedded certs present but signature validation failed";
                 } else {
                     validationErrorMessage += "embedded cert is null.";
                 }
@@ -869,8 +879,7 @@ public class ReferenceManifestValidator {
                         if (object instanceof X509Certificate embeddedCert) {
                             try {
                                 if ((subjectName.isEmpty() || BouncyCastleUtils.x500NameCompare(
-                                        embeddedCert.getSubjectX500Principal().getName(), subjectName))
-                                        && isCertChainValid(embeddedCert)) {
+                                        embeddedCert.getSubjectX500Principal().getName(), subjectName))) {
                                     publicKey = embeddedCert.getPublicKey();
                                     signingCert = embeddedCert;
                                     log.info("Certificate chain valid.");

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -51,7 +51,6 @@ import java.security.SignatureException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -167,6 +166,7 @@ public class ReferenceManifestValidator {
      * or the RIM's subject key identifier.  If the cert is matched then validation proceeds,
      * otherwise validation ends.
      *
+     * @param publicKey          public key from the CA credential
      * @param subjectKeyIdString string version of the subjet key id of the CA credential
      * @return true if the signature element is validated, false otherwise
      */
@@ -929,7 +929,7 @@ public class ReferenceManifestValidator {
         public boolean areAlgorithmsEqual(final String uri, final String name) {
             return (uri.equals(SwidTagConstants.SIGNATURE_ALGORITHM_RSA_SHA256)
                     || uri.equals(SwidTagConstants.SIGNATURE_ALGORITHM_RSA_SHA384)
-		            || uri.equals(SwidTagConstants.SIGNATURE_ALGORITHM_RSA_SHA512))
+                    || uri.equals(SwidTagConstants.SIGNATURE_ALGORITHM_RSA_SHA512))
                     && name.equalsIgnoreCase("RSA");
         }
 

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -2,6 +2,7 @@ package hirs.utils.rim;
 
 import hirs.utils.BouncyCastleUtils;
 import hirs.utils.swid.SwidTagConstants;
+import jakarta.xml.bind.UnmarshalException;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
@@ -15,8 +16,6 @@ import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
-import javax.xml.XMLConstants;
-import javax.security.auth.x500.X500Principal;
 import javax.xml.crypto.AlgorithmMethod;
 import javax.xml.crypto.KeySelector;
 import javax.xml.crypto.KeySelectorException;
@@ -32,19 +31,8 @@ import javax.xml.crypto.dsig.dom.DOMValidateContext;
 import javax.xml.crypto.dsig.keyinfo.KeyInfo;
 import javax.xml.crypto.dsig.keyinfo.KeyValue;
 import javax.xml.crypto.dsig.keyinfo.X509Data;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.stream.StreamSource;
 import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -76,16 +64,6 @@ import java.util.stream.Stream;
  */
 @Log4j2
 public class ReferenceManifestValidator {
-    private static final String SIGNATURE_ALGORITHM_RSA_SHA256 =
-            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
-    private static final String SIGNATURE_ALGORITHM_RSA_SHA384 =
-            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
-    private static final String SIGNATURE_ALGORITHM_RSA_SHA512 =
-	    "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
-    private static final String SCHEMA_PACKAGE = "hirs.utils.xjc";
-    private static final String SCHEMA_URL = "swid_schema.xsd";
-    private static final String SCHEMA_LANGUAGE = XMLConstants.W3C_XML_SCHEMA_NS_URI;
-    private static final String IDENTITY_TRANSFORM = "identity_transform.xslt";
     private static final String SHA256 = "SHA-256";
     private static final int EIGHT_BIT_MASK = 0xff;
     private static final int LEFT_SHIFT = 0x100;
@@ -153,7 +131,7 @@ public class ReferenceManifestValidator {
         } catch (IOException e) {
             log.error("Error while reading the RIM bytes: {}", e.getMessage());
             throw new IOException(e);
-        } catch (SAXException e) {
+        } catch (SAXException | UnmarshalException e) {
             log.error("Error while parsing the RIM bytes: {}", e.getMessage());
             throw new RuntimeException(e);
         }
@@ -174,7 +152,7 @@ public class ReferenceManifestValidator {
         } catch (IOException e) {
             log.error("Error while reading {}: {}", path, e.getMessage());
             throw new IOException(e);
-        } catch (SAXException e) {
+        } catch (SAXException | UnmarshalException e) {
             log.error("Error while parsing {}: {}", path, e.getMessage());
             throw new IOException(e);
         }
@@ -941,8 +919,8 @@ public class ReferenceManifestValidator {
          */
         public boolean areAlgorithmsEqual(final String uri, final String name) {
             return (uri.equals(SwidTagConstants.SIGNATURE_ALGORITHM_RSA_SHA256)
-                    || uri.equals(SIGNATURE_ALGORITHM_RSA_SHA384)
-		    || uri.equals(SIGNATURE_ALGORITHM_RSA_SHA512))
+                    || uri.equals(SwidTagConstants.SIGNATURE_ALGORITHM_RSA_SHA384)
+		            || uri.equals(SwidTagConstants.SIGNATURE_ALGORITHM_RSA_SHA512))
                     && name.equalsIgnoreCase("RSA");
         }
 

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -543,7 +543,6 @@ public class ReferenceManifestValidator {
             if (isValid) {
                 String successMessage = "XML signature verified.";
                 log.info(successMessage);
-                System.out.println(successMessage);
                 return true;
             } else {
                 whySignatureInvalid(signature, context);

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
@@ -14,7 +14,6 @@ import javax.xml.crypto.dsig.XMLSignature;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.*;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -74,7 +73,7 @@ public class SwidTagParser {
      *
      * @return the embedded X509Certificate if present, null otherwise.
      */
-    public static List<X509Certificate> getEmbeddedCertificates(Document rim) {
+    public static List<X509Certificate> getEmbeddedX509Certificates(Document rim) {
         if (rim == null) {
             log.warn("Cannot extract embedded certificate; RIM Document is null.");
             return null;

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
@@ -1,0 +1,145 @@
+package hirs.utils.rim;
+
+import hirs.utils.swid.SwidTagConstants;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.UnmarshalException;
+import jakarta.xml.bind.Unmarshaller;
+import lombok.extern.log4j.Log4j2;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.crypto.dsig.XMLSignature;
+import javax.xml.transform.*;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class handles parsing and validation Swidtag files.
+ */
+@Log4j2
+public class SwidTagParser {
+
+    /**
+     * This method validates the Document against the schema.
+     *
+     * @param doc of the input swidtag.
+     * @return document validated against the schema.
+     */
+    public static Document validateSwidtagSchema(final Document doc) {
+        SchemaFactory schemaFactory = SchemaFactory.newInstance(SwidTagConstants.SCHEMA_LANGUAGE);
+        try (InputStream is = SwidTagParser.class.getClassLoader().getResourceAsStream(
+                SwidTagConstants.SCHEMA_URL)) {
+            Schema schema = schemaFactory.newSchema(new StreamSource(is));
+            JAXBContext jaxbContext = JAXBContext.newInstance(SwidTagConstants.SCHEMA_PACKAGE);
+            Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
+            unmarshaller.setSchema(schema);
+            unmarshaller.unmarshal(doc);
+        } catch (UnmarshalException e) {
+            log.warn("Error validating swidtag file!");
+        } catch (IllegalArgumentException e) {
+            log.warn("Input file empty.");
+        } catch (JAXBException | SAXException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            log.error(e.getMessage());
+        }
+        return doc;
+    }
+
+    /**
+     * Retrieves the embedded X509Certificate structure(s)
+     * after the RIM document has been set and unmarshalled.
+     *
+     * @return the embedded X509Certificate if present, null otherwise.
+     */
+    public static List<X509Certificate> getEmbeddedCertificates(Document rim) {
+        if (rim == null) {
+            log.warn("Cannot extract embedded certificate; RIM Document is null.");
+            return null;
+        }
+        try {
+            NodeList certNodes = rim.getElementsByTagNameNS(
+                    XMLSignature.XMLNS, "X509Certificate"
+            );
+            List<X509Certificate> certs = new ArrayList<>();
+            if (certNodes.getLength() > 0) {
+                for (int i = 0; i < certNodes.getLength(); i++) {
+                    String certBase64 = certNodes.item(i).getTextContent();
+                    X509Certificate cert = parseCertFromPEMString(certBase64);
+                    certs.add(cert);
+                }
+            }
+            return certs;
+        } catch (Exception e) {
+            log.error("Failed to parse embedded certificate string from DOM element", e);
+        }
+        return null;
+    }
+
+    /**
+     * This method extracts certificate bytes from a string. The bytes are assumed to be
+     * PEM format, and a header and footer are concatenated with the input string to
+     * facilitate proper parsing.
+     *
+     * @param pemString the input string
+     * @return an X509Certificate created from the string, or null
+     */
+    public static X509Certificate parseCertFromPEMString(final String pemString) {
+        String certificateHeader = "-----BEGIN CERTIFICATE-----";
+        String certificateFooter = "-----END CERTIFICATE-----";
+        try {
+            CertificateFactory factory = CertificateFactory.getInstance("X.509");
+            InputStream inputStream = new ByteArrayInputStream((certificateHeader
+                    + System.lineSeparator()
+                    + pemString
+                    + System.lineSeparator()
+                    + certificateFooter).getBytes(StandardCharsets.UTF_8));
+            return (X509Certificate) factory.generateCertificate(inputStream);
+        } catch (CertificateException e) {
+            log.warn("Error creating CertificateFactory instance: {}", e.getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * This method strips all whitespace from an xml file, including indents and spaces
+     * added for human-readability.
+     *
+     * @param source of the input xml.
+     * @return Document representation of the xml.
+     */
+    public static Document removeXMLWhitespace(final StreamSource source) throws IOException {
+        Document doc = null;
+        try {
+            TransformerFactory tf = TransformerFactory.newInstance();
+            Source identitySource = new StreamSource(
+                    ReferenceManifestValidator.class.getClassLoader()
+                            .getResourceAsStream(SwidTagConstants.IDENTITY_TRANSFORM));
+            Transformer transformer = tf.newTransformer(identitySource);
+            DOMResult result = new DOMResult();
+            transformer.transform(source, result);
+            doc = (Document) result.getNode();
+        } catch (TransformerConfigurationException e) {
+            log.warn("Error configuring transformer!");
+            e.printStackTrace();
+        } catch (TransformerException e) {
+            log.warn("Error transforming input!");
+            e.printStackTrace();
+        }
+        return doc;
+    }
+}

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
@@ -11,12 +11,15 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import javax.xml.crypto.dsig.XMLSignature;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.*;
-import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -38,17 +41,23 @@ public class SwidTagParser {
      * @param doc of the input swidtag.
      * @return document validated against the schema.
      */
-    public static Document validateSwidtagSchema(final Document doc) {
-        SchemaFactory schemaFactory = SchemaFactory.newInstance(SwidTagConstants.SCHEMA_LANGUAGE);
+    public static Document validateSwidtagSchema(final Document doc) throws UnmarshalException {
+
         try (InputStream is = SwidTagParser.class.getClassLoader().getResourceAsStream(
                 SwidTagConstants.SCHEMA_URL)) {
+            if (is == null) {
+                log.error("Schema resource not found");
+                return null;
+            }
+            SchemaFactory schemaFactory = SchemaFactory.newInstance(SwidTagConstants.SCHEMA_LANGUAGE);
             Schema schema = schemaFactory.newSchema(new StreamSource(is));
             JAXBContext jaxbContext = JAXBContext.newInstance(SwidTagConstants.SCHEMA_PACKAGE);
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
             unmarshaller.setSchema(schema);
             unmarshaller.unmarshal(doc);
+            return doc;
         } catch (UnmarshalException e) {
-            log.warn("Error validating swidtag file!");
+            throw new UnmarshalException("Error parsing Base RIM: " + e.getCause());
         } catch (IllegalArgumentException e) {
             log.warn("Input file empty.");
         } catch (JAXBException | SAXException e) {
@@ -56,7 +65,7 @@ public class SwidTagParser {
         } catch (IOException e) {
             log.error(e.getMessage());
         }
-        return doc;
+        return null;
     }
 
     /**
@@ -116,30 +125,38 @@ public class SwidTagParser {
     }
 
     /**
-     * This method strips all whitespace from an xml file, including indents and spaces
-     * added for human-readability.
+     * This method converts a byte array to a Document object.
      *
-     * @param source of the input xml.
-     * @return Document representation of the xml.
+     * @param bytes data in
+     * @return a Document object representing the data in
+     * @throws ParserConfigurationException
+     * @throws IOException
+     * @throws SAXException
      */
-    public static Document removeXMLWhitespace(final StreamSource source) throws IOException {
-        Document doc = null;
-        try {
-            TransformerFactory tf = TransformerFactory.newInstance();
-            Source identitySource = new StreamSource(
-                    ReferenceManifestValidator.class.getClassLoader()
-                            .getResourceAsStream(SwidTagConstants.IDENTITY_TRANSFORM));
-            Transformer transformer = tf.newTransformer(identitySource);
-            DOMResult result = new DOMResult();
-            transformer.transform(source, result);
-            doc = (Document) result.getNode();
-        } catch (TransformerConfigurationException e) {
-            log.warn("Error configuring transformer!");
-            e.printStackTrace();
-        } catch (TransformerException e) {
-            log.warn("Error transforming input!");
-            e.printStackTrace();
-        }
-        return doc;
+    public static Document convertToDocument(final byte[] bytes)
+            throws ParserConfigurationException, IOException, SAXException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder builder = dbf.newDocumentBuilder();
+        ByteArrayInputStream bytesIn = new ByteArrayInputStream(bytes);
+        return builder.parse(bytesIn);
+    }
+
+    /**
+     * This method reads a file from the system and converts it to a Document object.
+     *
+     * @param filename String
+     * @return Document object representing the file
+     * @throws ParserConfigurationException
+     * @throws IOException
+     * @throws SAXException
+     */
+    public static Document convertToDocument(final String filename)
+            throws ParserConfigurationException, IOException, SAXException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder builder = dbf.newDocumentBuilder();
+        File fileIn = new File(filename);
+        return builder.parse(fileIn);
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
@@ -35,6 +35,12 @@ import java.util.List;
 public class SwidTagParser {
 
     /**
+     * Private constructor for utility class.
+     */
+    private SwidTagParser() {
+    }
+
+    /**
      * This method validates the Document against the schema.
      *
      * @param doc of the input swidtag.
@@ -71,9 +77,10 @@ public class SwidTagParser {
      * Retrieves the embedded X509Certificate structure(s)
      * after the RIM document has been set and unmarshalled.
      *
+     * @param rim the RIM document to extract embedded certs from.
      * @return the embedded X509Certificate if present, null otherwise.
      */
-    public static List<X509Certificate> getEmbeddedX509Certificates(Document rim) {
+    public static List<X509Certificate> getEmbeddedX509Certificates(final Document rim) {
         if (rim == null) {
             log.warn("Cannot extract embedded certificate; RIM Document is null.");
             return null;

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
@@ -32,7 +32,7 @@ import java.util.List;
  * This class handles parsing and validation Swidtag files.
  */
 @Log4j2
-public class SwidTagParser {
+public final class SwidTagParser {
 
     /**
      * Private constructor for utility class.

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/xml/pcclientrim/PcClientRim.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/xml/pcclientrim/PcClientRim.java
@@ -117,11 +117,11 @@ public class PcClientRim extends SwidTagGateway implements GenericRim {
     }
 
     /**
-     * This method clones a Document object's data into a new Document
+     * This method clones a Document object's data into a new Document.
      * @param doc to copy from
      * @return a new, identical doc
      */
-    private Document copyDoc(Document doc) {
+    private Document copyDoc(final Document doc) {
         try {
             TransformerFactory tf = TransformerFactory.newInstance();
             Transformer t = tf.newTransformer();

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
@@ -20,6 +20,7 @@ public final class SwidTagConstants {
     public static final String SCHEMA_PACKAGE = "hirs.utils.xjc";
     public static final String SCHEMA_LANGUAGE = XMLConstants.W3C_XML_SCHEMA_NS_URI;
     public static final String SCHEMA_URL = "swid_schema.xsd";
+    public static final String IDENTITY_TRANSFORM = "identity_transform.xslt";
     public static final String SWIDTAG_NAMESPACE = "http://standards.iso.org/iso/19770/-2/2015/schema.xsd";
     public static final String SOFTWARE_IDENTITY = "SoftwareIdentity";
     public static final String ENTITY = "Entity";

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
@@ -17,6 +17,10 @@ public final class SwidTagConstants {
     public static final String DEFAULT_ENGLISH = "en";
     public static final String SIGNATURE_ALGORITHM_RSA_SHA256 =
             "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+    public static final String SIGNATURE_ALGORITHM_RSA_SHA384 =
+            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
+    public static final String SIGNATURE_ALGORITHM_RSA_SHA512 =
+            "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
     public static final String SCHEMA_PACKAGE = "hirs.utils.xjc";
     public static final String SCHEMA_LANGUAGE = XMLConstants.W3C_XML_SCHEMA_NS_URI;
     public static final String SCHEMA_URL = "swid_schema.xsd";


### PR DESCRIPTION
Currently, if a Base RIM contains an embedded certificate(s), the user has no way of knowing.

This PR adds functionality to the Base RIM details page that indicate whether it contains embedded certificates by providing links. These links direct the user to a certificate-details page that describes the respective embedded certificate.

If a Base RIM does not have an embedded certificate, the SKID is displayed instead (already existing behavior).

Some things to note:

- All RIM signature validation up to now has been done by looking through the CA repository. In this PR, I essentially made a new route in several parts of the "upload" and "verify" code to save and access embedded certs from the RIM repository as well.
- These embedded certificates do not persist in the DB as `Certificates `and are not intended to. Instead I saved them as fields on `BaseReferenceManifest `objects. To ensure they can be retrieved from the RIM details page, I set the embedded certificate's ID to a newly generate UUID, which can be used as parameters to retrieve that embedded certificate for display. After this I `save` the base RIM into the RIM repository to update it with the embedded certs.
- To allow both "upload" and "verify" code to use XML parsing methods and touch the signature block (where the embedded cert lives), I created a utility class `SwidTagParser` and put overlapping parsing methods into that class for public static use. More refactoring is possible, but was not yet necessary for this PR. Can make an issue to finish refactoring parsing methods later.
- Assumes embedded certificates are of type `CertificateAuthorityCredential`. Other type may be embedded in the future, so will add an issue to the backlog for it.

To test:
1. Spin up ACA from this branch
2. View details of a Base RIM that has an embedded certificate(s). There should be link(s) at the bottom of the details page that indicate that this RIM has embedded certificate(s). Upon clicking a link, ensure that it goes to a certificate-details page that describes all the fields of the respective embedded certificate.
3. The embedded intermediate certificate will have the URI to the Root CA in the "Authority Access Info" section. Download the cert at that URI and upload it to the ACA. This will result in: Root CA in trust store, Intermediate + Leaf certs embedded in RIM. After Root CA is uploaded, the chain should be validated as complete, and certificate-details for both embedded certs should now have a green checkmark. The RIM details page should also have a green checkmark.
4. Upon clicking "Signing Certificate", ensure that the correct signing certificate for that RIM is displayed.
5. View details of a Base RIM that does NOT have an embedded certificate. It should display the SKID at the bottom instead.

Resolves #1194 