### PR TITLE
[#1207] Create links to base RIMs in composite RIM payload

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/DeviceInfoProcessorService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/DeviceInfoProcessorService.java
@@ -529,7 +529,7 @@ public class DeviceInfoProcessorService {
      * @param provisionedDeviceInfo provisioned Device Info
      */
     private void updateBaseSupportRIMSUsingDeviceInfo(final ProvisionerTpm2.DeviceInfo provisionedDeviceInfo) {
-        final String supportRimFilePattern = "(\\S+(\\.(?i)(rimpcr|rimel|bin|log))$)";
+        final String supportRimFilePattern = "[^/\\\\]+(\\.(?i)(rimpcr|rimel|bin|log))$";
         final Pattern supportRimPattern = Pattern.compile(supportRimFilePattern);
 
         final List<ByteString> swidfileList = provisionedDeviceInfo.getSwidfileList();

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/DeviceInfoProcessorService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/DeviceInfoProcessorService.java
@@ -19,6 +19,7 @@ import hirs.attestationca.persist.entity.userdefined.rim.BaseReferenceManifest;
 import hirs.attestationca.persist.entity.userdefined.rim.EventLogMeasurements;
 import hirs.attestationca.persist.entity.userdefined.rim.ReferenceDigestValue;
 import hirs.attestationca.persist.entity.userdefined.rim.SupportReferenceManifest;
+import hirs.attestationca.persist.service.ReferenceManifestPageService;
 import hirs.attestationca.persist.validation.SupplyChainCredentialValidator;
 import hirs.utils.HexUtils;
 import hirs.utils.SwidResource;
@@ -529,8 +530,7 @@ public class DeviceInfoProcessorService {
      * @param provisionedDeviceInfo provisioned Device Info
      */
     private void updateBaseSupportRIMSUsingDeviceInfo(final ProvisionerTpm2.DeviceInfo provisionedDeviceInfo) {
-        final String supportRimFilePattern = "[^/\\\\]+(\\.(?i)(rimpcr|rimel|bin|log))$";
-        final Pattern supportRimPattern = Pattern.compile(supportRimFilePattern);
+        final Pattern supportRimPattern = Pattern.compile(ReferenceManifestPageService.SUPPORT_RIM_FILE_PATTERN);
 
         final List<ByteString> swidfileList = provisionedDeviceInfo.getSwidfileList();
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -258,36 +258,40 @@ public class ReferenceManifestDetailsPageService {
         data.put("rimType", baseRim.getRimType());
 
         List<SwidResource> resources = baseRim.getFileResources();
-        SupportReferenceManifest support = null;
-
         ReferenceManifestValidator referenceManifestValidator = new ReferenceManifestValidator();
 
         // going to have to pull the filename and grab that from the DB
         // to get the id to make the link
         referenceManifestValidator.setRim(baseRim.getRimBytes());
         for (SwidResource swidRes : resources) {
-            support = (SupportReferenceManifest) this.referenceManifestRepository.findByHexDecHashAndRimType(
-                    swidRes.getHashValue(), ReferenceManifest.SUPPORT_RIM);
+            ReferenceManifest referenceManifest = this.referenceManifestRepository.findByHexDecHash(
+                    swidRes.getHashValue());
 
-            if (support != null && swidRes.getHashValue().equalsIgnoreCase(support.getHexDecHash())) {
-                baseRim.setAssociatedRim(support.getId());
-                referenceManifestValidator.validateSupportRimHash(support.getRimBytes(),
-                        swidRes.getHashValue());
-                if (referenceManifestValidator.isSupportRimValid()) {
-                    data.put("supportRimHashValid", true);
-                } else {
-                    data.put("supportRimHashValid", false);
+            if (referenceManifest != null && swidRes.getHashValue().equalsIgnoreCase(referenceManifest.getHexDecHash())) {
+                swidRes.setId(referenceManifest.getId());
+                swidRes.setRimType(referenceManifest.getRimType());
+                if (referenceManifest.getRimType().equals(ReferenceManifest.SUPPORT_RIM)) {
+                    SupportReferenceManifest supportRim = (SupportReferenceManifest) referenceManifest;
+                    baseRim.setAssociatedRim(supportRim.getId());
+                    data.put("associatedRim", baseRim.getAssociatedRim());
+                    referenceManifestValidator.validateSupportRimHash(supportRim.getRimBytes(),
+                            swidRes.getHashValue());
+                    if (referenceManifestValidator.isSupportRimValid()) {
+                        data.put("supportRimHashValid", true);
+                    } else {
+                        data.put("supportRimHashValid", false);
+                    }
+                    if (!baseRim.isSwidSupplemental() && !baseRim.isSwidPatch()) {
+                        data.put("pcrList", supportRim.getExpectedPCRList());
+                    }
                 }
-                break;
+            } else {
+                log.warn("Unable to locate resource file {} with size {} and hash {}.",
+                        swidRes.getName(), swidRes.getSize(), swidRes.getHashValue());
             }
         }
 
-        data.put("associatedRim", baseRim.getAssociatedRim());
         data.put("swidFiles", resources);
-        if (support != null && (!baseRim.isSwidSupplemental()
-                && !baseRim.isSwidPatch())) {
-            data.put("pcrList", support.getExpectedPCRList());
-        }
 
         List<CertificateAuthorityCredential> embeddedCertificates = new ArrayList<>();
         List<X509Certificate> rawEmbeddedCertificates;

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestPageService.java
@@ -55,8 +55,8 @@ public class ReferenceManifestPageService {
     private final ReferenceDigestValueRepository referenceDigestValueRepository;
     private final EntityManager entityManager;
 
-    private static final String BASE_RIM_FILE_PATTERN = "(\\S+(\\.(?i)swidtag)$)";
-    private static final String SUPPORT_RIM_FILE_PATTERN = "(\\S+(\\.(?i)(rimpcr|rimel|bin|log))$)";
+    private static final String BASE_RIM_FILE_PATTERN = "([^/\\\\]+\\.(?i)swidtag)$";
+    private static final String SUPPORT_RIM_FILE_PATTERN = "([^/\\\\]+\\.(?i)(rimpcr|rimel|bin|log))$";
 
     /**
      * Constructor for the Reference Manifest Page Service.

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestPageService.java
@@ -56,7 +56,7 @@ public class ReferenceManifestPageService {
     private final EntityManager entityManager;
 
     private static final String BASE_RIM_FILE_PATTERN = "([^/\\\\]+\\.(?i)swidtag)$";
-    private static final String SUPPORT_RIM_FILE_PATTERN = "([^/\\\\]+\\.(?i)(rimpcr|rimel|bin|log))$";
+    public static final String SUPPORT_RIM_FILE_PATTERN = "([^/\\\\]+\\.(?i)(rimpcr|rimel|bin|log))$";
 
     /**
      * Constructor for the Reference Manifest Page Service.

--- a/HIRS_AttestationCAPortal/src/main/resources/static/css/rim-details.css
+++ b/HIRS_AttestationCAPortal/src/main/resources/static/css/rim-details.css
@@ -121,3 +121,22 @@
   width: 20rem;
   font-weight: bold;
 }
+
+.error-color {
+  background-color: #FF6164;
+  color: #FFFFFF;
+}
+
+.accordion-button.error-color.collapsed {
+  background-color: #FF6164;
+  color: #FFFFFF;
+}
+
+.accordion-button.error-color:not(.collapsed) {
+  background-color: #FF6164;
+  color: #FFFFFF;
+}
+
+.accordion-button.error-color:focus {
+  box-shadow: none;
+}

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
@@ -547,7 +547,7 @@
                                                                 <th:block th:if="${#arrays.isEmpty(initialData.get('pcrList'))}
                                                                             and not ${initialData.get('swidPatch')}
                                                                             and not ${initialData.get('swidSupplemental')}">
-                                                                    <span style="color: red">PCR values not found.</span>
+                                                                    <span style="color: red">Support RIM not found.</span>
                                                                 </th:block>
                                                                 <th:block
                                                                     th:if="${not #arrays.isEmpty(initialData.get('pcrList'))}">

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
@@ -485,7 +485,9 @@
                                                         class="accordion-header">
                                                         <span data-toggle="tooltip" data-placement="top"
                                                             title="Resource File">
-                                                            <button class="accordion-button collapsed" type="button"
+                                                            <button class="accordion-button collapsed"
+                                                                th:classappend="${#strings.isEmpty(resource.id)} ? 'error-color'"
+                                                                type="button"
                                                                 data-bs-toggle="collapse"
                                                                 th:data-bs-target="${'#filesCollapse' + resourceStat.count}"
                                                                 aria-expanded="false"
@@ -542,6 +544,9 @@
                                                                 <span class="fieldHeader">URI Global:</span>
                                                                 <span class="fieldValue"
                                                                     th:text="${resource.rimUriGlobal}" /><br />
+                                                            </th:block>
+                                                            <th:block th:if="${#strings.isEmpty(resource.id)}">
+                                                                <span style="color: red">Resource file not found.</span>
                                                             </th:block>
                                                             <th:block th:if="${#strings.equalsIgnoreCase(resource.rimType, 'Support')}">
                                                                 <th:block th:if="${#arrays.isEmpty(initialData.get('pcrList'))}

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
@@ -443,10 +443,10 @@
                         th:if="${#strings.isEmpty(initialData.get('rimLinkId'))}" />
                     <th:block th:unless="${#strings.isEmpty(initialData.get('rimLinkId'))}">
                         <div>Rim Link Hash:
-                            <a
-                                href="@{/HIRS_AttestationCAPortal/portal/rim-details?(id=${initialData.get('rimLinkId')})">
+                            <a href="@{/HIRS_AttestationCAPortal/portal/rim-details?(id=${initialData.get('rimLinkId')})">
                                 <span>${initialData.get('rimLinkHash')}</span>
                             </a>
+                        </div>
                     </th:block>
                     <th:block th:if="${not #strings.isEmpty(initialData.get('rimLinkHash'))}">
                         <span>
@@ -485,41 +485,34 @@
                                                         class="accordion-header">
                                                         <span data-toggle="tooltip" data-placement="top"
                                                             title="Resource File">
-                                                            <th:block
-                                                                th:if="${not #strings.isEmpty(initialData.get('associatedRim'))}">
-                                                                <button class="accordion-button collapsed" type="button"
-                                                                    data-bs-toggle="collapse"
-                                                                    th:data-bs-target="${'#filesCollapse' + resourceStat.count}"
-                                                                    aria-expanded="false"
-                                                                    th:aria-controls="${'filesCollapse' + resourceStat.count}">
-                                                                    <a
-                                                                        th:href="@{/HIRS_AttestationCAPortal/portal/rim-details?(id=${initialData.get('associatedRim')})}">
-                                                                        <span th:text="${resource.name}">Associated
-                                                                            RIM</span>
-                                                                    </a>
+                                                            <button class="accordion-button collapsed" type="button"
+                                                                data-bs-toggle="collapse"
+                                                                th:data-bs-target="${'#filesCollapse' + resourceStat.count}"
+                                                                aria-expanded="false"
+                                                                th:aria-controls="${'filesCollapse' + resourceStat.count}">
+                                                                <th:block th:if="${#strings.isEmpty(resource.id)}">
+                                                                    <span th:text="${resource.name}">Resource File</span>
+                                                                </th:block>
+                                                                <th:block th:unless="${#strings.isEmpty(resource.id)}">
+                                                                <a
+                                                                    th:href="@{/HIRS_AttestationCAPortal/portal/rim-details?(id=${resource.id})}">
+                                                                    <span th:text="${resource.name}">Resource File</span>
+                                                                </a>
+                                                                </th:block>
+                                                                <th:block
+                                                                    th:if="${#strings.equalsIgnoreCase(resource.rimType, 'Support')}">
                                                                     <th:block
-                                                                        th:if="${not #strings.isEmpty(initialData.get('supportRimHashValid'))}">
+                                                                        th:if="${#strings.isEmpty(initialData.get('supportRimHashValid'))}">
+                                                                        <img th:src="@{/icons/ic_error_red_24dp.png}"
+                                                                             title="Support RIM hash not valid!" />
+                                                                    </th:block>
+                                                                    <th:block
+                                                                        th:unless="${#strings.isEmpty(initialData.get('supportRimHashValid'))}">
                                                                         <img th:src="@{/icons/ic_checkbox_marked_circle_black_green_24dp.png}"
                                                                             title="Support RIM hash valid" />
                                                                     </th:block>
-                                                                    <th:block
-                                                                        th:unless="${not #strings.isEmpty(initialData.get('supportRimHashValid'))}">
-                                                                        <img th:src="@{/icons/ic_error_red_24dp.png}"
-                                                                            title="Support RIM hash not valid!" />
-                                                                    </th:block>
-                                                                </button>
-                                                            </th:block>
-                                                            <th:block
-                                                                th:unless="${not #strings.isEmpty(initialData.get('associatedRim'))}">
-                                                                <button class="accordion-button collapsed" type="button"
-                                                                    data-bs-toggle="collapse"
-                                                                    th:data-bs-target="${'#filesCollapse' + resourceStat.count}"
-                                                                    aria-expanded="false"
-                                                                    th:aria-controls="${'filesCollapse' + resourceStat.count}">
-                                                                    <span th:text="${resource.name}">Associated
-                                                                        RIM</span>
-                                                                </button>
-                                                            </th:block>
+                                                                </th:block>
+                                                            </button>
                                                         </span><!-- Tooltip -->
                                                     </h3>
                                                     <div th:id="${'filesCollapse' + resourceStat.count}"
@@ -550,45 +543,47 @@
                                                                 <span class="fieldValue"
                                                                     th:text="${resource.rimUriGlobal}" /><br />
                                                             </th:block>
-                                                            <th:block
-                                                                th:if="${not #arrays.isEmpty(initialData.get('pcrList'))}">
-                                                                <div th:id="${'pcrAccordion' + resourceStat.count}"
-                                                                    class="accordion">
-                                                                    <div
-                                                                        class="accordion-item border rounded mb-2 overflow-hidden">
-                                                                        <h3 class="accordion-header"
-                                                                            th:id="${'pcrHeader' + resourceStat.count}">
-                                                                            <button class="accordion-button collapsed"
-                                                                                type="button" data-bs-toggle="collapse"
-                                                                                th:data-bs-target="${'#pcrCollapse' + resourceStat.count}"
+                                                            <th:block th:if="${#strings.equalsIgnoreCase(resource.rimType, 'Support')}">
+                                                                <th:block th:if="${#arrays.isEmpty(initialData.get('pcrList'))}
+                                                                            and not ${initialData.get('swidPatch')}
+                                                                            and not ${initialData.get('swidSupplemental')}">
+                                                                    <span style="color: red">PCR values not found.</span>
+                                                                </th:block>
+                                                                <th:block
+                                                                    th:if="${not #arrays.isEmpty(initialData.get('pcrList'))}">
+                                                                    <div th:id="${'pcrAccordion' + resourceStat.count}"
+                                                                        class="accordion">
+                                                                        <div
+                                                                            class="accordion-item border rounded mb-2 overflow-hidden">
+                                                                            <h3 class="accordion-header"
+                                                                                th:id="${'pcrHeader' + resourceStat.count}">
+                                                                                <button class="accordion-button collapsed"
+                                                                                    type="button" data-bs-toggle="collapse"
+                                                                                    th:data-bs-target="${'#pcrCollapse' + resourceStat.count}"
+                                                                                    aria-expanded="false"
+                                                                                    th:aria-controls="${'pcrCollapse' + resourceStat.count}">
+                                                                                    Expected PCR Values
+                                                                                </button>
+                                                                            </h3>
+                                                                            <div class="accordion-collapse collapse"
+                                                                                th:id="${'pcrCollapse' + resourceStat.count}"
+                                                                                th:aria-labelledby="${'pcrHeader' + resourceStat.count}"
                                                                                 aria-expanded="false"
-                                                                                th:aria-controls="${'pcrCollapse' + resourceStat.count}">
-                                                                                Expected PCR Values
-                                                                            </button>
-                                                                        </h3>
-                                                                        <div class="accordion-collapse collapse"
-                                                                            th:id="${'pcrCollapse' + resourceStat.count}"
-                                                                            th:aria-labelledby="${'pcrHeader' + resourceStat.count}"
-                                                                            aria-expanded="false"
-                                                                            th:data-bs-parent="${'#pcrAccordion' + resourceStat.count}">
-                                                                            <div class="accordion-body">
-                                                                                <th:block
-                                                                                    th:each="pcr, pcrStat : ${initialData.get('pcrList')}">
-                                                                                    <span
-                                                                                        th:text="${'PCR' + pcrStat.index + ': '}" />
-                                                                                    <span
-                                                                                        style="overflow-wrap: break-word"
-                                                                                        th:text="${pcr}"></span><br />
-                                                                                </th:block>
-                                                                            </div><!--accordion body-->
-                                                                        </div><!--accordion collapse-->
-                                                                    </div><!--accordion item-->
-                                                                </div><!--pcrAccordion-->
-                                                            </th:block>
-                                                            <th:block th:if="${#arrays.isEmpty(initialData.get('pcrList'))}
-                                                                        and not ${initialData.get('swidPatch')}
-                                                                        and not ${initialData.get('swidSupplemental')}">
-                                                                <span style="color: red">PCR values not found.</span>
+                                                                                th:data-bs-parent="${'#pcrAccordion' + resourceStat.count}">
+                                                                                <div class="accordion-body">
+                                                                                    <th:block
+                                                                                        th:each="pcr, pcrStat : ${initialData.get('pcrList')}">
+                                                                                        <span
+                                                                                            th:text="${'PCR' + pcrStat.index + ': '}" />
+                                                                                        <span
+                                                                                            style="overflow-wrap: break-word"
+                                                                                            th:text="${pcr}"></span><br />
+                                                                                    </th:block>
+                                                                                </div><!--accordion body-->
+                                                                            </div><!--accordion collapse-->
+                                                                        </div><!--accordion item-->
+                                                                    </div><!--pcrAccordion-->
+                                                                </th:block>
                                                             </th:block>
                                                         </div><!--accordion body-->
                                                     </div><!--accordion collapse-->

--- a/HIRS_Utils/src/main/java/hirs/utils/SwidResource.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/SwidResource.java
@@ -10,6 +10,7 @@ import lombok.ToString;
 import javax.xml.namespace.QName;
 import java.math.BigInteger;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * This object is used to represent the content of a Swid Tags Directory
@@ -20,6 +21,10 @@ public class SwidResource {
 
     @Getter
     private static final boolean VALID_FILE_SIZE = false;
+
+    @Getter
+    @Setter
+    private UUID id;
 
     @Getter
     @Setter
@@ -37,6 +42,7 @@ public class SwidResource {
     private String rimFormat;
 
     @Getter
+    @Setter
     private String rimType;
 
     @Getter


### PR DESCRIPTION
### Major changes ###

1. Composite RIMs now link to lower base RIMs in their payloads.
2. Payload support RIMs display expected PCRs or an error message; base RIMs do not.
3. Payload files that cannot be queried in the backend are logged for reference.


Closes #1207 