### PR TITLE
Have platform certs search for Holder by using both EK SN and EK issuer

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/CertificateRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/CertificateRepository.java
@@ -74,6 +74,19 @@ public interface CertificateRepository extends JpaRepository<Certificate, UUID> 
     Certificate findBySerialNumber(BigInteger serialNumber, String dType);
 
     /**
+     * Query that retrieves a certificate using the provided serial number,
+     * issuer, and dtype.
+     *
+     * @param serialNumber serial number
+     * @param issuer issuer distinguished name
+     * @param dType dtype
+     * @return a Certificate object
+     */
+    @Query(value = "SELECT * FROM Certificate WHERE serialNumber = ?1 AND issuer = ?2 AND DTYPE = ?3",
+            nativeQuery = true)
+    Certificate findBySerialNumberAndIssuer(BigInteger serialNumber, String issuer, String dType);
+
+    /**
      * Query that retrieves a list of platform credentials using the provided board serial number
      * and a dtype of "Platform Credential".
      *

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/EndorsementCertificateRepository.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/manager/EndorsementCertificateRepository.java
@@ -41,12 +41,14 @@ public interface EndorsementCertificateRepository extends JpaRepository<Endorsem
     Page<EndorsementCredential> findByArchiveFlag(boolean archiveFlag, Pageable pageable);
 
     /**
-     * Query that retrieves an {@link EndorsementCredential} object using the provided serial number.
+     * Query that retrieves an {@link EndorsementCredential} object using the provided serial number
+     * and issuer.
      *
      * @param serialNumber big integer representation of the serial number
+     * @param issuer string representation of the issuer
      * @return an {@link EndorsementCredential} object
      */
-    EndorsementCredential findBySerialNumber(BigInteger serialNumber);
+    EndorsementCredential findBySerialNumberAndIssuer(BigInteger serialNumber, String issuer);
 
     /**
      * Query that retrieves a list of {@link EndorsementCredential} objects using the provided device id.

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/PlatformCertificatePageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/PlatformCertificatePageService.java
@@ -55,10 +55,12 @@ public class PlatformCertificatePageService {
      * Retrieves an {@link EndorsementCredential} object using the provided holder serial number.
      *
      * @param holderSerialNumber big integer representation of the holder serial number
+     * @param issuer string representation of the holder issuer
      * @return an {@link EndorsementCredential} object
      */
-    public EndorsementCredential findEndorsementCertificateBySerialNumber(final BigInteger holderSerialNumber) {
-        return endorsementCertificateRepository.findBySerialNumber(holderSerialNumber);
+    public EndorsementCredential findEndorsementCertificateBySerialNumberAndIssuer(
+            final BigInteger holderSerialNumber, final String issuer) {
+        return endorsementCertificateRepository.findBySerialNumberAndIssuer(holderSerialNumber, issuer);
     }
 
     /**

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -271,7 +271,8 @@ public class ReferenceManifestDetailsPageService {
             ReferenceManifest referenceManifest = this.referenceManifestRepository.findByHexDecHash(
                     swidRes.getHashValue());
 
-            if (referenceManifest != null && swidRes.getHashValue().equalsIgnoreCase(referenceManifest.getHexDecHash())) {
+            if (referenceManifest != null && swidRes.getHashValue().equalsIgnoreCase(
+                    referenceManifest.getHexDecHash())) {
                 swidRes.setId(referenceManifest.getId());
                 swidRes.setRimType(referenceManifest.getRimType());
                 if (referenceManifest.getRimType().equals(ReferenceManifest.SUPPORT_RIM)) {

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestPageService.java
@@ -55,7 +55,15 @@ public class ReferenceManifestPageService {
     private final ReferenceDigestValueRepository referenceDigestValueRepository;
     private final EntityManager entityManager;
 
-    private static final String BASE_RIM_FILE_PATTERN = "([^/\\\\]+\\.(?i)swidtag)$";
+    /**
+     * Regex pattern used to identify base RIM files with a `.swidtag` extension.
+     */
+    public static final String BASE_RIM_FILE_PATTERN = "([^/\\\\]+\\.(?i)swidtag)$";
+
+    /**
+     * Regex pattern used to identify supported RIM-related files, with extensions
+     * including: .rimpcr, .rimel, .bin. .log.
+     */
     public static final String SUPPORT_RIM_FILE_PATTERN = "([^/\\\\]+\\.(?i)(rimpcr|rimel|bin|log))$";
 
     /**

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PlatformCertificatePageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PlatformCertificatePageController.java
@@ -126,7 +126,8 @@ public class PlatformCertificatePageController extends PageController<NoPagePara
         for (PlatformCredential pc : pcFilteredRecordsList) {
             // find the EC using the PC's "holder serial number"
             EndorsementCredential associatedEC = platformCertificatePageService
-                    .findEndorsementCertificateBySerialNumber(pc.getHolderSerialNumber());
+                    .findEndorsementCertificateBySerialNumberAndIssuer(pc.getHolderSerialNumber(),
+                            pc.getIssuer());
 
             if (associatedEC != null) {
                 log.debug("EC ID for holder s/n {} = {}", pc.getHolderSerialNumber(), associatedEC.getId());

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -552,7 +552,9 @@ public final class CertificateStringMapBuilder {
             data.put("holderIssuer", certificate.getHolderIssuer());
             if (certificate.isPlatformBase()) {
                 EndorsementCredential ekCertificate = (EndorsementCredential) certificateRepository
-                        .findBySerialNumber(certificate.getHolderSerialNumber(),
+                        .findBySerialNumberAndIssuer(
+                                certificate.getHolderSerialNumber(),
+                                certificate.getHolderIssuer(),
                                 "EndorsementCredential");
 
                 if (ekCertificate != null) {

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
@@ -52,7 +52,7 @@ public final class SwidTagParser {
      * @param doc of the input swidtag.
      * @return document validated against the schema.
      */
-    public static Document validateSwidtagSchema(Document doc) throws UnmarshalException {
+    public static Document validateSwidtagSchema(final Document doc) throws UnmarshalException {
 
         try (InputStream is = SwidTagParser.class.getClassLoader().getResourceAsStream(
                 SwidTagConstants.SCHEMA_URL)) {
@@ -60,14 +60,14 @@ public final class SwidTagParser {
                 log.error("Schema resource not found");
                 return null;
             }
-            doc = removeXMLWhitespace(doc);
+            Document validatedDoc = removeXMLWhitespace(doc);
             SchemaFactory schemaFactory = SchemaFactory.newInstance(SwidTagConstants.SCHEMA_LANGUAGE);
             Schema schema = schemaFactory.newSchema(new StreamSource(is));
             JAXBContext jaxbContext = JAXBContext.newInstance(SwidTagConstants.SCHEMA_PACKAGE);
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
             unmarshaller.setSchema(schema);
-            unmarshaller.unmarshal(doc);
-            return doc;
+            unmarshaller.unmarshal(validatedDoc);
+            return validatedDoc;
         } catch (UnmarshalException e) {
             throw new UnmarshalException("Error parsing Base RIM: " + e.getCause());
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
Previously, Platform Certs were searching for their Holder using just their Serial Number. According to TCG Platform Cert profile spec, they should be looking to match both the SN and the Issuer of the EK. This PR makes this adjustment. This change also allows EKs with non-unique serial numbers to be present without causing a datatables error.

This PR also fixes some misc checkstyle warnings.

To test:
- On the ACA spun up from this branch, upload an EK with an SN and an Issuer.
- Upload a Base Platform Cert whose Holder is that EK. Ensure that when you go to the details page, the Holder SN and Issuer match with the correct EK cert.