### PR TITLE
Update github actions to not require tests to run for doc-only/image-only file merges - closed

### DIFF
--- a/.github/workflows/dotnet_provisioner_unit_tests.yml
+++ b/.github/workflows/dotnet_provisioner_unit_tests.yml
@@ -3,17 +3,31 @@ name: Dotnet Provisioner Unit Tests and Packages
 
 on: 
   push:
-    paths-ignore:
-      - '**/*.md'       # Ignores all Markdown files
-      - '**/*.png'      # Ignores all PNG images
-      - '**/*.jpg'      # Ignores all JPG images
-      - 'mkdocs.yml'    # Ignores the MkDocs config
 env:
   DOTNET_VERSION: 10.0.x
   DOTNET_MSI_TARGETFRAMEWORK: net10.0
   DOTNET_ROLL_FORWARD: LatestMajor
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+            - '!**/*.md'       # all Markdown files
+            - '!**/*.png'      # all PNG images
+            - '!**/*.jpg'      # all JPG images
+            - '!mkdocs.yml'    # the MkDocs config
+            - '**'
   test:
+    needs: check-changes
+    # Run if code changes exist OR if triggered manually
+    if: ${{ needs.check-changes.outputs.code_changed == 'true' || github.event_name == 'workflow_dispatch' }}
     name: Run Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/hirs_package_linux.yml
+++ b/.github/workflows/hirs_package_linux.yml
@@ -5,16 +5,30 @@ on:
     branches:
       - '*v3*'
       - 'main'
-    paths-ignore:
-      - '**/*.md'       # Ignores all Markdown files
-      - '**/*.png'      # Ignores all PNG images
-      - '**/*.jpg'      # Ignores all JPG images
-      - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+            - '!**/*.md'       # all Markdown files
+            - '!**/*.png'      # all PNG images
+            - '!**/*.jpg'      # all JPG images
+            - '!mkdocs.yml'    # the MkDocs config
+            - '**'
   # run the package script for HIRS ACA, Provisioners, tcg_rim_tool, and tcg_eventlog_tool
   Package_linux:
+    needs: check-changes
+    # Run if code changes exist OR if triggered manually
+    if: ${{ needs.check-changes.outputs.code_changed == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/hirs_unit_tests.yml
+++ b/.github/workflows/hirs_unit_tests.yml
@@ -8,17 +8,31 @@ on:
     branches:
       - '*v3*'
       - 'main'
-    paths-ignore:
-      - '**/*.md'       # Ignores all Markdown files
-      - '**/*.png'      # Ignores all PNG images
-      - '**/*.jpg'      # Ignores all JPG images
-      - 'mkdocs.yml'    # Ignores the MkDocs config
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+            - '!**/*.md'       # all Markdown files
+            - '!**/*.png'      # all PNG images
+            - '!**/*.jpg'      # all JPG images
+            - '!mkdocs.yml'    # the MkDocs config
+            - '**'
   # Run the unit tests and package HIRS ACA, provisoner, and tools
   ACA_Provisioner_Unit_Tests:
+    needs: check-changes
+    # Run if code changes exist OR if triggered manually
+    if: ${{ needs.check-changes.outputs.code_changed == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest  # Configures the job to run on the latest version of an Ubuntu Linux runner
     steps:
       - uses: actions/checkout@v6  # run v6 of actions/checkout action, which checks out your repository onto the runner

--- a/.github/workflows/rim_tests.yml
+++ b/.github/workflows/rim_tests.yml
@@ -6,14 +6,28 @@ on:
     branches:
       - '*v3*'
       - 'main'
-    paths-ignore:
-      - '**/*.md'       # Ignores all Markdown files
-      - '**/*.png'      # Ignores all PNG images
-      - '**/*.jpg'      # Ignores all JPG images
-      - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+            - '!**/*.md'       # all Markdown files
+            - '!**/*.png'      # all PNG images
+            - '!**/*.jpg'      # all JPG images
+            - '!mkdocs.yml'    # the MkDocs config
+            - '**'
   tcg_rim_tool_tests:
+    needs: check-changes
+    # Run if code changes exist OR if triggered manually
+    if: ${{ needs.check-changes.outputs.code_changed == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -6,14 +6,28 @@ on:
     branches:
       - '*v3*'
       - 'main'
-    paths-ignore:
-      - '**/*.md'       # Ignores all Markdown files
-      - '**/*.png'      # Ignores all PNG images
-      - '**/*.jpg'      # Ignores all JPG images
-      - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+            - '!**/*.md'       # all Markdown files
+            - '!**/*.png'      # all PNG images
+            - '!**/*.jpg'      # all JPG images
+            - '!mkdocs.yml'    # the MkDocs config
+            - '**'
   DockerTests:
+    needs: check-changes
+    # Run if code changes exist OR if triggered manually
+    if: ${{ needs.check-changes.outputs.code_changed == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     outputs:
       test-result: ${{ steps.set_outputs.outputs.test-result }}


### PR DESCRIPTION
Closes #1255 
Currently github actions is blocking merge of doc/image files because they do not run system tests. Need to be able to merge them even though they don't run system tests.