### PR TITLE
Remove ignore doc files in github actions

### DIFF
--- a/.github/workflows/dotnet_provisioner_unit_tests.yml
+++ b/.github/workflows/dotnet_provisioner_unit_tests.yml
@@ -3,11 +3,6 @@ name: Dotnet Provisioner Unit Tests and Packages
 
 on:
   push:
-    paths-ignore:
-      - '**/*.md'       # Ignores all Markdown files
-      - '**/*.png'      # Ignores all PNG images
-      - '**/*.jpg'      # Ignores all JPG images
-      - 'mkdocs.yml'    # Ignores the MkDocs config
 env:
   DOTNET_VERSION: 10.0.x
   DOTNET_MSI_TARGETFRAMEWORK: net10.0

--- a/.github/workflows/hirs_package_linux.yml
+++ b/.github/workflows/hirs_package_linux.yml
@@ -5,11 +5,6 @@ on:
     branches:
       - '*v3*'
       - 'main'
-    paths-ignore:
-      - '**/*.md'       # Ignores all Markdown files
-      - '**/*.png'      # Ignores all PNG images
-      - '**/*.jpg'      # Ignores all JPG images
-      - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/hirs_unit_tests.yml
+++ b/.github/workflows/hirs_unit_tests.yml
@@ -8,11 +8,6 @@ on:
     branches:
       - '*v3*'
       - 'main'
-    paths-ignore:
-      - '**/*.md'       # Ignores all Markdown files
-      - '**/*.png'      # Ignores all PNG images
-      - '**/*.jpg'      # Ignores all JPG images
-      - 'mkdocs.yml'    # Ignores the MkDocs config
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/rim_tests.yml
+++ b/.github/workflows/rim_tests.yml
@@ -6,11 +6,6 @@ on:
     branches:
       - '*v3*'
       - 'main'
-    paths-ignore:
-      - '**/*.md'       # Ignores all Markdown files
-      - '**/*.png'      # Ignores all PNG images
-      - '**/*.jpg'      # Ignores all JPG images
-      - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 jobs:
   tcg_rim_tool_tests:

--- a/.github/workflows/system_test.yml
+++ b/.github/workflows/system_test.yml
@@ -6,11 +6,6 @@ on:
     branches:
       - '*v3*'
       - 'main'
-    paths-ignore:
-      - '**/*.md'       # Ignores all Markdown files
-      - '**/*.png'      # Ignores all PNG images
-      - '**/*.jpg'      # Ignores all JPG images
-      - 'mkdocs.yml'    # Ignores the MkDocs config
   workflow_dispatch:
 jobs:
   DockerTests:


### PR DESCRIPTION
Closes #1295 

Need to remove ignore doc files in github actions because it prevents tests from running, and if tests don't run the PR cannot be merged without administrative override