### PR TITLE
Prevent a GitHub Actions workflow from running tests when only MkDocs files have changed

### DIFF
--- a/.github/workflows/dotnet_provisioner_unit_tests.yml
+++ b/.github/workflows/dotnet_provisioner_unit_tests.yml
@@ -1,7 +1,14 @@
 # Updated: 02/03/2026
 name: Dotnet Provisioner Unit Tests and Packages
 
-on: push
+on: 
+  push:
+    paths-ignore:
+      - '**/*.md'       # Ignores all Markdown files
+      - '**/*.png'      # Ignores all PNG images
+      - '**/*.jpg'      # Ignores all JPG images
+      - '**/*.jpeg'     # Ignores all JPEG images
+      - 'mkdocs.yml'    # Ignores the MkDocs config
 env:
   DOTNET_VERSION: 10.0.x
   DOTNET_MSI_TARGETFRAMEWORK: net10.0

--- a/.github/workflows/dotnet_provisioner_unit_tests.yml
+++ b/.github/workflows/dotnet_provisioner_unit_tests.yml
@@ -7,7 +7,6 @@ on:
       - '**/*.md'       # Ignores all Markdown files
       - '**/*.png'      # Ignores all PNG images
       - '**/*.jpg'      # Ignores all JPG images
-      - '**/*.jpeg'     # Ignores all JPEG images
       - 'mkdocs.yml'    # Ignores the MkDocs config
 env:
   DOTNET_VERSION: 10.0.x

--- a/.github/workflows/hirs_package_linux.yml
+++ b/.github/workflows/hirs_package_linux.yml
@@ -9,7 +9,6 @@ on:
       - '**/*.md'       # Ignores all Markdown files
       - '**/*.png'      # Ignores all PNG images
       - '**/*.jpg'      # Ignores all JPG images
-      - '**/*.jpeg'     # Ignores all JPEG images
       - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 

--- a/.github/workflows/hirs_package_linux.yml
+++ b/.github/workflows/hirs_package_linux.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - '*v3*'
       - 'main'
+    paths-ignore:
+      - '**/*.md'       # Ignores all Markdown files
+      - '**/*.png'      # Ignores all PNG images
+      - '**/*.jpg'      # Ignores all JPG images
+      - '**/*.jpeg'     # Ignores all JPEG images
+      - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/hirs_unit_tests.yml
+++ b/.github/workflows/hirs_unit_tests.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - '*v3*'
       - 'main'
+    paths-ignore:
+      - '**/*.md'       # Ignores all Markdown files
+      - '**/*.png'      # Ignores all PNG images
+      - '**/*.jpg'      # Ignores all JPG images
+      - '**/*.jpeg'     # Ignores all JPEG images
+      - 'mkdocs.yml'    # Ignores the MkDocs config
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/hirs_unit_tests.yml
+++ b/.github/workflows/hirs_unit_tests.yml
@@ -12,7 +12,6 @@ on:
       - '**/*.md'       # Ignores all Markdown files
       - '**/*.png'      # Ignores all PNG images
       - '**/*.jpg'      # Ignores all JPG images
-      - '**/*.jpeg'     # Ignores all JPEG images
       - 'mkdocs.yml'    # Ignores the MkDocs config
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/rim_tests.yml
+++ b/.github/workflows/rim_tests.yml
@@ -10,7 +10,6 @@ on:
       - '**/*.md'       # Ignores all Markdown files
       - '**/*.png'      # Ignores all PNG images
       - '**/*.jpg'      # Ignores all JPG images
-      - '**/*.jpeg'     # Ignores all JPEG images
       - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 jobs:

--- a/.github/workflows/rim_tests.yml
+++ b/.github/workflows/rim_tests.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - '*v3*'
       - 'main'
+    paths-ignore:
+      - '**/*.md'       # Ignores all Markdown files
+      - '**/*.png'      # Ignores all PNG images
+      - '**/*.jpg'      # Ignores all JPG images
+      - '**/*.jpeg'     # Ignores all JPEG images
+      - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 jobs:
   tcg_rim_tool_tests:

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -6,6 +6,12 @@ on:
     branches:
       - '*v3*'
       - 'main'
+    paths-ignore:
+      - '**/*.md'       # Ignores all Markdown files
+      - '**/*.png'      # Ignores all PNG images
+      - '**/*.jpg'      # Ignores all JPG images
+      - '**/*.jpeg'     # Ignores all JPEG images
+      - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 jobs:
   DockerTests:

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -10,7 +10,6 @@ on:
       - '**/*.md'       # Ignores all Markdown files
       - '**/*.png'      # Ignores all PNG images
       - '**/*.jpg'      # Ignores all JPG images
-      - '**/*.jpeg'     # Ignores all JPEG images
       - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
Closes #1233 
Need to prevent a GitHub Actions workflow from running tests when only MkDocs files have changed, as mkdocs file changes do not require tests to be run and they are triggering too many github actions.