### PR TITLE
[#1228] Label composite RIMs on the ReferenceManifest page

### DIFF
--- a/HIRS_AttestationCAPortal/src/main/resources/templates/reference-manifests.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/reference-manifests.html
@@ -46,6 +46,8 @@
                             const payload = row.payloadType;
                             if (!payload) {
                                 return rimType;
+                            } else if (payload.toLowerCase() === "hybrid") {
+                                return "Composite";
                             }
                             return rimType + "-" + payload;
                         },

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/rim-details.html
@@ -477,13 +477,13 @@
                     <div id="directoryAccordion" class="accordion">
                         <div class="accordion-item border rounded mb-2 overflow-hidden">
                             <h4 id="directoryHeading" class="accordion-header">
-                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                                <button class="accordion-button" type="button" data-bs-toggle="collapse"
                                     data-bs-target="#directorycollapse" aria-expanded="true"
                                     aria-controls="directorycollapse">
                                     Directory
                                 </button>
                             </h4>
-                            <div id="directorycollapse" class="accordion-collapse collapse"
+                            <div id="directorycollapse" class="accordion-collapse show"
                                 aria-labelledby="directoryHeading" aria-expanded="true"
                                 data-bs-parent="#directoryAccordion">
                                 <div class="accordion-body">


### PR DESCRIPTION
The major change here is that base RIMs with Rim Type "Base - Hybrid" are now Rim Type "Composite".

<img width="1288" height="208" alt="image" src="https://github.com/user-attachments/assets/b2961f58-b24b-424f-8ed9-5a0533eb38fb" />


Closes #1228 