### PR TITLE
[#1221] Verify pc client RIMs with public key only

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/FirmwareScvValidator.java
@@ -241,12 +241,7 @@ public class FirmwareScvValidator extends SupplyChainCredentialValidator {
 
         if (passed && !referenceManifestValidator.isSignatureValid()) {
             passed = false;
-            String validationErrorMessage = referenceManifestValidator.getValidationErrorMessage();
-            if (!validationErrorMessage.isEmpty()) {
-                rimSignatureStatus = new AppraisalStatus(FAIL, validationErrorMessage);
-            } else {
-                rimSignatureStatus = new AppraisalStatus(FAIL, "Base RIM signature invalid.");
-            }
+            rimSignatureStatus = new AppraisalStatus(FAIL, "Base RIM signature invalid.");
         }
 
         if (passed && !referenceManifestValidator.isSupportRimValid()) {

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -97,9 +97,6 @@ public class ReferenceManifestValidator {
     private boolean supportRimValid;
 
     @Getter
-    private String validationErrorMessage;
-
-    @Getter
     private X509Certificate signingCertificate;
 
     /**
@@ -161,84 +158,6 @@ public class ReferenceManifestValidator {
     }
 
     /**
-     * This method attempts to validate the signature element of the instance's RIM
-     * using a given cert.  The cert is compared to either the RIM's embedded certificate
-     * or the RIM's subject key identifier.  If the cert is matched then validation proceeds,
-     * otherwise validation ends.
-     *
-     * @param publicKey          public key from the CA credential
-     * @param subjectKeyIdString string version of the subjet key id of the CA credential
-     * @return true if the signature element is validated, false otherwise
-     */
-
-    public boolean validateXmlSignature(final PublicKey publicKey, final String subjectKeyIdString) {
-        DOMValidateContext context = null;
-        validationErrorMessage = "Unable to verify RIM signature: ";
-        try {
-            NodeList nodes = getXmlElement(XMLSignature.XMLNS, "Signature");
-
-            if (nodes.getLength() == 0) {
-                validationErrorMessage += "invalid XML, signature element not found.";
-                log.error(validationErrorMessage);
-                return false;
-            }
-
-            if (trustStoreFile != null && !trustStoreFile.isEmpty()) {
-                trustStore = parseCertificatesFromPem(trustStoreFile);
-            }
-
-            NodeList certElement = getXmlElement(XMLSignature.XMLNS, "X509Certificate");
-            if (certElement.getLength() > 0) {
-                List<X509Certificate> embeddedCerts =
-                        SwidTagParser.getEmbeddedX509Certificates(rim);
-                if (embeddedCerts != null && !embeddedCerts.isEmpty()) {
-                    for (X509Certificate embeddedCert : embeddedCerts) {
-                        if (isCertChainValid(embeddedCert)) {
-                            context = new DOMValidateContext(new X509KeySelector(), nodes.item(0));
-                            subjectKeyIdentifier = getCertificateSubjectKeyIdentifier(embeddedCert);
-                            validationErrorMessage = "";
-                            this.publicKey = publicKey;
-                            signatureValid = validateSignedXMLDocument(context);
-                            if (signatureValid) {
-                                signingCertificate = embeddedCert;
-                                return true;
-                            }
-                        }
-                    }
-                    validationErrorMessage += "embedded certs present but signature validation failed";
-                } else {
-                    validationErrorMessage += "embedded cert is null.";
-                }
-            } else {
-                if (publicKey != null && !subjectKeyIdString.isEmpty()) {
-                    subjectKeyIdentifier = getKeyName();
-                    if (subjectKeyIdentifier.equals(subjectKeyIdString)) {
-                        context = new DOMValidateContext(publicKey,
-                                nodes.item(0));
-                    } else {
-                        validationErrorMessage += "issuer cert not found";
-                    }
-                } else {
-                    System.out.println("A public signing certificate (-p) is required "
-                            + "to verify this base RIM.");
-                }
-            }
-            if (context != null) {
-                validationErrorMessage = "";
-                this.publicKey = publicKey;
-                signatureValid = validateSignedXMLDocument(context);
-                return signatureValid;
-            }
-        } catch (IOException e) {
-            log.warn("Error while parsing certificate data: {}", e.getMessage());
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        return false;
-    }
-
-    /**
      * This method validates a base RIM in two parts:
      * 1. validate the support RIM(s) in the Payload
      * 2. validate the XML signature over the entire document
@@ -270,6 +189,87 @@ public class ReferenceManifestValidator {
             System.out.println(System.lineSeparator() + "Overall base RIM validation failed.");
             return false;
         }
+    }
+
+    /**
+     * This method attempts to validate the signature element of the instance's RIM
+     * using a given cert.  The cert is compared to either the RIM's embedded certificate
+     * or the RIM's subject key identifier.  If the cert is matched then validation proceeds,
+     * otherwise validation ends.
+     *
+     * @param publicKey          public key from the CA credential
+     * @param subjectKeyIdString string version of the subjet key id of the CA credential
+     * @return true if the signature element is validated, false otherwise
+     */
+
+    public boolean validateXmlSignature(final PublicKey publicKey, final String subjectKeyIdString) {
+        DOMValidateContext context = null;
+        try {
+            NodeList nodes = getXmlElement(XMLSignature.XMLNS, "Signature");
+
+            if (nodes.getLength() == 0) {
+                log.error("RIM signature element not found.");
+                return false;
+            }
+
+            if (trustStoreFile != null && !trustStoreFile.isEmpty()) {
+                trustStore = parseCertificatesFromPem(trustStoreFile);
+            }
+
+            NodeList certElement = getXmlElement(XMLSignature.XMLNS, "X509Certificate");
+            if (certElement.getLength() > 0) {
+                List<X509Certificate> embeddedCerts =
+                        SwidTagParser.getEmbeddedX509Certificates(rim);
+                if (embeddedCerts != null && !embeddedCerts.isEmpty()) {
+                    for (X509Certificate embeddedCert : embeddedCerts) {
+                        if (isCertChainValid(embeddedCert)) {
+                            context = new DOMValidateContext(new X509KeySelector(), nodes.item(0));
+                            subjectKeyIdentifier = getCertificateSubjectKeyIdentifier(embeddedCert);
+                            this.publicKey = publicKey;
+                            signatureValid = validateSignedXMLDocument(context);
+                            if (signatureValid) {
+                                signingCertificate = embeddedCert;
+                                return true;
+                            }
+                        }
+                    }
+                    log.warn("Embedded certs present but signature validation failed.");
+                } else {
+                    log.warn("Empty or null embedded cert(s) encountered, please verify.");
+                }
+            } else {
+                if (publicKey != null) {
+                    context = new DOMValidateContext(publicKey, nodes.item(0));
+                    if (subjectKeyIdString.isEmpty()) {
+                        log.warn("No subject key identifier given for public key {}",
+                            Arrays.toString(publicKey.getEncoded()));
+                    } else {
+                        subjectKeyIdentifier = getKeyName();
+                        if (subjectKeyIdentifier == null) {
+                            log.warn("Could not parse subject key identifier from RIM.");
+                        } else if (subjectKeyIdentifier.equals(subjectKeyIdString)) {
+                            log.info("Subject key identifier confirmed: {}", subjectKeyIdString);
+                        } else {
+                            log.warn("Subject key identifier not matched: given {} but found {}",
+                                    subjectKeyIdString, subjectKeyIdentifier);
+                        }
+                    }
+                } else {
+                    log.error("Public key is null, please verify.");
+                }
+            }
+            if (context != null) {
+                this.publicKey = publicKey;
+                signatureValid = validateSignedXMLDocument(context);
+                return signatureValid;
+            }
+        } catch (IOException e) {
+            log.error("Error while parsing certificate data: {}", e.getMessage());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return false;
     }
 
     /**
@@ -793,7 +793,7 @@ public class ReferenceManifestValidator {
     /**
      * This method parses the subject key identifier from the KeyName element of a signature.
      *
-     * @return SKID if found, or an empty string.
+     * @return SKID if found, or null.
      */
     private String getKeyName() {
         NodeList keyName = getXmlElement(XMLSignature.XMLNS, "KeyName");

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/ReferenceManifestValidator.java
@@ -212,7 +212,9 @@ public class ReferenceManifestValidator {
                 return false;
             }
 
-            if (trustStoreFile != null && !trustStoreFile.isEmpty()) {
+            if (trustStoreFile == null || trustStoreFile.isEmpty()) {
+                log.warn("No truststore file given, unable to validate cert chain.");
+            } else {
                 trustStore = parseCertificatesFromPem(trustStoreFile);
             }
 

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
@@ -22,10 +22,18 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -125,6 +133,41 @@ public final class SwidTagParser {
             return (X509Certificate) factory.generateCertificate(inputStream);
         } catch (CertificateException e) {
             log.warn("Error creating CertificateFactory instance: {}", e.getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * This method converts a public key string into a PublicKey object.
+     *
+     * @param publicKeyFile to convert to a PublicKey
+     * @param algorithm of the returned PublicKey
+     * @return PublicKey
+     */
+    public static PublicKey parsePublicKeyFromPem(final String publicKeyFile, final String algorithm) {
+        String header = "-----BEGIN PUBLIC KEY-----";
+        String footer = "-----END PUBLIC KEY-----";
+        String pemString;
+        try {
+            pemString = Files.readString(Path.of(publicKeyFile));
+        } catch (IOException e) {
+            log.error("Error reading public key file {}: {}", publicKeyFile, e.getMessage());
+            return null;
+        }
+        String publicKeyContent = pemString.replace(header, "")
+                .replace(footer, "")
+                .replaceAll("\\s+", "");
+
+        byte[] decodedBytes = Base64.getDecoder().decode(publicKeyContent);
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(decodedBytes);
+        try {
+            KeyFactory kf = KeyFactory.getInstance(algorithm);
+            return kf.generatePublic(keySpec);
+        } catch (NoSuchAlgorithmException e) {
+            log.error("Error creating key factory for public key generation: {}", e.getMessage());
+        } catch (InvalidKeySpecException e) {
+            log.error("Error creating a public key: {}", e.getMessage());
         }
 
         return null;

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/xml/pcclientrim/PcClientRim.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/xml/pcclientrim/PcClientRim.java
@@ -42,7 +42,7 @@ public class PcClientRim extends SwidTagGateway implements GenericRim {
     private boolean isValid;
 
     /**
-     * Validate a PC Client RIM.
+     * Validate a PC Client RIM with a certificate.
      *
      * @param verifyFile      RIM to verify
      * @param certificateFile certificate
@@ -57,13 +57,65 @@ public class PcClientRim extends SwidTagGateway implements GenericRim {
         ReferenceManifestValidator validator = new ReferenceManifestValidator();
         validator.setRim(verifyFile);
         validator.setTrustStoreFile(trustStore);
-        HexFormat hexTool = HexFormat.of();
         if (rimel != null) {
             validator.setHasSupportRim(true);
             validator.setSupportRimDirectory(rimel);
         }
 
-        rim = copyDoc(validator.getRim());
+        addMeasurementForBaseRim(verifyFile, validator.getRim());
+
+        if (validator.validateBaseRim(certificateFile)) {
+            valid = true;
+        } else {
+            throw new RuntimeException("Failed to verify " + verifyFile);
+        }
+
+        isValid = valid;
+        return valid;
+    }
+
+    /**
+     * Validate a PC Client RIM with a public key.
+     *
+     * @param verifyFile RIM to verify
+     * @param publicKeyFile public key
+     * @param rimel RIM event log
+     * @return true if validated
+     * @throws IOException if there is an I/O error during the operation.
+     */
+    public boolean validate(final String verifyFile, final String publicKeyFile, final String rimel)
+            throws IOException {
+        boolean valid;
+        PublicKey pk = SwidTagParser.parsePublicKeyFromPem(publicKeyFile, "RSA");
+        ReferenceManifestValidator validator = new ReferenceManifestValidator();
+        validator.setRim(verifyFile);
+        if (rimel != null) {
+            validator.setHasSupportRim(true);
+            validator.setSupportRimDirectory(rimel);
+        }
+
+        addMeasurementForBaseRim(verifyFile, validator.getRim());
+
+        if (validator.validateXmlSignature(pk, "")) {
+            valid = true;
+        } else {
+            throw new RuntimeException("Failed to verify " + verifyFile);
+        }
+
+        isValid = valid;
+        return valid;
+    }
+
+    /**
+     * This method creates a measurement object based on the base RIM being verified.
+     *
+     * @param verifyFile RIM to verify
+     * @param baseRim Document object of the RIM to verify
+     * @throws RemoteException if a tagId cannot be parsed
+     */
+    private void addMeasurementForBaseRim(final String verifyFile, final Document baseRim)
+            throws RemoteException {
+        rim = copyDoc(baseRim);
 
         NodeList si = rim.getElementsByTagNameNS(SwidTagConstants.SWIDTAG_NAMESPACE,
                 SwidTagConstants.SOFTWARE_IDENTITY);
@@ -92,6 +144,7 @@ public class PcClientRim extends SwidTagGateway implements GenericRim {
                 SwidTagConstants.FILE);
         // Make a measurement for each Hash item and add it to the list of
         // measurements
+        HexFormat hexTool = HexFormat.of();
         for (int count = 0; count < files.getLength(); count++) {
             Element file = (Element) files.item(count);
             digest = file.getAttributeNS(SwidTagConstants.SHA_256_HASH.getNamespaceURI(),
@@ -107,38 +160,6 @@ public class PcClientRim extends SwidTagGateway implements GenericRim {
             measurement.setMeasurementBytes(digestBytes);
             measurements.add(measurement);
         }
-
-        if (validator.validateBaseRim(certificateFile)) {
-            valid = true;
-        } else {
-            throw new RuntimeException("Failed to verify " + verifyFile);
-        }
-
-        isValid = valid;
-        return valid;
-    }
-
-    /**
-     * This validate method takes just a public key to verify the input file (rimel optional).
-     *
-     * @param verifyFile to be verified
-     * @param publicKeyFile PK to verify with
-     * @param rimel optional
-     * @return true if valid, false if not
-     */
-    public boolean validate(final String verifyFile, final String publicKeyFile, final String rimel)
-                            throws IOException {
-        boolean valid;
-        PublicKey pk = SwidTagParser.parsePublicKeyFromPem(publicKeyFile, "RSA");
-        ReferenceManifestValidator validator = new ReferenceManifestValidator();
-        if (validator.validateXmlSignature(pk, "")) {
-            valid = true;
-        } else {
-            throw new RuntimeException("Failed to verify " + verifyFile);
-        }
-
-        isValid = valid;
-        return valid;
     }
 
     /**

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/xml/pcclientrim/PcClientRim.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/xml/pcclientrim/PcClientRim.java
@@ -126,9 +126,10 @@ public class PcClientRim extends SwidTagGateway implements GenericRim {
      * @param rimel optional
      * @return true if valid, false if not
      */
-    public boolean validate(final String verifyFile, final String publicKeyFile, final String rimel) {
+    public boolean validate(final String verifyFile, final String publicKeyFile, final String rimel)
+                            throws IOException {
         boolean valid;
-        PublicKey pk = SwidTagParser.parsePublicKeyFromPem(publicKeyFile, "SHA256");
+        PublicKey pk = SwidTagParser.parsePublicKeyFromPem(publicKeyFile, "RSA");
         ReferenceManifestValidator validator = new ReferenceManifestValidator();
         if (validator.validateXmlSignature(pk, "")) {
             valid = true;

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/xml/pcclientrim/PcClientRim.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/xml/pcclientrim/PcClientRim.java
@@ -1,6 +1,7 @@
 package hirs.utils.rim.unsignedRim.xml.pcclientrim;
 
 import hirs.utils.rim.ReferenceManifestValidator;
+import hirs.utils.rim.SwidTagParser;
 import hirs.utils.rim.unsignedRim.GenericRim;
 import hirs.utils.rim.unsignedRim.common.measurement.Measurement;
 import hirs.utils.swid.SwidTagConstants;
@@ -17,6 +18,7 @@ import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.dom.DOMSource;
 import java.io.IOException;
 import java.rmi.RemoteException;
+import java.security.PublicKey;
 import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.List;
@@ -107,6 +109,28 @@ public class PcClientRim extends SwidTagGateway implements GenericRim {
         }
 
         if (validator.validateBaseRim(certificateFile)) {
+            valid = true;
+        } else {
+            throw new RuntimeException("Failed to verify " + verifyFile);
+        }
+
+        isValid = valid;
+        return valid;
+    }
+
+    /**
+     * This validate method takes just a public key to verify the input file (rimel optional).
+     *
+     * @param verifyFile to be verified
+     * @param publicKeyFile PK to verify with
+     * @param rimel optional
+     * @return true if valid, false if not
+     */
+    public boolean validate(final String verifyFile, final String publicKeyFile, final String rimel) {
+        boolean valid;
+        PublicKey pk = SwidTagParser.parsePublicKeyFromPem(publicKeyFile, "SHA256");
+        ReferenceManifestValidator validator = new ReferenceManifestValidator();
+        if (validator.validateXmlSignature(pk, "")) {
             valid = true;
         } else {
             throw new RuntimeException("Failed to verify " + verifyFile);


### PR DESCRIPTION
The changes made in this PR allow a PC Client RIM to be verified by just the public key it was signed with.  A message will be logged that without the trust store or public certificate the public key itself cannot be validated.

### Major changes ###

- trust store and public certificate file can be omitted if a public key file is given;
- A method was added to SwidTagParser to create a PublicKey object from a PEM file;
- PcClientRim class now has two overloaded validate() methods; code that creates a Measurement object from the base RIM is in a private method called by both.

Closes #1221 