### PR TITLE
Update Base RIM details page to add missing attributes

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/ReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/ReferenceManifest.java
@@ -131,6 +131,9 @@ public class ReferenceManifest extends ArchivableEntity {
     @JsonIgnore
     private String base64Hash = "";
 
+    @Column
+    private String payloadType = null;
+
     /**
      * Default constructor necessary for Hibernate.
      */

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/ReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/ReferenceManifest.java
@@ -106,6 +106,9 @@ public class ReferenceManifest extends ArchivableEntity {
     private String swidVersion = null;
 
     @Column
+    private String swidVersionScheme = null;
+
+    @Column
     private String platformModel = null;
 
     @Column(nullable = false)

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
@@ -94,8 +94,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
 
     private String entityRole = null;
 
-    private String entityThumbprint = null;
-
     private String linkHref = null;
 
     private String linkRel = null;
@@ -202,7 +200,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
             this.entityName = entity.getAttribute(SwidTagConstants.NAME);
             this.entityRegId = entity.getAttribute(SwidTagConstants.REGID);
             this.entityRole = entity.getAttribute(SwidTagConstants.ROLE);
-            this.entityThumbprint = entity.getAttribute(SwidTagConstants.THUMBPRINT);
         } else {
             log.warn("Entity Tag not found.");
         }

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
@@ -71,9 +71,6 @@ public class BaseReferenceManifest extends ReferenceManifest {
     private String platformVersion = null;
 
     @Column
-    private String payloadType = null;
-
-    @Column
     private String firmwareManufacturer = null;
 
     @Column
@@ -182,7 +179,7 @@ public class BaseReferenceManifest extends ReferenceManifest {
                     softwareMeta.getAttribute(SwidTagConstants.PLATFORM_MANUFACTURER_FULL_STR));
             this.setPlatformModel(softwareMeta.getAttribute(SwidTagConstants.PLATFORM_MODEL_STR));
             this.platformVersion = softwareMeta.getAttribute(SwidTagConstants.PLATFORM_VERSION_STR);
-            this.payloadType = softwareMeta.getAttribute(SwidTagConstants.PAYLOAD_TYPE_STR);
+            this.setPayloadType(softwareMeta.getAttribute(SwidTagConstants.PAYLOAD_TYPE_STR));
             this.firmwareManufacturer = softwareMeta.getAttribute(SwidTagConstants.FIRMWARE_MANUFACTURER_FULL_STR);
             this.firmwareManufacturerId = softwareMeta.getAttribute(SwidTagConstants.FIRMWARE_MANUFACTURER_ID_STR);
             this.firmwareModel = softwareMeta.getAttribute(SwidTagConstants.FIRMWARE_MODEL_STR);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
@@ -74,6 +74,18 @@ public class BaseReferenceManifest extends ReferenceManifest {
     private String payloadType = null;
 
     @Column
+    private String firmwareManufacturer = null;
+
+    @Column
+    private String firmwareManufacturerId = null;
+
+    @Column
+    private String firmwareModel = null;
+
+    @Column
+    private String firmwareVersion = null;
+
+    @Column
     private String pcURIGlobal = null;
 
     @Column
@@ -142,7 +154,7 @@ public class BaseReferenceManifest extends ReferenceManifest {
                     Boolean.parseBoolean(softwareIdentity.getAttribute(SwidTagConstants.SUPPLEMENTAL)));
             this.setSwidVersion(softwareIdentity.getAttribute(SwidTagConstants.VERSION));
             this.setSwidTagVersion(softwareIdentity.getAttribute(SwidTagConstants.TAGVERSION));
-
+            this.setSwidVersionScheme(softwareIdentity.getAttribute(SwidTagConstants.VERSION_SCHEME));
             parseSoftwareMeta(meta);
             parseEntity(entity);
             parseLink(link);
@@ -171,6 +183,10 @@ public class BaseReferenceManifest extends ReferenceManifest {
             this.setPlatformModel(softwareMeta.getAttribute(SwidTagConstants.PLATFORM_MODEL_STR));
             this.platformVersion = softwareMeta.getAttribute(SwidTagConstants.PLATFORM_VERSION_STR);
             this.payloadType = softwareMeta.getAttribute(SwidTagConstants.PAYLOAD_TYPE_STR);
+            this.firmwareManufacturer = softwareMeta.getAttribute(SwidTagConstants.FIRMWARE_MANUFACTURER_FULL_STR);
+            this.firmwareManufacturerId = softwareMeta.getAttribute(SwidTagConstants.FIRMWARE_MANUFACTURER_ID_STR);
+            this.firmwareModel = softwareMeta.getAttribute(SwidTagConstants.FIRMWARE_MODEL_STR);
+            this.firmwareVersion = softwareMeta.getAttribute(SwidTagConstants.FIRMWARE_VERSION_STR);
             this.pcURIGlobal = softwareMeta.getAttribute(SwidTagConstants.PC_URI_GLOBAL_STR);
             this.pcURILocal = softwareMeta.getAttribute(SwidTagConstants.PC_URI_LOCAL_STR);
         } else {
@@ -292,6 +308,18 @@ public class BaseReferenceManifest extends ReferenceManifest {
             swidResource.setSize(file.getAttribute(SwidTagConstants.SIZE));
             swidResource.setHashValue(file.getAttribute(SwidTagConstants.SHA_256_HASH.getPrefix() + ":"
                     + SwidTagConstants.SHA_256_HASH.getLocalPart()));
+            swidResource.setRimFormat(
+                    file.getAttributeNS(
+                            SwidTagConstants.QNAME_SUPPORT_RIM_FORMAT.getNamespaceURI(),
+                            SwidTagConstants.QNAME_SUPPORT_RIM_FORMAT.getLocalPart()));
+            swidResource.setRimType(
+                    file.getAttributeNS(
+                            SwidTagConstants.QNAME_SUPPORT_RIM_TYPE.getNamespaceURI(),
+                            SwidTagConstants.QNAME_SUPPORT_RIM_TYPE.getLocalPart()));
+            swidResource.setRimUriGlobal(
+                    file.getAttributeNS(
+                            SwidTagConstants.QNAME_SUPPORT_RIM_URI_GLOBAL.getNamespaceURI(),
+                            SwidTagConstants.QNAME_SUPPORT_RIM_URI_GLOBAL.getLocalPart()));
             validHashes.add(swidResource);
         }
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -186,6 +186,7 @@ public class ReferenceManifestDetailsPageService {
         // Software Identity
         data.put("swidName", baseRim.getSwidName());
         data.put("swidVersion", baseRim.getSwidVersion());
+        data.put("swidVersionScheme", baseRim.getSwidVersionScheme());
         data.put("swidTagVersion", baseRim.getSwidTagVersion());
 
         if (baseRim.getSwidCorpus() == 1) {
@@ -242,6 +243,10 @@ public class ReferenceManifestDetailsPageService {
         data.put("revision", baseRim.getRevision());
         data.put("bindingSpec", baseRim.getBindingSpec());
         data.put("bindingSpecVersion", baseRim.getBindingSpecVersion());
+        data.put("firmwareManufacturer", baseRim.getFirmwareManufacturer());
+        data.put("firmwareManufacturerId", baseRim.getFirmwareManufacturerId());
+        data.put("firmwareModel", baseRim.getFirmwareModel());
+        data.put("firmwareVersion", baseRim.getFirmwareVersion());
         data.put("pcUriGlobal", baseRim.getPcURIGlobal());
         data.put("pcUriLocal", baseRim.getPcURILocal());
         data.put("rimLinkHash", baseRim.getRimLinkHash());

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -213,7 +213,6 @@ public class ReferenceManifestDetailsPageService {
         data.put("entityName", baseRim.getEntityName());
         data.put("entityRegId", baseRim.getEntityRegId());
         data.put("entityRole", baseRim.getEntityRole());
-        data.put("entityThumbprint", baseRim.getEntityThumbprint());
 
         // Link
         String linkHref = baseRim.getLinkHref();

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/reference-manifests.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/reference-manifests.html
@@ -41,6 +41,14 @@
                         data: "rimType",
                         orderable: true,
                         searchable: true,
+                        render: function (data, type, row) {
+                            const rimType = data || "";
+                            const payload = row.payloadType;
+                            if (!payload) {
+                                return rimType;
+                            }
+                            return rimType + "-" + payload;
+                        },
                         columnControl: ["searchDropdown"],
                     },
                     {
@@ -117,7 +125,7 @@
                     <tr>
                         <th></th>
                         <th>Tag Id</th>
-                        <th>Type</th>
+                        <th>Rim Type</th>
                         <th>Manufacturer</th>
                         <th>Model</th>
                         <th>Version</th>

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
@@ -369,6 +369,7 @@
                 <div id="softwareIdentity" class="col col-md-8">
                     <span th:text="${'SWID Name: ' + initialData.get('swidName')}" />
                     <span th:text="${'SWID Version: ' + initialData.get('swidVersion')}" />
+                    <span th:text="${'SWID Version Scheme: ' + initialData.get('swidVersionScheme')}" />
                     <span th:text="${'SWID Tag ID: ' + initialData.get('swidTagId')}" />
                     <span th:text="${'SWID Tag Version: ' + initialData.get('swidTagVersion')}" />
                     <span th:if="${initialData.get('swidCorpus')}">
@@ -397,7 +398,8 @@
                     <span th:text="${'Entity Reg ID: ' + initialData.entityRegId}"
                         th:if="${not #strings.isEmpty(initialData.entityRegId)}" />
                     <span th:text="${'Entity Role: ' + initialData.entityRole}" />
-                    <span th:text="${'Entity Thumbprint: ' + initialData.entityThumbprint}" />
+                    <span th:text="${'Entity Thumbprint: ' + initialData.entityThumbprint}"
+                        th:if="${not #strings.isEmpty(initialData.entityThumbprint)}" />
                 </div>
             </div><!--entity row-->
             <div class="rimrow">
@@ -429,16 +431,27 @@
                     <span th:text="${'Platform Model: ' + initialData.get('platformModel')}" />
                     <span th:text="${'Platform Version: ' + initialData.get('platformVersion')}"
                         th:if="${not #strings.isEmpty(initialData.get('platformVersion'))}" />
-                    <span th:text="${'Colloquial Version: ' + initialData.get('colloquialVersion')}" />
-                    <span th:text="${'Edition: ' + initialData.edition}" />
-                    <span th:text="${'Product: ' + initialData.get('product')}" />
-                    <span th:text="${'Revision: ' + initialData.get('revision')}" />
-                    <span th:text="${'Payload Type: ' + initialData.get('payloadType')}"
-                        th:if="${not #strings.isEmpty(initialData.get('payloadType'))}" />
+                    <span th:text="${'Colloquial Version: ' + initialData.get('colloquialVersion')}"
+                        th:if="${not #strings.isEmpty(initialData.get('colloquialVersion'))}" />
+                    <span th:text="${'Edition: ' + initialData.get('edition')}"
+                        th:if="${not #strings.isEmpty(initialData.get('edition'))}" />
+                    <span th:text="${'Product: ' + initialData.get('product')}"
+                        th:if="${not #strings.isEmpty(initialData.get('product'))}" />
+                    <span th:text="${'Revision: ' + initialData.get('revision')}"
+                        th:if="${not #strings.isEmpty(initialData.get('revision'))}" />
+                    <span th:text="${'Payload Type: ' + initialData.get('payloadType')}" />
+                    <span th:text="${'Firmware Manufacturer ID: ' + initialData.get('firmwareManufacturerId')}"
+                          th:if="${not #strings.isEmpty(initialData.get('firmwareManufacturerId'))}" />
+                    <span th:text="${'Firmware Manufacturer: ' + initialData.get('firmwareManufacturer')}"
+                          th:if="${not #strings.isEmpty(initialData.get('firmwareManufacturer'))}" />
+                    <span th:text="${'Firmware Model: ' + initialData.get('firmwareModel')}"
+                          th:if="${not #strings.isEmpty(initialData.get('firmwareModel'))}" />
+                    <span th:text="${'Firmware Version: ' + initialData.get('firmwareVersion')}"
+                          th:if="${not #strings.isEmpty(initialData.get('firmwareVersion'))}" />
                     <span th:text="${'Binding Spec: ' + initialData.get('bindingSpec')}" />
-                    <span th:text="${'Binding Spec Version: ' +initialData.get('bindingSpecVersion')}" />
-                    <span th:text="${'PC URI Global: ' + initialData.get('pcUriGlobal')}"
-                        th:if="${not #strings.isEmpty(initialData.get('pcUriGlobal'))}" />
+                    <span th:text="${'Binding Spec Version: ' + initialData.get('bindingSpecVersion')}" />
+                    <span th:text="${'PC URI Local: ' + initialData.get('pcUriLocal')}" />
+                    <span th:text="${'PC URI Global: ' + initialData.get('pcUriGlobal')}" />
                     <span th:text="${'Rim Link Hash: ' + initialData.get('rimLinkHash')}"
                         th:if="${#strings.isEmpty(initialData.get('rimLinkId'))}" />
                     <th:block th:unless="${#strings.isEmpty(initialData.get('rimLinkId'))}">
@@ -535,18 +548,18 @@
                                                                 style="overflow-wrap: break-word">[none]</span><br />
                                                             <th:block
                                                                 th:if="${not #strings.isEmpty(resource.rimFormat)}">
-                                                                <span class="fieldHeader">RIM Format:</span>
+                                                                <span class="fieldHeader">Support RIM Format:</span>
                                                                 <span class="fieldValue"
                                                                     th:text="${resource.rimFormat}" /><br />
                                                             </th:block>
                                                             <th:block th:if="${not #strings.isEmpty(resource.rimType)}">
-                                                                <span class="fieldHeader">RIM Type:</span>
+                                                                <span class="fieldHeader">Support RIM Type:</span>
                                                                 <span class="fieldValue"
                                                                     th:text="${resource.rimType}" /><br />
                                                             </th:block>
                                                             <th:block
                                                                 th:if="${not #strings.isEmpty(resource.rimUriGlobal)}">
-                                                                <span class="fieldHeader">URI Global:</span>
+                                                                <span class="fieldHeader">Support URI Global:</span>
                                                                 <span class="fieldValue"
                                                                     th:text="${resource.rimUriGlobal}" /><br />
                                                             </th:block>

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
@@ -398,8 +398,6 @@
                     <span th:text="${'Entity Reg ID: ' + initialData.entityRegId}"
                         th:if="${not #strings.isEmpty(initialData.entityRegId)}" />
                     <span th:text="${'Entity Role: ' + initialData.entityRole}" />
-                    <span th:text="${'Entity Thumbprint: ' + initialData.entityThumbprint}"
-                        th:if="${not #strings.isEmpty(initialData.entityThumbprint)}" />
                 </div>
             </div><!--entity row-->
             <div class="rimrow">

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
@@ -426,24 +426,24 @@
                     <span class="colHeader">Meta</span>
                 </div>
                 <div id="meta" class="col col-md-8">
-                    <span th:text="${'Platform Manufacturer ID: ' + initialData.get('platformManufacturerId')}" />
+                    <span th:text="${'Colloquial Version: ' + initialData.get('colloquialVersion')}"
+                          th:if="${not #strings.isEmpty(initialData.get('colloquialVersion'))}" />
+                    <span th:text="${'Edition: ' + initialData.get('edition')}"
+                          th:if="${not #strings.isEmpty(initialData.get('edition'))}" />
+                    <span th:text="${'Product: ' + initialData.get('product')}"
+                          th:if="${not #strings.isEmpty(initialData.get('product'))}" />
+                    <span th:text="${'Revision: ' + initialData.get('revision')}"
+                          th:if="${not #strings.isEmpty(initialData.get('revision'))}" />
+                    <span th:text="${'Payload Type: ' + initialData.get('payloadType')}" />
                     <span th:text="${'Platform Manufacturer: ' + initialData.get('platformManufacturer')}" />
+                    <span th:text="${'Platform Manufacturer ID: ' + initialData.get('platformManufacturerId')}" />
                     <span th:text="${'Platform Model: ' + initialData.get('platformModel')}" />
                     <span th:text="${'Platform Version: ' + initialData.get('platformVersion')}"
                         th:if="${not #strings.isEmpty(initialData.get('platformVersion'))}" />
-                    <span th:text="${'Colloquial Version: ' + initialData.get('colloquialVersion')}"
-                        th:if="${not #strings.isEmpty(initialData.get('colloquialVersion'))}" />
-                    <span th:text="${'Edition: ' + initialData.get('edition')}"
-                        th:if="${not #strings.isEmpty(initialData.get('edition'))}" />
-                    <span th:text="${'Product: ' + initialData.get('product')}"
-                        th:if="${not #strings.isEmpty(initialData.get('product'))}" />
-                    <span th:text="${'Revision: ' + initialData.get('revision')}"
-                        th:if="${not #strings.isEmpty(initialData.get('revision'))}" />
-                    <span th:text="${'Payload Type: ' + initialData.get('payloadType')}" />
-                    <span th:text="${'Firmware Manufacturer ID: ' + initialData.get('firmwareManufacturerId')}"
-                          th:if="${not #strings.isEmpty(initialData.get('firmwareManufacturerId'))}" />
                     <span th:text="${'Firmware Manufacturer: ' + initialData.get('firmwareManufacturer')}"
                           th:if="${not #strings.isEmpty(initialData.get('firmwareManufacturer'))}" />
+                    <span th:text="${'Firmware Manufacturer ID: ' + initialData.get('firmwareManufacturerId')}"
+                          th:if="${not #strings.isEmpty(initialData.get('firmwareManufacturerId'))}" />
                     <span th:text="${'Firmware Model: ' + initialData.get('firmwareModel')}"
                           th:if="${not #strings.isEmpty(initialData.get('firmwareModel'))}" />
                     <span th:text="${'Firmware Version: ' + initialData.get('firmwareVersion')}"

--- a/HIRS_Utils/src/main/java/hirs/utils/SwidResource.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/SwidResource.java
@@ -34,12 +34,15 @@ public class SwidResource {
     private String hashValue;
 
     @Getter
+    @Setter
     private String rimFormat;
 
     @Getter
+    @Setter
     private String rimType;
 
     @Getter
+    @Setter
     private String rimUriGlobal;
     //    private TpmWhiteListBaseline tpmWhiteList;
     private DigestAlgorithm digest = DigestAlgorithm.SHA1;
@@ -78,13 +81,13 @@ public class SwidResource {
         for (Map.Entry<QName, String> entry
                 : file.getOtherAttributes().entrySet()) {
             switch (entry.getKey().getLocalPart()) {
-                case "supportRIMFormat":
+                case "supportRimFormat":
                     this.rimFormat = entry.getValue();
                     break;
-                case "supportRIMType":
+                case "supportRimType":
                     this.rimType = entry.getValue();
                     break;
-                case "supportRIMURIGlobal":
+                case "supportRimUriGlobal":
                     this.rimUriGlobal = entry.getValue();
                     break;
                 case "hash":

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
@@ -50,7 +50,7 @@ public final class SwidTagConstants {
     public static final String EDITION = "edition";
     public static final String PRODUCT = "product";
     public static final String REVISION = "revision";
-    public static final String PAYLOAD_TYPE = "PayloadType";
+    public static final String PAYLOAD_TYPE = "payloadType";
     public static final String HYBRID = "hybrid";
     public static final String PLATFORM_MANUFACTURER_STR = "platformManufacturerStr";
     public static final String PLATFORM_MANUFACTURER_ID = "platformManufacturerId";
@@ -62,19 +62,19 @@ public final class SwidTagConstants {
     public static final String FIRMWARE_VERSION = "firmwareVersion";
     public static final String BINDING_SPEC = "bindingSpec";
     public static final String BINDING_SPEC_VERSION = "bindingSpecVersion";
-    public static final String PC_URI_LOCAL = "pcURIlocal";
-    public static final String PC_URI_GLOBAL = "pcURIGlobal";
+    public static final String PC_URI_LOCAL = "pcUriLocal";
+    public static final String PC_URI_GLOBAL = "pcUriGlobal";
     public static final String RIM_LINK_HASH = "rimLinkHash";
     public static final String SIZE = "size";
     public static final String HASH = "hash";
-    public static final String SUPPORT_RIM_TYPE = "supportRIMType";
-    public static final String SUPPORT_RIM_FORMAT = "supportRIMFormat";
+    public static final String SUPPORT_RIM_TYPE = "supportRimType";
+    public static final String SUPPORT_RIM_FORMAT = "supportRimFormat";
     public static final String ROOT = "root";
     public static final String LOCATION = "location";
     public static final String TCG_EVENTLOG_ASSERTION = "TCG_EventLog_Assertion";
     public static final String TPM_PCR_ASSERTION = "TPM_PCR_Assertion";
     public static final String SUPPORT_RIM_FORMAT_MISSING = "supportRIMFormat missing";
-    public static final String SUPPORT_RIM_URI_GLOBAL = "supportRIMURIGlobal";
+    public static final String SUPPORT_RIM_URI_GLOBAL = "supportRimUriGlobal";
     public static final String DATETIME = "dateTime";
     public static final String NIST_NS = "http://csrc.nist.gov/ns/swid/2015-extensions/1.0";
     public static final String TCG_NS = "https://trustedcomputinggroup.org/wp-content/uploads/TCG_RIM_Model";
@@ -107,6 +107,14 @@ public final class SwidTagConstants {
             + PLATFORM_MODEL;
     public static final String PLATFORM_VERSION_STR = RIM_PFX + FX_SEPARATOR
             + PLATFORM_VERSION;
+    public static final String FIRMWARE_MANUFACTURER_FULL_STR = RIM_PFX + FX_SEPARATOR
+            + FIRMWARE_MANUFACTURER_STR;
+    public static final String FIRMWARE_MANUFACTURER_ID_STR = RIM_PFX + FX_SEPARATOR
+            + FIRMWARE_MANUFACTURER_ID;
+    public static final String FIRMWARE_MODEL_STR = RIM_PFX + FX_SEPARATOR
+            + FIRMWARE_MODEL;
+    public static final String FIRMWARE_VERSION_STR = RIM_PFX + FX_SEPARATOR
+            + FIRMWARE_VERSION;
     public static final String PAYLOAD_TYPE_STR = RIM_PFX + FX_SEPARATOR
             + PAYLOAD_TYPE;
     public static final String PC_URI_LOCAL_STR = RIM_PFX + FX_SEPARATOR


### PR DESCRIPTION
- **NOTE: To get their details updated on the details page, Base RIMs will need to be re-uploaded upon using this branch.**

The Base RIM details page on the ACA portal is missing some attributes that it should be pulling and displaying from uploaded swidtag files. This is due to a handful of reasons: the casing/spelling of attributes in the code does not match some of the casing in the spec-accurate swidtag files, some fields displays were not functioning properly since test patterns were limited, and new RIM specs have been released that add new attributes.

The following have been added/changed (refer to latest TCG RIM IM spec and TCG PC Client RIM spec):
- Swid Version Scheme
  - added in TCG RIM IM as `versionScheme`
- `firmwareManufacturerStr`, `firmwareManufacturerId`, `firmwareModel`, `firmwareVersion`
  - added in TCG RIM IM
- Remove `entityThumbprint`, which is no longer in RIM spec
- If REQUIRED attribute is missing, the field will still be displayed followed by a blank space. If OPTIONAL attribute is missing, the field will not be displayed at all (but will be displayed if present)
- Fixed display of `payloadType`, `pcUriLocal`, `pcUriGlobal`, `supportRimFormat`, `supportRimType`, `supportRimUriGlobal`
- Re-order some attributes in rim-details so they match spec
- Add the payloadType to the Reference Manifest, concatenated on the rimType column, i.e. Base-Indirect or Base-Hybrid. If a Reference Manifest does not have a payload, it will remain as is, i.e. Base or Support.

To test, spin up ACA from this branch and upload Base RIM swidtag files that contain these fields. Go to Base RIM details page and ensure that details are accurately displayed and nothing is missing.