### PR TITLE
[#1240] Fix issue with XML whitespace validation

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/rim/BaseReferenceManifest.java
@@ -16,6 +16,7 @@ import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -296,7 +297,13 @@ public class BaseReferenceManifest extends ReferenceManifest {
         Element file = null;
         SwidResource swidResource = null;
         for (int i = 0; i < fileNodeList.getLength(); i++) {
-            file = (Element) fileNodeList.item(i);
+            Node childNode = fileNodeList.item(i);
+
+            if (childNode.getNodeType() != Node.ELEMENT_NODE) {
+                continue;
+            }
+
+            file = (Element) childNode;
             swidResource = new SwidResource();
             swidResource.setName(file.getAttribute(SwidTagConstants.NAME));
             swidResource.setSize(file.getAttribute(SwidTagConstants.SIZE));

--- a/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/SwidTagParser.java
@@ -14,12 +14,6 @@ import javax.xml.crypto.dsig.XMLSignature;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
@@ -60,14 +54,13 @@ public final class SwidTagParser {
                 log.error("Schema resource not found");
                 return null;
             }
-            Document validatedDoc = removeXMLWhitespace(doc);
             SchemaFactory schemaFactory = SchemaFactory.newInstance(SwidTagConstants.SCHEMA_LANGUAGE);
             Schema schema = schemaFactory.newSchema(new StreamSource(is));
             JAXBContext jaxbContext = JAXBContext.newInstance(SwidTagConstants.SCHEMA_PACKAGE);
             Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
             unmarshaller.setSchema(schema);
-            unmarshaller.unmarshal(validatedDoc);
-            return validatedDoc;
+            unmarshaller.unmarshal(doc);
+            return doc;
         } catch (UnmarshalException e) {
             throw new UnmarshalException("Error parsing Base RIM: " + e.getCause());
         } catch (IllegalArgumentException e) {
@@ -76,8 +69,6 @@ public final class SwidTagParser {
             e.printStackTrace();
         } catch (IOException e) {
             log.error(e.getMessage());
-        } catch (TransformerException e) {
-            log.error("Error transforming input: " + e.getCause());
         }
         return null;
     }
@@ -173,24 +164,5 @@ public final class SwidTagParser {
         DocumentBuilder builder = dbf.newDocumentBuilder();
         File fileIn = new File(filename);
         return builder.parse(fileIn);
-    }
-
-    /**
-     * This method strips all whitespace from an xml file, including indents and spaces
-     * added for human-readability.
-     *
-     * @param document of the xml file
-     * @return Document object without whitespace
-     */
-    private static Document removeXMLWhitespace(final Document document) throws TransformerException {
-        TransformerFactory tf = TransformerFactory.newInstance();
-        Source source = new StreamSource(
-                SwidTagParser.class.getClassLoader().getResourceAsStream(
-                        SwidTagConstants.IDENTITY_TRANSFORM)
-        );
-        Transformer transformer = tf.newTransformer(source);
-        DOMResult result = new DOMResult();
-        transformer.transform(new DOMSource(document), result);
-        return (Document) result.getNode();
     }
 }


### PR DESCRIPTION
Fixes an issue where XML whitespace is being removed during base RIM parsing, leading to validation issues in certain cases. Also fixes a related bug in BaseReferenceManifest involving incorrectly processed whitespace nodes.