### PR TITLE
[#1239] Implement hashing algorithm for support RIM

### DIFF
--- a/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/xml/pcclientrim/PcClientRim.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/rim/unsignedRim/xml/pcclientrim/PcClientRim.java
@@ -195,17 +195,19 @@ public class PcClientRim extends SwidTagGateway implements GenericRim {
      *
      * @param configFile      config file
      * @param rimEventLog     event log
+     * @param hashAlgorithm   hash algorithm
      * @param certificateFile certificate
      * @param privateKeyFile  private key
      * @param embeddedCert    true if cert should be embedded
      * @param outFile         ouptut RIM
      */
-    public void create(final String configFile, final String rimEventLog, final String certificateFile,
-                       final String privateKeyFile, final boolean embeddedCert, final String outFile) {
+    public void create(final String configFile, final String rimEventLog, final String hashAlgorithm,
+                       final String certificateFile, final String privateKeyFile,
+                       final boolean embeddedCert, final String outFile) {
         SwidTagGateway gateway = new SwidTagGateway();
         gateway.setAttributesFile(configFile);
         gateway.setRimEventLog(rimEventLog);
-
+        gateway.setHashAlgorithm(hashAlgorithm);
         gateway.setDefaultCredentials(false);
         gateway.setPemCertificateFile(certificateFile);
         gateway.setPemPrivateKeyFile(privateKeyFile);

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/HashSwid.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/HashSwid.java
@@ -22,18 +22,6 @@ public class HashSwid {
     public static final String SHA512 = "SHA-512";
 
     /**
-     * Getter method for the hash that uses 256 bit hash.
-     *
-     * @param filepath the file to hash.
-     * @return the SHA-256 hash of the file's contents, as a hexadecimal string.
-     * @throws Exception if any issues arise while retrieving the SHA256 hash
-     */
-    public static String get256Hash(final String filepath)
-            throws NoSuchAlgorithmException, IOException {
-        return getHashValue(filepath, SHA256);
-    }
-
-    /**
      * This method creates the hash based on the provided algorithm
      * only accessible through helper methods.
      * This method assumes an input file that is small enough to read in its
@@ -111,13 +99,26 @@ public class HashSwid {
     }
 
     /**
+     * Getter method for the hash that uses 256 bit hash.
+     *
+     * @param filepath the file to hash.
+     * @return the SHA-256 hash of the file's contents, as a hexadecimal string.
+     * @throws Exception if any issues arise while retrieving the SHA256 hash
+     */
+    public static String get256Hash(final String filepath)
+            throws NoSuchAlgorithmException, IOException {
+        return getHashValue(filepath, SHA256);
+    }
+
+    /**
      * Getter method for the hash that uses 384 bit hash.
      *
      * @param filepath the file to hash.
      * @return the SHA-384 hash of the file's contents, as a hexadecimal string.
      * @throws Exception if any issues arise while retrieving the SHA384 hash.
      */
-    public String get384Hash(final String filepath) throws Exception {
+    public static String get384Hash(final String filepath)
+            throws NoSuchAlgorithmException, IOException {
         return getHashValue(filepath, SHA384);
     }
 
@@ -128,7 +129,8 @@ public class HashSwid {
      * @return the SHA-512 hash of the file's contents, as a hexadecimal string.
      * @throws Exception if any issues arise while retrieving the SHA512 hash.
      */
-    public String get512Hash(final String filepath) throws Exception {
+    public static String get512Hash(final String filepath)
+            throws NoSuchAlgorithmException, IOException {
         return getHashValue(filepath, SHA512);
     }
 }

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
@@ -128,6 +128,8 @@ public final class SwidTagConstants {
             "http://www.w3.org/2001/04/xmlenc#sha256", HASH, SHA256);
     public static final QName SHA_384_HASH = new QName(
             "http://www.w3.org/2001/04/xmlenc#sha384", HASH, SHA384);
+    public static final QName SHA_512_HASH = new QName(
+            "http://www.w3.org/2001/04/xmlenc#sha512", HASH, SHA512);
     public static final QName QNAME_COLLOQUIAL_VERSION = new QName(
             NIST_NS, COLLOQUIAL_VERSION, N8060_PFX);
     public static final QName QNAME_EDITION = new QName(

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagConstants.java
@@ -67,6 +67,9 @@ public final class SwidTagConstants {
     public static final String RIM_LINK_HASH = "rimLinkHash";
     public static final String SIZE = "size";
     public static final String HASH = "hash";
+    public static final String SHA256 = "SHA256";
+    public static final String SHA384 = "SHA384";
+    public static final String SHA512 = "SHA512";
     public static final String SUPPORT_RIM_TYPE = "supportRimType";
     public static final String SUPPORT_RIM_FORMAT = "supportRimFormat";
     public static final String ROOT = "root";
@@ -122,9 +125,9 @@ public final class SwidTagConstants {
     public static final String PC_URI_GLOBAL_STR = RIM_PFX + FX_SEPARATOR
             + PC_URI_GLOBAL;
     public static final QName SHA_256_HASH = new QName(
-            "http://www.w3.org/2001/04/xmlenc#sha256", HASH, "SHA256");
+            "http://www.w3.org/2001/04/xmlenc#sha256", HASH, SHA256);
     public static final QName SHA_384_HASH = new QName(
-            "http://www.w3.org/2001/04/xmlenc#sha384", HASH, "SHA384");
+            "http://www.w3.org/2001/04/xmlenc#sha384", HASH, SHA384);
     public static final QName QNAME_COLLOQUIAL_VERSION = new QName(
             NIST_NS, COLLOQUIAL_VERSION, N8060_PFX);
     public static final QName QNAME_EDITION = new QName(

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
@@ -528,27 +528,28 @@ public class SwidTagGateway {
         String fileHash = jsonObject.getString(SwidTagConstants.HASH, "");
 
         if (fileHash.isEmpty()) {
-            if (rimEventLog.isEmpty() || hashAlgorithm.isEmpty()) {
+            if (rimEventLog.isEmpty()) {
                 throw new RuntimeException("The config file must declare a file hash, "
-                       + "or a support RIM and hash algorithm must be given.");
-            } else {
-                switch (hashAlgorithm.toUpperCase()) {
-                    case SwidTagConstants.SHA256:
-                        fileHash = HashSwid.get256Hash(rimEventLog);
-                        hashKey = SwidTagConstants.SHA_256_HASH;
-                        break;
-                    case SwidTagConstants.SHA384:
-                        fileHash = HashSwid.get384Hash(rimEventLog);
-                        hashKey = SwidTagConstants.SHA_384_HASH;
-                        break;
-                    case SwidTagConstants.SHA512:
-                        fileHash = HashSwid.get512Hash(rimEventLog);
-                        hashKey = SwidTagConstants.SHA_512_HASH;
-                        break;
-                    default:
-                        throw new NoSuchAlgorithmException("Unexpected value: " + hashAlgorithm);
-                };
+                        + "or a support RIM and hash algorithm must be given.");
+            } else if (hashAlgorithm.isEmpty()) {
+                System.out.println("No hash algorithm given, defaulting to SHA256.");
             }
+            switch (hashAlgorithm.toUpperCase()) {
+                case SwidTagConstants.SHA256:
+                    fileHash = HashSwid.get256Hash(rimEventLog);
+                    hashKey = SwidTagConstants.SHA_256_HASH;
+                    break;
+                case SwidTagConstants.SHA384:
+                    fileHash = HashSwid.get384Hash(rimEventLog);
+                    hashKey = SwidTagConstants.SHA_384_HASH;
+                    break;
+                case SwidTagConstants.SHA512:
+                    fileHash = HashSwid.get512Hash(rimEventLog);
+                    hashKey = SwidTagConstants.SHA_512_HASH;
+                    break;
+                default:
+                    throw new NoSuchAlgorithmException("Unexpected value: " + hashAlgorithm);
+            };
         }
         addNonNullAttribute(attributes, hashKey, fileHash, true);
         String supportRimFormat = jsonObject.getString(SwidTagConstants.SUPPORT_RIM_FORMAT,

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
@@ -532,7 +532,7 @@ public class SwidTagGateway {
                 throw new RuntimeException("The config file must declare a file hash, "
                        + "or a support RIM and hash algorithm must be given.");
             } else {
-                switch (hashAlgorithm) {
+                switch (hashAlgorithm.toUpperCase()) {
                     case SwidTagConstants.SHA256:
                         fileHash = HashSwid.get256Hash(rimEventLog);
                         hashKey = SwidTagConstants.SHA_256_HASH;

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
@@ -524,23 +524,33 @@ public class SwidTagGateway {
         file.setName(jsonObject.getString(SwidTagConstants.NAME, ""));
         file.setSize(new BigInteger(jsonObject.getString(SwidTagConstants.SIZE, "0")));
         Map<QName, String> attributes = file.getOtherAttributes();
-        String fileHash;
-        if (rimEventLog.isEmpty()) {
-            fileHash = jsonObject.getString(SwidTagConstants.HASH);
-        } else {
-            String defaultHashValue = "";
-            if (!hashAlgorithm.isEmpty()) {
-                defaultHashValue = switch (hashAlgorithm) {
-                    case SwidTagConstants.SHA256 -> HashSwid.get256Hash(rimEventLog);
-                    case SwidTagConstants.SHA384 -> HashSwid.get384Hash(rimEventLog);
-                    case SwidTagConstants.SHA512 -> HashSwid.get512Hash(rimEventLog);
-                    default -> throw new NoSuchAlgorithmException("Unexpected value: " + hashAlgorithm);
+        QName hashKey = new QName("");
+        String fileHash = jsonObject.getString(SwidTagConstants.HASH, "");
+
+        if (fileHash.isEmpty()) {
+            if (rimEventLog.isEmpty() || hashAlgorithm.isEmpty()) {
+                throw new RuntimeException("The config file must declare a file hash, "
+                       + "or a support RIM and hash algorithm must be given.");
+            } else {
+                switch (hashAlgorithm) {
+                    case SwidTagConstants.SHA256:
+                        fileHash = HashSwid.get256Hash(rimEventLog);
+                        hashKey = SwidTagConstants.SHA_256_HASH;
+                        break;
+                    case SwidTagConstants.SHA384:
+                        fileHash = HashSwid.get384Hash(rimEventLog);
+                        hashKey = SwidTagConstants.SHA_384_HASH;
+                        break;
+                    case SwidTagConstants.SHA512:
+                        fileHash = HashSwid.get512Hash(rimEventLog);
+                        hashKey = SwidTagConstants.SHA_512_HASH;
+                        break;
+                    default:
+                        throw new NoSuchAlgorithmException("Unexpected value: " + hashAlgorithm);
                 };
             }
-            fileHash = jsonObject.getString(SwidTagConstants.HASH,
-                    defaultHashValue);
         }
-        addNonNullAttribute(attributes, SwidTagConstants.SHA_256_HASH, fileHash, true);
+        addNonNullAttribute(attributes, hashKey, fileHash, true);
         String supportRimFormat = jsonObject.getString(SwidTagConstants.SUPPORT_RIM_FORMAT,
                 SwidTagConstants.SUPPORT_RIM_FORMAT_MISSING);
         if (!supportRimFormat.equals(SwidTagConstants.SUPPORT_RIM_FORMAT_MISSING)) {

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
@@ -2,6 +2,7 @@ package hirs.utils.swid;
 
 import hirs.utils.xjc.Directory;
 import hirs.utils.xjc.Entity;
+import hirs.utils.xjc.File;
 import hirs.utils.xjc.FilesystemItem;
 import hirs.utils.xjc.Link;
 import hirs.utils.xjc.ObjectFactory;
@@ -131,6 +132,12 @@ public class SwidTagGateway {
     private String rimEventLog;
 
     /**
+     * hashing algorithm for paylod file(s)
+     */
+    @Setter
+    private String hashAlgorithm;
+
+    /**
      * timestamp format in XML signature.
      */
     @Setter
@@ -246,7 +253,7 @@ public class SwidTagGateway {
         }
         Iterator itr = files.iterator();
         while (itr.hasNext()) {
-            hirs.utils.xjc.File file;
+            File file;
             try {
                 file = createFile((JsonObject) itr.next());
             } catch (NoSuchAlgorithmException | IOException e) {
@@ -511,18 +518,27 @@ public class SwidTagGateway {
      * @param jsonObject the Properties object containing parameters from file
      * @return File object created from the properties
      */
-    private hirs.utils.xjc.File createFile(final JsonObject jsonObject)
+    private File createFile(final JsonObject jsonObject)
         throws NoSuchAlgorithmException, IOException {
-        hirs.utils.xjc.File file = objectFactory.createFile();
+        File file = objectFactory.createFile();
         file.setName(jsonObject.getString(SwidTagConstants.NAME, ""));
         file.setSize(new BigInteger(jsonObject.getString(SwidTagConstants.SIZE, "0")));
         Map<QName, String> attributes = file.getOtherAttributes();
         String fileHash;
         if (rimEventLog.isEmpty()) {
-            fileHash = jsonObject.getString(SwidTagConstants.SHA_256_HASH.getLocalPart());
+            fileHash = jsonObject.getString(SwidTagConstants.HASH);
         } else {
-            fileHash = jsonObject.getString(SwidTagConstants.SHA_256_HASH.getLocalPart(),
-                    HashSwid.get256Hash(rimEventLog));
+            String defaultHashValue = "";
+            if (!hashAlgorithm.isEmpty()) {
+                defaultHashValue = switch (hashAlgorithm) {
+                    case SwidTagConstants.SHA256 -> HashSwid.get256Hash(rimEventLog);
+                    case SwidTagConstants.SHA384 -> HashSwid.get384Hash(rimEventLog);
+                    case SwidTagConstants.SHA512 -> HashSwid.get512Hash(rimEventLog);
+                    default -> throw new NoSuchAlgorithmException("Unexpected value: " + hashAlgorithm);
+                };
+            }
+            fileHash = jsonObject.getString(SwidTagConstants.HASH,
+                    defaultHashValue);
         }
         addNonNullAttribute(attributes, SwidTagConstants.SHA_256_HASH, fileHash, true);
         String supportRimFormat = jsonObject.getString(SwidTagConstants.SUPPORT_RIM_FORMAT,

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
@@ -524,7 +524,7 @@ public class SwidTagGateway {
         file.setName(jsonObject.getString(SwidTagConstants.NAME, ""));
         file.setSize(new BigInteger(jsonObject.getString(SwidTagConstants.SIZE, "0")));
         Map<QName, String> attributes = file.getOtherAttributes();
-        QName hashKey = new QName("");
+        QName hashKey = SwidTagConstants.SHA_256_HASH; //default to SHA256
         String fileHash = jsonObject.getString(SwidTagConstants.HASH, "");
 
         if (fileHash.isEmpty()) {

--- a/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
+++ b/HIRS_Utils/src/main/java/hirs/utils/swid/SwidTagGateway.java
@@ -532,6 +532,7 @@ public class SwidTagGateway {
                 throw new RuntimeException("The config file must declare a file hash, "
                         + "or a support RIM and hash algorithm must be given.");
             } else if (hashAlgorithm.isEmpty()) {
+                hashAlgorithm = SwidTagConstants.SHA256;
                 System.out.println("No hash algorithm given, defaulting to SHA256.");
             }
             switch (hashAlgorithm.toUpperCase()) {


### PR DESCRIPTION
Major changes include:

- Add constants to specify SHA256, SHA384, and SHA512
- Add methods to calculate a file digest using the above hashes
- Create a base RIM with a file attribute corresponding to the above hash and digest

Closes #1239 