### PR TITLE
Add robustness to EK parsing for both implicit and explicit fields

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/EndorsementCredential.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/certificate/EndorsementCredential.java
@@ -431,7 +431,18 @@ public class EndorsementCredential extends DeviceAssociatedCertificate {
                                 unwrapTaggedObject(taggedObj)));
                         case EK_FIPS_TAG -> parseFipsLevel(ASN1Sequence.getInstance(unwrapTaggedObject(taggedObj)));
                         case EK_ISO_9000_CERT_TAG -> {
-                            this.iso9000Certified = ASN1Boolean.getInstance(taggedObj, false).isTrue();
+                            ASN1Primitive primitive = unwrapTaggedObject(taggedObj);
+                            if (primitive instanceof ASN1Boolean b) {
+                                this.iso9000Certified = b.isTrue();
+                            } else if (primitive instanceof ASN1OctetString oct) {
+                                byte[] bytes = oct.getOctets();
+                                if (bytes.length > 0) {
+                                    this.iso9000Certified = bytes[0] != 0;
+                                }
+                            } else {
+                                log.warn("Unexpected  for Iso9000Certified: {}", primitive.getClass());
+                                this.iso9000Certified = false;
+                            }
                         } default -> log.warn("Encountered unknown TPM Security Assertions tag "
                                 + "in Endorsement Credential: {}", tag);
                     }


### PR DESCRIPTION
Though the "TCG EK Credential Profile For TPM Family 2.0 (v2.7)" spec calls for TPMSecurityAssertions to be `implicit`, some certs from various companies and tools may still use `explicit`. To ensure the ACA can read them regardless, robustness should be maintained in EK cert parsing. This PR fixes in particular:

- Ability for ACA to parse EK certs whose `Iso9000Certified` field is `explicit`