### PR TITLE
[#1272] Fixing regression with AK/EK public area

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/CertificateRequestProcessorService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/provision/service/CertificateRequestProcessorService.java
@@ -163,7 +163,7 @@ public class CertificateRequestProcessorService {
             // Get attestation public key
             ParsedTpmPublic akPub;
             try {
-                akPub = TpmPublicHelper.parseTpmPublicArea(identityClaim.getEkPublicArea().toByteArray());
+                akPub = TpmPublicHelper.parseTpmPublicArea(identityClaim.getAkPublicArea().toByteArray());
             } catch (Exception e) {
                 log.error("Could not parse AK pub: {}", e.getMessage());
                 throw new IllegalStateException(e.getMessage());


### PR DESCRIPTION
Fixes regression with EK/AK public areas being swapped in one location, potentially impacting certificate issuance.

Closes #1272.