### PR TITLE
Cleaned up Help and Version CLI output

### DIFF
--- a/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
+++ b/HIRS_Provisioner.NET/hirs/HIRS_Provisioner.NET.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="paccor.HardwareManifestPlugin" Version="2.1.0" />
     <PackageReference Include="paccor.HardwareManifestPluginManager" Version="2.1.0" />
-    <PackageReference Include="paccor.paccor_scripts" Version="2.5.1" />
+    <PackageReference Include="paccor.paccor_scripts" Version="2.5.2" />
     <PackageReference Include="paccor.pcie" Version="0.8.5" />
     <PackageReference Include="paccor.smbios" Version="0.8.5" />
     <PackageReference Include="paccor.storage" Version="0.8.5" />
@@ -87,7 +87,7 @@
     <Exec Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))'" Command="for /f %%i in ('dir /s /b $(FOLDER_PROTO)\*.proto') do (  $(protoc) -I=$(FOLDER_PROTO) --csharp_out=$(FOLDER_OUT) %%i )" />
     <Exec Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'" Command="for file in `ls -1R $(FOLDER_PROTO)/*.proto` ; do $(protoc) -I=$(FOLDER_PROTO) --csharp_out=$(FOLDER_OUT) $file; done " />
   </Target>
-  <Import Project="$(NuGetPackageRoot)paccor.paccor_scripts/2.5.1/contentFiles/any/net10.0/resources/paccor.paccor_scripts.targets" Condition="Exists('$(NuGetPackageRoot)paccor.paccor_scripts/2.5.1/contentFiles/any/net10.0/resources/paccor.paccor_scripts.targets')" />
+  <Import Project="$(NuGetPackageRoot)paccor.paccor_scripts/2.5.2/contentFiles/any/net10.0/resources/paccor.paccor_scripts.targets" Condition="Exists('$(NuGetPackageRoot)paccor.paccor_scripts/2.5.2/contentFiles/any/net10.0/resources/paccor.paccor_scripts.targets')" />
   <Target Name="ImportPaccorScripts" BeforeTargets="PreBuildEvent">
     <ItemGroup>
       <PaccorScriptsLinux Include="$(dotnet_paccor_scripts_directory)/*" />

--- a/HIRS_Provisioner.NET/hirs/src/Program.cs
+++ b/HIRS_Provisioner.NET/hirs/src/Program.cs
@@ -31,8 +31,10 @@ namespace hirs {
                         .WithParsed(parsed => cli = parsed)
                         .WithNotParsed(HandleParseError);
 
-                if (cliParseResult.Tag == ParserResultType.NotParsed) {
-                    // Help text requested, or parsing failed. Exit.
+                if (cliParseResult.Tag == ParserResultType.NotParsed
+                    && !cliParseResult.Errors.IsHelp()
+                    && !cliParseResult.Errors.IsVersion()) {
+                    // Parsing failed. Exit.
                     Log.Warning("Could not parse command line arguments. Set --tcp --sim, --tcp <ip>:<port>, --nix, or --win. See documentation for further assistance.");
                 } else {
                     Provisioner p = new(settings, cli);
@@ -51,8 +53,16 @@ namespace hirs {
         }
 
         private static void HandleParseError(IEnumerable<Error> errs) {
+            IEnumerable<Error> enumerable = errs.ToList();
+            if (enumerable.IsHelp() || enumerable.IsVersion()) 
+            {
+                return;
+            }
+            
             //handle errors
-            Log.Error("There was a CLI error: " + errs.ToString());
+            foreach (Error err in enumerable) {
+                Log.Error($"There was a CLI error: {err.Tag}");
+            }
         }
 
         private static bool IsRunningAsAdmin() {


### PR DESCRIPTION
Set paccor_scripts plugin to 2.5.2 to fix a line endings issue.
Cleaned up Help and Version CLI output

These commands should no longer include the CLI error encountered message:
tpm_aca_provision --help 
tpm_aca_provision --version
