### PR TITLE
Prevent non-unique returns for RIM lookup when reading composite SWID resources

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -268,8 +268,13 @@ public class ReferenceManifestDetailsPageService {
         // to get the id to make the link
         referenceManifestValidator.setRim(baseRim.getRimBytes());
         for (SwidResource swidRes : resources) {
-            ReferenceManifest referenceManifest = this.referenceManifestRepository.findByHexDecHash(
-                    swidRes.getHashValue());
+            ReferenceManifest referenceManifest = this.referenceManifestRepository.findByHexDecHashAndRimType(
+                    swidRes.getHashValue(), ReferenceManifest.SUPPORT_RIM);
+
+            if (referenceManifest == null) {
+                referenceManifest = this.referenceManifestRepository.findByHexDecHashAndRimType(
+                        swidRes.getHashValue(), ReferenceManifest.BASE_RIM);
+            }
 
             if (referenceManifest != null && swidRes.getHashValue().equalsIgnoreCase(referenceManifest.getHexDecHash())) {
                 swidRes.setId(referenceManifest.getId());


### PR DESCRIPTION
RIM Details Page Service has functionality to read through SWID file's resources, which typically contain other RIMs of different types. Originally, it queried the database to look up those RIMs by their hashes AND rimType. #1210 modified this query to just look up by the hash initially. This change caused the possibility of non-unique returns, which in turn caused an error in the ACA.

This PR reverts the query so it looks up RIMs by both their hash AND rimType, while still retaining functionality added by #1210 .