### PR TITLE
[#1280] New PXE boot policy

### DIFF
--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/PolicySettings.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/entity/userdefined/PolicySettings.java
@@ -90,6 +90,9 @@ public class PolicySettings extends UserDefinedEntity {
     @Column(nullable = false, columnDefinition = "boolean default false")
     private boolean ignoreOsEvtEnabled = false;
 
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean ignoreOsEvtPxeBootEnabled = false;
+
     @Column(nullable = false, columnDefinition = "boolean default true")
     private boolean saveProtobufToLogOnFailedValEnabled = true;
 

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/PolicyPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/PolicyPageService.java
@@ -327,10 +327,6 @@ public class PolicyPageService {
             return false;
         }
 
-        if (isIgnoreOSEvtPxeBootOptionEnabled) {
-            policySettings.setIgnoreGptEnabled(true);
-        }
-
         policySettings.setIgnoreOsEvtPxeBootEnabled(isIgnoreOSEvtPxeBootOptionEnabled);
 
         policyRepository.saveAndFlush(policySettings);

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/PolicyPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/PolicyPageService.java
@@ -311,6 +311,37 @@ public class PolicyPageService {
     }
 
     /**
+     * Updates the Ignore OS Events for PXE Boot policy under the Firmware Validation policy setting
+     * according to user input.
+     *
+     * @param isIgnoreOSEvtPxeBootOptionEnabled boolean value representation of the current policy option's state
+     * @return true if the policy was updated successfully; otherwise, false.
+     */
+    public boolean updateIgnoreOSEventsPxeBootPolicy(final boolean isIgnoreOSEvtPxeBootOptionEnabled) {
+        PolicySettings policySettings = getDefaultPolicy();
+
+        //If Ignore OS events is enabled and Firmware Validation is not enabled, disallow change
+        if (isIgnoreOSEvtPxeBootOptionEnabled && !policySettings.isFirmwareValidationEnabled()) {
+            log.error("Ignore OS Events for PXE Boot cannot be enabled without Firmware Validation "
+                    + "policy enabled.");
+            return false;
+        }
+
+        if (isIgnoreOSEvtPxeBootOptionEnabled) {
+            policySettings.setIgnoreGptEnabled(true);
+        }
+
+        policySettings.setIgnoreOsEvtPxeBootEnabled(isIgnoreOSEvtPxeBootOptionEnabled);
+
+        policyRepository.saveAndFlush(policySettings);
+
+        log.debug("Current ACA Policy after updating the Ignore OS Events for PXE Boot policy:"
+                + " {}", policySettings);
+
+        return true;
+    }
+
+    /**
      * Updates the Issued Attestation Certificate generation policy according to user input.
      *
      * @param isIssuedAttestationOptionEnabled boolean value representation of the current policy option's

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/service/ReferenceManifestDetailsPageService.java
@@ -70,6 +70,7 @@ public class ReferenceManifestDetailsPageService {
      * @param referenceDigestValueRepository reference digest value repository
      * @param certificateRepository          certificate repository
      * @param caCertificateRepository        certificate authority credential repository
+     * @param policyRepository               policy settings repository
      */
     @Autowired
     public ReferenceManifestDetailsPageService(final ReferenceManifestRepository referenceManifestRepository,

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/PcrValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/PcrValidator.java
@@ -160,7 +160,7 @@ public class PcrValidator {
     }
 
     /**
-     * Checks that the expected FM events occurring. There are policy options that
+     * Checks that the expected FW events occurring. There are policy options that
      * will ignore certin PCRs, Event Types and Event Variables present.
      *
      * @param tcgMeasurementLog Measurement log from the client
@@ -175,11 +175,14 @@ public class PcrValidator {
         // log firmware policy settings
         if (policySettings.isIgnoreImaEnabled()) {
             log.info("IMA Ignored - any associated events will not be checked");
-        } else if (policySettings.isIgnoretBootEnabled()) {
+        }
+        if (policySettings.isIgnoretBootEnabled()) {
             log.info("TBOOT Ignored - any associated events will not be checked");
-        } else if (policySettings.isIgnoreGptEnabled()) {
+        }
+        if (policySettings.isIgnoreGptEnabled()) {
             log.info("GPT Ignored - any associated events will not be checked");
-        } else if (policySettings.isIgnoreOsEvtEnabled()) {
+        }
+        if (policySettings.isIgnoreOsEvtEnabled()) {
             log.info("OS Ignored - any associated events will not be checked");
         }
 
@@ -197,6 +200,10 @@ public class PcrValidator {
             } else {
                 if (policySettings.isIgnoreGptEnabled() && tpe.getEventTypeStr().contains(EVT_EFI_GPT)) {
                     log.debug(String.format("GPT Ignored -> %s", tpe));
+                } else if (policySettings.isIgnoreOsEvtPxeBootEnabled()
+                        && tpe.getEventType() == EvConstants.EV_EFI_BOOT_SERVICES_APPLICATION
+                        && tpe.getEventContentStr().contains("root=(http:")) {
+                    log.debug(String.format("OS Evt Ignored during PXE Boot -> %s", tpe));
                 } else if (policySettings.isIgnoreOsEvtEnabled()
                         && firmwareBootFinished[tpe.getPcrIndex()]) {
                     log.debug(String.format("Firmware boot finished -> %s", tpe));

--- a/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/PcrValidator.java
+++ b/HIRS_AttestationCA/src/main/java/hirs/attestationca/persist/validation/PcrValidator.java
@@ -197,23 +197,28 @@ public class PcrValidator {
                 log.debug(String.format("TBOOT Ignored -> %s", tpe));
             } else if (policySettings.isIgnoreOsEvtEnabled() && (tpe.getPcrIndex() > FIRMWARE_PCR_END)) {
                 log.debug(String.format("OS Evt Ignored -> %s", tpe));
+            } else if (policySettings.isIgnoreGptEnabled() && tpe.getEventTypeStr().contains(EVT_EFI_GPT)) {
+                log.debug(String.format("GPT Ignored -> %s", tpe));
+            } else if (policySettings.isIgnoreOsEvtPxeBootEnabled()) {
+                if (tpe.getPcrIndex() > FIRMWARE_PCR_END) {
+                    log.debug(String.format("OS Evt Ignored -> %s", tpe));
+                } else if (tpe.getEventType() == EvConstants.EV_EFI_BOOT_SERVICES_APPLICATION
+                        && tpe.getEventContentStr().contains("PIWG Firmware Volume Path")) {
+                    log.debug(String.format("Boot event ignored during PXE Boot -> %s", tpe));
+                    String eventDigest = tpe.getEventDigestStr();
+                    if (eventLogRecords.containsKey(eventDigest)) {
+                        log.debug(String.format("%s found in the Support RIM", eventDigest));
+                    }
+                }
+            } else if (policySettings.isIgnoreOsEvtEnabled()
+                    && firmwareBootFinished[tpe.getPcrIndex()]) {
+                log.debug(String.format("Firmware boot finished -> %s", tpe));
             } else {
-                if (policySettings.isIgnoreGptEnabled() && tpe.getEventTypeStr().contains(EVT_EFI_GPT)) {
-                    log.debug(String.format("GPT Ignored -> %s", tpe));
-                } else if (policySettings.isIgnoreOsEvtPxeBootEnabled()
-                        && tpe.getEventType() == EvConstants.EV_EFI_BOOT_SERVICES_APPLICATION
-                        && tpe.getEventContentStr().contains("root=(http:")) {
-                    log.debug(String.format("OS Evt Ignored during PXE Boot -> %s", tpe));
-                } else if (policySettings.isIgnoreOsEvtEnabled()
-                        && firmwareBootFinished[tpe.getPcrIndex()]) {
-                    log.debug(String.format("Firmware boot finished -> %s", tpe));
-                } else {
-                    if (!eventLogRecords.containsKey(tpe.getEventDigestStr())) {
-                        tpmPcrEventsNotExpected.add(tpe);
-                    }
-                    if (tpe.getEventType() == EvConstants.EV_SEPARATOR) {
-                        firmwareBootFinished[tpe.getPcrIndex()] = true;
-                    }
+                if (!eventLogRecords.containsKey(tpe.getEventDigestStr())) {
+                    tpmPcrEventsNotExpected.add(tpe);
+                }
+                if (tpe.getEventType() == EvConstants.EV_SEPARATOR) {
+                    firmwareBootFinished[tpe.getPcrIndex()] = true;
                 }
             }
         }

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/PolicyPageModel.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/PolicyPageModel.java
@@ -24,6 +24,7 @@ public class PolicyPageModel {
     private boolean ignoreTbootEnabled;
     private boolean ignoreGptEnabled;
     private boolean ignoreOsEvtEnabled;
+    private boolean ignoreOsEvtPxeBootEnabled;
     private boolean ignorePcieVpdAttributeEnabled;
     private boolean issueAttestationCertificateEnabled;
     private boolean issueDevIdCertificateEnabled;
@@ -62,6 +63,7 @@ public class PolicyPageModel {
         this.ignoreTbootEnabled = policySettings.isIgnoretBootEnabled();
         this.ignoreGptEnabled = policySettings.isIgnoreGptEnabled();
         this.ignoreOsEvtEnabled = policySettings.isIgnoreOsEvtEnabled();
+        this.ignoreOsEvtPxeBootEnabled = policySettings.isIgnoreOsEvtPxeBootEnabled();
         this.generateAttestCertExpirationValue = policySettings.getValidityDays();
         this.generateAttestCertThresholdValue = policySettings.getReissueThreshold();
         this.generateDevIdCertExpirationValue = policySettings.getDevIdValidityDays();

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateDetailsPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/CertificateDetailsPageController.java
@@ -41,10 +41,11 @@ public class CertificateDetailsPageController extends PageController<Certificate
     /**
      * Constructor providing the Page's display and routing specification.
      *
-     * @param certificateRepository     the certificate repository
-     * @param componentResultRepository the component result repository
-     * @param caCredentialRepository    the ca credential manager
-     * @param referenceManifestRepository the rim repository
+     * @param certificateRepository         the certificate repository
+     * @param componentResultRepository     the component result repository
+     * @param componentAttributeRepository  the component attribute repository
+     * @param caCredentialRepository        the ca credential manager
+     * @param referenceManifestRepository   the rim repository
      */
     @Autowired
     public CertificateDetailsPageController(final CertificateRepository certificateRepository,

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PolicyPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PolicyPageController.java
@@ -537,6 +537,56 @@ public class PolicyPageController extends PageController<NoPageParams> {
     }
 
     /**
+     * Updates the Ignore OS Events for PXE Boot policy under the Firmware Validation policy setting
+     * and redirects the user back to the Policy Settings page.
+     *
+     * @param ppModel            The data posted by the form mapped into an object.
+     * @param redirectAttributes RedirectAttributes used to forward data back to the original
+     *                           page.
+     * @return redirect to Policy Settings page
+     * @throws URISyntaxException if malformed URI
+     */
+    @PostMapping("update-os-events-pxe-boot-ignore")
+    public RedirectView updateIgnoreOsEventsPxeBootPolicy(@ModelAttribute final PolicyPageModel ppModel,
+                                                   final RedirectAttributes redirectAttributes)
+            throws URISyntaxException {
+        Map<String, Object> model = new HashMap<>();
+        PageMessages messages = new PageMessages();
+
+        log.info(
+                "Received request to update the Ignore OS Events for PXE Boot policy "
+                        + "under the Firmware Validation policy setting");
+
+        try {
+            final boolean isIgnoreOsEvtPxeBootOptionEnabled = ppModel.isIgnoreOsEvtPxeBootEnabled();
+            final boolean isIgnoreOsEvtPxeBootPolicyUpdateSuccessful =
+                    policyPageService.updateIgnoreOSEventsPxeBootPolicy(
+                            isIgnoreOsEvtPxeBootOptionEnabled);
+
+            if (!isIgnoreOsEvtPxeBootPolicyUpdateSuccessful) {
+                messages.addErrorMessage(
+                        "Ignore OS Events cannot be enabled without Firmware Validation policy enabled.");
+                model.put(MESSAGES_ATTRIBUTE, messages);
+                return redirectToSelf(new NoPageParams(), model, redirectAttributes);
+            }
+
+            // if the Ignore OS events policy update was successful
+            messages.addSuccessMessage(
+                    isIgnoreOsEvtPxeBootOptionEnabled ? "Ignore OS Events for PXE Boot enabled" :
+                            "Ignore OS Events for PXE Boot disabled");
+            model.put(MESSAGES_ATTRIBUTE, messages);
+        } catch (Exception exception) {
+            final String errorMessage =
+                    "An exception was thrown while updating ACA OS Events Ignore for PXE Boot policy";
+            log.error(errorMessage, exception);
+            messages.addErrorMessage(errorMessage);
+            model.put(MESSAGES_ATTRIBUTE, messages);
+        }
+
+        return redirectToSelf(new NoPageParams(), model, redirectAttributes);
+    }
+
+    /**
      * Updates the Attestation Certificate generation policy setting and redirects the user
      * back to the Policy Settings page.
      *

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PolicyPageController.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/controllers/PolicyPageController.java
@@ -572,8 +572,8 @@ public class PolicyPageController extends PageController<NoPageParams> {
 
             // if the Ignore OS events policy update was successful
             messages.addSuccessMessage(
-                    isIgnoreOsEvtPxeBootOptionEnabled ? "Ignore OS Events for PXE Boot enabled" :
-                            "Ignore OS Events for PXE Boot disabled");
+                    isIgnoreOsEvtPxeBootOptionEnabled ? "Ignore OS Events for PXE Boot enabled"
+                            : "Ignore OS Events for PXE Boot disabled");
             model.put(MESSAGES_ATTRIBUTE, messages);
         } catch (Exception exception) {
             final String errorMessage =

--- a/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
+++ b/HIRS_AttestationCAPortal/src/main/java/hirs/attestationca/portal/page/utils/CertificateStringMapBuilder.java
@@ -535,12 +535,13 @@ public final class CertificateStringMapBuilder {
      * @return certificate information
      * @throws IOException when parsing the certificate
      */
-    public static HashMap<String, Object> getPlatformInformation(final UUID uuid,
-                                                                 final CertificateRepository certificateRepository,
-                                                                 final ComponentResultRepository componentResultRepository,
-                                                                 final ComponentAttributeRepository componentAttributeRepository,
-                                                                 final CACredentialRepository caCertificateRepository,
-                                                                 final String provisionSessionId)
+    public static HashMap<String, Object> getPlatformInformation(
+                                                final UUID uuid,
+                                                final CertificateRepository certificateRepository,
+                                                final ComponentResultRepository componentResultRepository,
+                                                final ComponentAttributeRepository componentAttributeRepository,
+                                                final CACredentialRepository caCertificateRepository,
+                                                final String provisionSessionId)
             throws IllegalArgumentException, IOException {
         HashMap<String, Object> data = new HashMap<>();
         PlatformCredential certificate = (PlatformCredential) certificateRepository.getCertificate(uuid);

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/policy.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/policy.html
@@ -401,7 +401,7 @@
                             <form method="POST"
                                   th:action="@{/HIRS_AttestationCAPortal/portal/policy/update-os-events-pxe-boot-ignore}"
                                   th:object="${initialData}">
-                                Ignore OS Events:
+                                Ignore OS Events for PXE Boot:
                                 <span th:text="${initialData.ignoreOsEvtPxeBootEnabled ? 'Enabled' : 'Disabled'}"></span>
 
                                 <!-- trigger to open the modal -->

--- a/HIRS_AttestationCAPortal/src/main/resources/templates/policy.html
+++ b/HIRS_AttestationCAPortal/src/main/resources/templates/policy.html
@@ -397,6 +397,42 @@
                                 </div>
                             </form>
                         </li>
+                        <li>
+                            <form method="POST"
+                                  th:action="@{/HIRS_AttestationCAPortal/portal/policy/update-os-events-pxe-boot-ignore}"
+                                  th:object="${initialData}">
+                                Ignore OS Events:
+                                <span th:text="${initialData.ignoreOsEvtPxeBootEnabled ? 'Enabled' : 'Disabled'}"></span>
+
+                                <!-- trigger to open the modal -->
+                                <a data-bs-toggle="modal" th:href="'#' + ignoreOSPxeBootPolicyModal">
+                                    <img class="action-icons" alt="Editor Icon"
+                                         th:src="@{/icons//svg/pencil-deep-sky-blue-fill-18dp.svg}"
+                                         title="Click here to edit the Ignore OS Events for PXE Boot Policy"
+                                         data-bs-toggle="tooltip" />
+                                </a>
+
+                                <!-- modal fragment -->
+                                <div
+                                        th:replace="~{fragments/modal :: modal( id='ignoreOSPxeBootPolicyModal',  label='Edit Ignore OS Events for PXE Boot Policy Setting', bodyContent=~{this::#osIgnoredPxeBootPolicyBody}, customFooterButtons=${null})}">
+                                    <!-- Define the content of the modal -->
+                                    <div id="osIgnoredPxeBootPolicyBody">
+                                        <div class="radio">
+                                            <label>
+                                                <input th:field="*{ignoreOsEvtPxeBootEnabled}" type="radio" value="true" />
+                                                Ignore OS Events for PXE Boot enabled
+                                            </label>
+                                        </div>
+                                        <div class="radio">
+                                            <label>
+                                                <input th:field="*{ignoreOsEvtPxeBootEnabled}" type="radio" value="false" />
+                                                Ignore OS Events for PXE Boot disabled
+                                            </label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </form>
+                        </li>
                     </ul>
                 </div>
             </li>


### PR DESCRIPTION
This PR creates a new ACA policy specifically for PXE boot environments.  If enabled, this policy will ignore OS events and EV_EFI_BOOT_SERVICES_APPLICATION events that measure PIWG firmware volumes.

Closes #1280 